### PR TITLE
clean up npm artifact

### DIFF
--- a/packages/ace-linters/package.json
+++ b/packages/ace-linters/package.json
@@ -48,6 +48,7 @@
   },
   "main": "build/ace-linters.js",
   "types": "types/index.d.ts",
+  "files": ["build", "types"],
   "repository": {
     "url": "https://github.com/mkslanc/ace-linters"
   },


### PR DESCRIPTION
Include only public files into the published module.

Current distribution includes all sorts of development files and typescript sources, as can be seen here: https://unpkg.com/browse/ace-linters@0.11.3/

This is problematic, because when I am importing `ace-linters` into my project, I get typescript errors from the library source, which takes precedence over the compiled code