### PR TITLE
Update package.json to include types for all dialects

### DIFF
--- a/packages/ace-sql-linter/package.json
+++ b/packages/ace-sql-linter/package.json
@@ -20,6 +20,21 @@
       ],
       "build/plsql-service": [
         "./types/plsql-service.d.ts"
+      ],
+      "build/flinksql-service": [
+        "./types/flinksql-service.d.ts"
+      ],
+      "build/hivesql-service": [
+        "./types/hivesql-service.d.ts"
+      ],
+      "build/impalasql-service": [
+        "./types/impalasql-service.d.ts"
+      ],
+      "build/sparksql-service": [
+        "./types/sparksql-service.d.ts"
+      ],
+      "build/trinosql-service": [
+        "./types/trinosql-service.d.ts"
       ]
     }
   }


### PR DESCRIPTION
Adding type information for the other SQL dialects. Noticed that while trying to use the Trino SQL variant.