### PR TITLE
fix language client argument in Usage with WebWorker examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ let editor = ace.edit("container", {
 });
 
 // Create a language provider for web worker
-let languageProvider = AceLanguageClient.for(worker);
+let languageProvider = AceLanguageClient.for(serverData);
 
 // Register the editor with the language provider
 languageProvider.registerEditor(editor);

--- a/packages/ace-linters/README.md
+++ b/packages/ace-linters/README.md
@@ -147,7 +147,7 @@ let editor = ace.edit("container", {
 });
 
 // Create a language provider for web worker
-let languageProvider = AceLanguageClient.for(worker);
+let languageProvider = AceLanguageClient.for(serverData);
 
 // Register the editor with the language provider
 languageProvider.registerEditor(editor);


### PR DESCRIPTION
Based on [the code](https://github.com/mkslanc/ace-linters/blob/main/packages/demo/webworker-json-rpc/demo.ts#L26) from `demo/webworker-json-rpc` folder there is a wrong const used in README examples