### PR TITLE
Add ability for user to change `formatOptions` for TypeScript

### DIFF
--- a/packages/ace-linters/tests/utils.tests.ts
+++ b/packages/ace-linters/tests/utils.tests.ts
@@ -1,0 +1,31 @@
+import {mergeObjects} from "../utils";
+import {expect} from "chai";
+
+describe('mergeObjects', () => {
+    it('should merge two objects with priority to first object values', () => {
+        const obj1 = { a: 1, b: { c: 3, d: 4 } };
+        const obj2 = { b: { c: 5, e: 6 }, f: 7 };
+        const expected = { a: 1, b: { c: 3, d: 4, e: 6 }, f: 7 };
+        expect(mergeObjects(obj1, obj2)).to.deep.equal(expected);
+    });
+
+    it('should merge arrays within the objects', () => {
+        const obj1 = { a: [1, 2], b: { c: [3, 4] } };
+        const obj2 = { a: [3, 4], b: { c: [5, 6] } };
+        const expected = { a: [1, 2, 3, 4], b: { c: [3, 4, 5, 6] } };
+        expect(mergeObjects(obj1, obj2)).to.deep.equal(expected);
+    });
+
+    it('should handle empty objects', () => {
+        const obj1 = {};
+        const obj2 = { a: 1, b: 2 };
+        expect(mergeObjects(obj1, obj2)).to.deep.equal(obj2);
+        expect(mergeObjects(obj2, obj1)).to.deep.equal(obj2);
+    });
+
+    it('should handle null input', () => {
+        const obj = { a: 1, b: 2 };
+        expect(mergeObjects(null, obj)).to.deep.equal(obj);
+        expect(mergeObjects(obj, null)).to.deep.equal(obj);
+    });
+});

--- a/packages/ace-linters/types/language-service.d.ts
+++ b/packages/ace-linters/types/language-service.d.ts
@@ -88,7 +88,8 @@ export declare namespace AceLinters {
         compilerOptions?: ts.CompilerOptions,
         extraLibs?: {
             [path: string]: ExtraLib;
-        }
+        },
+        formatOptions?: ts.FormatCodeSettings
     }
 
     export interface HtmlServiceOptions {
@@ -138,14 +139,26 @@ export declare namespace AceLinters {
         javascript: JavascriptServiceOptions,
         python: PythonServiceOptions
     }
-    
-    export type SupportedServices = "json" | "typescript" | "css" | "html" | "yaml" | "php" | "xml" | "javascript" | "lua" | "less" | "scss" | "python";
+
+    export type SupportedServices =
+        "json"
+        | "typescript"
+        | "css"
+        | "html"
+        | "yaml"
+        | "php"
+        | "xml"
+        | "javascript"
+        | "lua"
+        | "less"
+        | "scss"
+        | "python";
 
     export interface ProviderOptions {
         functionality: {
             hover: boolean,
             completion: {
-                overwriteCompleters: boolean    
+                overwriteCompleters: boolean
             } | false,
             completionResolve: boolean,
             format: boolean

--- a/packages/ace-linters/utils.ts
+++ b/packages/ace-linters/utils.ts
@@ -1,17 +1,20 @@
 export function mergeObjects(obj1, obj2) {
     if (!obj1) return obj2;
     if (!obj2) return obj1;
-    const mergedObjects = {};
-    for (const key of [...Object.keys(obj1), ...Object.keys(obj2)]) {
+
+    const mergedObjects = { ...obj2, ...obj1 }; // Give priority to obj1 values by spreading obj2 first, then obj1
+
+    for (const key of Object.keys(mergedObjects)) {
         if (obj1[key] && obj2[key]) {
             if (Array.isArray(obj1[key])) {
                 mergedObjects[key] = obj1[key].concat(obj2[key]);
-            } else {
+            } else if (Array.isArray(obj2[key])) {
+                mergedObjects[key] = obj2[key].concat(obj1[key]);
+            } else if (typeof obj1[key] === 'object' && typeof obj2[key] === 'object') {
                 mergedObjects[key] = mergeObjects(obj1[key], obj2[key]);
             }
-        } else {
-            mergedObjects[key] = obj1[key] ?? obj2[key];
         }
     }
+
     return mergedObjects;
 }

--- a/packages/demo/webworker-lsp/demo.ts
+++ b/packages/demo/webworker-lsp/demo.ts
@@ -64,9 +64,19 @@ languageProvider.setGlobalOptions("typescript", {
     compilerOptions: {
         allowJs: true,
         target: ScriptTarget.ESNext,
-        jsx: JsxEmit.Preserve
+        jsx: JsxEmit.Preserve,
+        moduleResolution: 99
     }
 });
+
+languageProvider.setGlobalOptions("typescript", {
+    compilerOptions: {
+        module: 6
+    },
+    formatOptions: {
+        indentSize: 2
+    }
+}, true);
 
 languageProvider.setGlobalOptions("json", {
     schemas: [


### PR DESCRIPTION
Standard formatting options would be: 
```javascript
$defaultFormatOptions = {
        insertSpaceAfterCommaDelimiter: true,
        insertSpaceAfterSemicolonInForStatements: true,
        insertSpaceBeforeAndAfterBinaryOperators: true,
        insertSpaceAfterConstructor: false,
        insertSpaceAfterKeywordsInControlFlowStatements: true,
        insertSpaceAfterFunctionKeywordForAnonymousFunctions: true,
        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
        insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
        insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: true,
        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
        insertSpaceAfterTypeAssertion: false,
        insertSpaceBeforeFunctionParenthesis: false,
        placeOpenBraceOnNewLineForFunctions: false,
        placeOpenBraceOnNewLineForControlBlocks: false,
        indentSize: 4,
        tabSize: 4,
        newLineCharacter: "\n",
        convertTabsToSpaces: true,
    }
```