### PR TITLE
Catch content modified error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,13 +28,6 @@
         "webpack-dev-server": "^4.15.1"
       }
     },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@ace-linters/demo": {
       "resolved": "packages/demo",
       "link": true
@@ -48,102 +41,45 @@
       "link": true
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@astral-sh/ruff-wasm-web": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@astral-sh/ruff-wasm-web/-/ruff-wasm-web-0.9.9.tgz",
-      "integrity": "sha512-VGjO627xKzszpNRVbrCQyYXIXfh8t9Ju6t+GDPjoRUF+1D6Dlgze0Qjl1fKWLTecNUrd55oKgFutezSuwGfMdA==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@astral-sh/ruff-wasm-web/-/ruff-wasm-web-0.9.10.tgz",
+      "integrity": "sha512-0q6zR5qxGG/BI0nAmbwi+pxc4DNOVFviJnPd9DoLHCCpUhAJ7hw4s3hh9SAaRovARK3p0Gaw37zqK8tpoEzjhg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -151,24 +87,26 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.9",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.9",
-        "@babel/helper-compilation-targets": "^7.22.9",
-        "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.8",
-        "@babel/types": "^7.22.5",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
+        "json5": "^2.2.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -179,90 +117,71 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/generator": {
-      "version": "7.23.6",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.9",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.5",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.9",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.5"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -271,30 +190,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -302,7 +201,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -310,7 +211,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -318,99 +221,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.6",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.10"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -419,31 +251,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.6",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -451,22 +284,15 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -474,6 +300,8 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -485,6 +313,8 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -494,14 +324,392 @@
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -516,27 +724,36 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.0.tgz",
+      "integrity": "sha512-RoV8Xs9eNwiDvhv7M+xcL4PWyRyIXRY/FLp3buU4h1EYfdF7unWUy3dOjPqb3C7rMUewIcqwW850PgS8h1o1yg==",
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -556,19 +773,63 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -577,6 +838,8 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -587,11 +850,16 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -607,14 +875,32 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -625,8 +911,59 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@istanbuljs/nyc-config-typescript": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
+      "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -641,6 +978,8 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -648,10 +987,11 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -662,7 +1002,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -674,6 +1016,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -683,13 +1026,16 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -698,18 +1044,23 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.4",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -721,6 +1072,8 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -728,6 +1081,8 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -738,16 +1093,16 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
-      "integrity": "sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.3.6",
+        "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
+        "proxy-agent": "^6.5.0",
         "semver": "^7.6.3",
         "tar-fs": "^3.0.6",
         "unbzip2-stream": "^1.4.3",
@@ -760,50 +1115,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -813,41 +1128,18 @@
         "node": ">=10"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@swc/core": {
-      "version": "1.3.70",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.9.tgz",
+      "integrity": "sha512-4UQ66FwTkFDr+UzYzRNKQyHMScOrc4zJbTJHyK6dP1yVMrxi5sl0FTzNKiqoYvRZ7j8TAYgtYvvuPSW/XXvp5g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.19"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -856,19 +1148,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.70",
-        "@swc/core-darwin-x64": "1.3.70",
-        "@swc/core-linux-arm-gnueabihf": "1.3.70",
-        "@swc/core-linux-arm64-gnu": "1.3.70",
-        "@swc/core-linux-arm64-musl": "1.3.70",
-        "@swc/core-linux-x64-gnu": "1.3.70",
-        "@swc/core-linux-x64-musl": "1.3.70",
-        "@swc/core-win32-arm64-msvc": "1.3.70",
-        "@swc/core-win32-ia32-msvc": "1.3.70",
-        "@swc/core-win32-x64-msvc": "1.3.70"
+        "@swc/core-darwin-arm64": "1.11.9",
+        "@swc/core-darwin-x64": "1.11.9",
+        "@swc/core-linux-arm-gnueabihf": "1.11.9",
+        "@swc/core-linux-arm64-gnu": "1.11.9",
+        "@swc/core-linux-arm64-musl": "1.11.9",
+        "@swc/core-linux-x64-gnu": "1.11.9",
+        "@swc/core-linux-x64-musl": "1.11.9",
+        "@swc/core-win32-arm64-msvc": "1.11.9",
+        "@swc/core-win32-ia32-msvc": "1.11.9",
+        "@swc/core-win32-x64-msvc": "1.11.9"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "*"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -876,8 +1168,172 @@
         }
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.9.tgz",
+      "integrity": "sha512-moqbPCWG6SHiDMENTDYsEQJ0bFustbLtrdbDbdjnijSyhCyIcm9zKowmovE6MF8JBdOwmLxbuN1Yarq6CrPNlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.9.tgz",
+      "integrity": "sha512-/lgMo5l9q6y3jjLM3v30y6SBvuuyLsM/K94hv3hPvDf91N+YlZLw4D7KY0Qknfhj6WytoAcjOIDU6xwBRPyUWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.9.tgz",
+      "integrity": "sha512-7bL6z/63If11IpBElQRozIGRadiy6rt3DoUyfGuFIFQKxtnZxzHuLxm1/wrCAGN9iAZxrpHxHP0VbPQvr6Mcjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.9.tgz",
+      "integrity": "sha512-9ArpxjrNbyFTr7gG+toiGbbK2mfS+X97GIruBKPsD8CJH/yJlMknBsX3lfy9h/L119zYVnFBmZDnwsv5yW8/cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.9.tgz",
+      "integrity": "sha512-UOnunJWu7T7oNkBr4DLMwXXbldjiwi+JxmqBKrD2+BNiHGu6P5VpqDHiTGuWuLrda0TcTmeNE6gzlIVOVBo/vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.9.tgz",
+      "integrity": "sha512-HAqmCkNoNhRusBqSokyylXKsLJ/dr3dnMgBERdUrCIh47L8CKR2qEFUP6FI05sHVB85403ctWnfzBYblcarpqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.9.tgz",
+      "integrity": "sha512-THwUT2g2qSWUxhi3NGRCEdmh/q7WKl3d5jcN9mz/4jum76Tb46LB9p3oOVPBIcfnFQ9OaddExjCwLoUl0ju2pA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.9.tgz",
+      "integrity": "sha512-r4SGD9lR0MM9HSIsQ72BEL3Za3XsuVj+govuXQTlK0mty5gih4L+Qgfnb9PmhjFakK3F63gZyyEr2y8Fj0mN6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.9.tgz",
+      "integrity": "sha512-jrEh6MDSnhwfpjRlSWd2Bk8pS5EjreQD1YbkNcnXviQf3+H0wSPmeVSktZyoIdkxAuc2suFx8mj7Yja2UXAgUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.70",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.9.tgz",
+      "integrity": "sha512-oAwuhzr+1Bmb4As2wa3k57/WPJeyVEYRQelwEMYjPgi/h6TH+Y69jQAgKOd+ec1Yl8L5nkWTZMVA/dKDac1bAQ==",
       "cpu": [
         "x64"
       ],
@@ -892,6 +1348,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-WkAZaAfj44kh/UFdAQcrMP1I0nwRqpt27u+08LMBYMqmQfwwMofYoMh/48NGkMMRfC4ynpfwRbJuu8ErfNloeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -900,27 +1374,37 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.2",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -929,7 +1413,9 @@
       }
     },
     "node_modules/@types/bonjour": {
-      "version": "3.5.10",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+      "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -937,12 +1423,16 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.5",
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {
-      "version": "3.4.35",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -950,7 +1440,9 @@
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.5.0",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+      "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -959,7 +1451,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.44.0",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -967,14 +1461,28 @@
         "@types/json-schema": "*"
       }
     },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.17",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -985,7 +1493,22 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.35",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -996,12 +1519,16 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.11",
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1009,42 +1536,71 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
-      "version": "1.3.2",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.7",
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "0.17.1",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1053,7 +1609,9 @@
       }
     },
     "node_modules/@types/serve-index": {
-      "version": "1.9.1",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+      "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1061,17 +1619,21 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.2",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/mime": "*",
-        "@types/node": "*"
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/sockjs": {
-      "version": "0.3.33",
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+      "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1079,7 +1641,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.5",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1097,8 +1661,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.14",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1149,153 +1721,170 @@
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
-      "dev": true
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1305,6 +1894,8 @@
     },
     "node_modules/@webpack-cli/info": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1316,6 +1907,8 @@
     },
     "node_modules/@webpack-cli/serve": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1329,6 +1922,8 @@
     },
     "node_modules/@xml-tools/ast": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
+      "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1339,6 +1934,8 @@
     },
     "node_modules/@xml-tools/common": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
+      "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1347,6 +1944,8 @@
     },
     "node_modules/@xml-tools/constraints": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@xml-tools/constraints/-/constraints-1.1.1.tgz",
+      "integrity": "sha512-c9K/Ozmem2zbLta7HOjJpXszZA/UQkm3pKT3AAa+tKdnsIomPwcRXkltdd+UtdXcOTbqsuTV0fnSkLBgjlnxbQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1356,6 +1955,8 @@
     },
     "node_modules/@xml-tools/content-assist": {
       "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/content-assist/-/content-assist-3.1.11.tgz",
+      "integrity": "sha512-ExVgzRLutvBEMi0JQ8vi4ccao0lrq8DTsWKeAEH6/Zy2Wfp+XAR4ERNpFK7yp+QHQkWROr/XSNVarcTuopE+lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1366,6 +1967,8 @@
     },
     "node_modules/@xml-tools/parser": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1374,6 +1977,8 @@
     },
     "node_modules/@xml-tools/simple-schema": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@xml-tools/simple-schema/-/simple-schema-3.0.5.tgz",
+      "integrity": "sha512-8qrm23eGAFtvNWmJu46lttae+X8eOEPMXryf4JH6NBpFl1pphkNXqr7bAKnOjELmLPXHStoeKZO2vptyn4cPPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1384,6 +1989,8 @@
     },
     "node_modules/@xml-tools/validation": {
       "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@xml-tools/validation/-/validation-1.0.16.tgz",
+      "integrity": "sha512-w/+kUYcxKXfQz8TQ3qAAuLl9N2WZ0HGiwI8nVuIe29dAZmyeXx5ZpODAW7yJoarH0/wZ+rhbc3XxbRqIPcSofA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1395,16 +2002,20 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1415,14 +2026,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ace-clang-linter": {
       "resolved": "packages/ace-clang-linter",
       "link": true
     },
     "node_modules/ace-code": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/ace-code/-/ace-code-1.37.0.tgz",
-      "integrity": "sha512-nJaeN/JH+Nq6hIWPBn/iExb+d3LerKXen95aUrO05S9fKvBnZYeXEkRgLhkQn0j5it/B/AoOZDyT1/St7TGfgw==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/ace-code/-/ace-code-1.39.0.tgz",
+      "integrity": "sha512-6aSpPdwCu92iPQYrgONjSrvXDSxcEojwzPj2FHXugfSTrh3miyX27fMVWnRtktJEqqrQRj7+gC7q6hsvBW41bQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 0.6.0"
@@ -1437,9 +2058,10 @@
       "link": true
     },
     "node_modules/ace-layout": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ace-layout/-/ace-layout-1.4.2.tgz",
-      "integrity": "sha512-bGeyykQw6WAGbO2fGPwfAisA3jen9RtPBUWsAJiBdmAsPFSFJP5clHmqe1+WbiB3TUM3Pfc+62XVy1wbyocfJg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ace-layout/-/ace-layout-1.5.0.tgz",
+      "integrity": "sha512-kkv0pYvNUvTBYCmN9H8vuWpY7Ah8xyrjKrX+bYu5OgK0THLjN3j7p+bAfen0ACNqEPQ//4aq81fX+fCLR1MCHw==",
+      "license": "MIT"
     },
     "node_modules/ace-linters": {
       "resolved": "packages/ace-linters",
@@ -1462,7 +2084,9 @@
       "link": true
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1471,45 +2095,42 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.2.0",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1522,6 +2143,8 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1536,6 +2159,8 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1551,14 +2176,16 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1567,11 +2194,15 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1579,7 +2210,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1588,6 +2221,8 @@
     },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true,
       "engines": [
         "node >= 0.8.0"
@@ -1599,6 +2234,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1606,6 +2243,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1641,6 +2280,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/antlr4ng-cli/-/antlr4ng-cli-1.0.7.tgz",
       "integrity": "sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==",
+      "deprecated": "This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -1650,6 +2290,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1662,6 +2304,8 @@
     },
     "node_modules/append-transform": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1673,25 +2317,35 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
-      "version": "2.1.2",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1699,34 +2353,42 @@
       }
     },
     "node_modules/asn1.js": {
-      "version": "5.4.1",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/assert": {
-      "version": "2.0.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1748,13 +2410,20 @@
     },
     "node_modules/async": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1763,70 +2432,91 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
-      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.1.tgz",
+      "integrity": "sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.0.0",
-        "bare-path": "^2.0.0",
+        "bare-path": "^3.0.0",
         "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
       }
     },
     "node_modules/bare-os": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
-      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.0.tgz",
+      "integrity": "sha512-BUrFS5TqSBdA0LwHop4OjPJwisqxGy6JsWVqV6qaFoe965qqtaKfDzHY5T2YA1gUL0ZeeQeA+4BBc1FJTcHiPw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
     },
     "node_modules/bare-path": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "bare-os": "^2.1.0"
+        "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.0.tgz",
-      "integrity": "sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "b4a": "^1.6.6",
-        "streamx": "^2.20.0"
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
       }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
         {
@@ -1846,6 +2536,8 @@
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1857,6 +2549,8 @@
     },
     "node_modules/basic-auth/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1872,11 +2566,15 @@
     },
     "node_modules/batch": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/big.js": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1884,15 +2582,22 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1921,16 +2626,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1941,19 +2636,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1961,19 +2643,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/bonjour-service": {
-      "version": "1.1.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+      "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-flatten": "^2.1.2",
-        "dns-equal": "^1.0.0",
         "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5"
       }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1995,16 +2695,22 @@
     },
     "node_modules/brorand": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2018,6 +2724,8 @@
     },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2028,6 +2736,8 @@
     },
     "node_modules/browserify-des": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2038,16 +2748,24 @@
       }
     },
     "node_modules/browserify-rsa": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bn.js": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.2",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2055,18 +2773,61 @@
         "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.4",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.6",
-        "readable-stream": "^3.6.2",
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
         "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 0.12"
       }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2074,9 +2835,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -2092,11 +2853,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2107,6 +2869,8 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
       "funding": [
         {
@@ -2142,20 +2906,27 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
-      "version": "3.0.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2164,6 +2935,8 @@
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2177,17 +2950,47 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2198,6 +3001,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2205,6 +3010,8 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2212,9 +3019,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001704",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz",
+      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==",
       "dev": true,
       "funding": [
         {
@@ -2229,20 +3036,23 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "4.3.7",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
+        "type-detect": "^4.1.0"
       },
       "engines": {
         "node": ">=4"
@@ -2250,6 +3060,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2262,26 +3074,23 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/check-error": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
         "node": "*"
       }
     },
     "node_modules/chevrotain": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2289,14 +3098,10 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2310,12 +3115,17 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2326,7 +3136,9 @@
       }
     },
     "node_modules/chrome-trace-event": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2334,14 +3146,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.5.tgz",
-      "integrity": "sha512-RuLrmzYrxSb0s9SgpB+QN5jJucPduZQ/9SIe76MDxYJuecPW5mxMdacJ1f4EtgiV+R0p3sCkznTMvH0MPGFqjA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0",
         "zod": "3.23.8"
       },
       "peerDependencies": {
@@ -2349,16 +3160,23 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2366,17 +3184,24 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2390,6 +3215,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2400,26 +3227,38 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2430,16 +3269,18 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
+        "negotiator": "~0.6.4",
         "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
@@ -2448,6 +3289,8 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2456,20 +3299,21 @@
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/compression/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2478,15 +3322,21 @@
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2508,13 +3358,15 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2523,11 +3375,15 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2551,11 +3407,15 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/corser": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2591,6 +3451,8 @@
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2599,12 +3461,16 @@
       }
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2617,6 +3483,8 @@
     },
     "node_modules/create-hmac": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2630,11 +3498,15 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2646,24 +3518,30 @@
       }
     },
     "node_modules/crypto-browserify": {
-      "version": "3.12.0",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -2677,10 +3555,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2693,6 +3573,8 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2700,7 +3582,9 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2712,10 +3596,14 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "license": "MIT"
     },
     "node_modules/default-gateway": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2727,6 +3615,8 @@
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2759,6 +3649,8 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2766,10 +3658,13 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -2807,6 +3702,8 @@
     },
     "node_modules/des.js": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2827,18 +3724,22 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1342118",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1342118.tgz",
-      "integrity": "sha512-75fMas7PkYNDTmDyb6PRJCH7ILmHLp+BhrZGeMsa4bCh40DTxgCz2NRy5UDzII4C5KuD0oBMZ9vXKhEl6UD/3w==",
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "5.0.0",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2847,6 +3748,8 @@
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2856,12 +3759,16 @@
       }
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2871,13 +3778,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/dns-equal": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/dns-packet": {
-      "version": "5.6.0",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2889,6 +3793,8 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -2898,9 +3804,11 @@
       }
     },
     "node_modules/domain-browser": {
-      "version": "4.22.0",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
+      "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
       "dev": true,
-      "license": "MIT",
+      "license": "Artistic-2.0",
       "engines": {
         "node": ">=10"
       },
@@ -2939,48 +3847,19 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/dts-bundle-generator/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dts-bundle-generator/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dts-bundle-generator/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
+        "node": ">= 0.4"
       }
     },
     "node_modules/ee-first": {
@@ -2991,15 +3870,16 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.6.tgz",
-      "integrity": "sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==",
-      "dev": true
+      "version": "1.5.116",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.116.tgz",
+      "integrity": "sha512-mufxTCJzLBQVvSdZzX1s5YAuXsN1M4tTyYxOOL1TcSKtIzQ9rjIrm7yFK80rN5dwGTePgdoABDSHpuVtRQh0Zw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3013,17 +3893,23 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3051,10 +3937,11 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -3074,7 +3961,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.10.0",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3095,14 +3984,11 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -3118,22 +4004,36 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.3.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es6-object-assign": {
-      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3170,21 +4070,26 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3226,25 +4131,29 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.45.0",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3279,6 +4188,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3290,7 +4201,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3300,7 +4213,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.1",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -3315,57 +4230,33 @@
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
-    "node_modules/eslint/node_modules/find-up": {
-      "version": "5.0.0",
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
+        "type-fest": "^0.20.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-limit": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -3375,6 +4266,8 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -3390,6 +4283,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -3401,7 +4296,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3412,6 +4309,8 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3419,6 +4318,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -3429,6 +4330,8 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3436,6 +4339,8 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3444,6 +4349,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3461,11 +4368,15 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3474,6 +4385,8 @@
     },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3483,6 +4396,8 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3505,6 +4420,8 @@
     },
     "node_modules/execa/node_modules/get-stream": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3515,9 +4432,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3526,7 +4443,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3540,7 +4457,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3555,15 +4472,16 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/express/node_modules/array-flatten": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3572,8 +4490,26 @@
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -3598,6 +4534,8 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -3608,7 +4546,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3616,7 +4556,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3624,6 +4564,8 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3635,10 +4577,14 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -3660,6 +4606,8 @@
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3667,7 +4615,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3675,6 +4625,8 @@
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3696,6 +4648,8 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -3719,6 +4673,8 @@
     },
     "node_modules/filter-obj": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.2.tgz",
+      "integrity": "sha512-lO3ttPjHZRfjMcxWKb1j1eDhTFsu4meeR3lnMcnBFhk6RuLhvEiuALu2TlfL310ph4lCYYwgF/ElIjdP739tdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3763,6 +4719,8 @@
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3778,19 +4736,25 @@
       }
     },
     "node_modules/find-up": {
-      "version": "4.1.0",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^5.0.0",
+        "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
@@ -3798,10 +4762,13 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -3809,7 +4776,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -3834,15 +4803,25 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3855,6 +4834,8 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3873,6 +4854,8 @@
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true,
       "funding": [
         {
@@ -3890,28 +4873,17 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs-monkey": {
-      "version": "1.0.4",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
+      "integrity": "sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==",
       "dev": true,
       "license": "Unlicense"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -3941,6 +4913,8 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3949,6 +4923,8 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3957,6 +4933,8 @@
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3964,17 +4942,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3985,10 +4968,26 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4008,16 +5007,15 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.2.0"
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">= 14"
@@ -4025,6 +5023,9 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -4043,6 +5044,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4055,23 +5058,23 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
-      "version": "13.20.0",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/globby": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4090,11 +5093,13 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4102,31 +5107,28 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "license": "MIT"
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4145,19 +5147,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4168,11 +5161,13 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4182,20 +5177,23 @@
       }
     },
     "node_modules/hash-base": {
-      "version": "3.1.0",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.10"
       }
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4205,6 +5203,8 @@
     },
     "node_modules/hasha": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4216,14 +5216,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hasha/node_modules/type-fest": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/hasown": {
@@ -4241,6 +5233,8 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4249,6 +5243,8 @@
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4259,6 +5255,8 @@
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4270,6 +5268,8 @@
     },
     "node_modules/hpack.js/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4284,11 +5284,15 @@
     },
     "node_modules/hpack.js/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hpack.js/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4297,6 +5301,8 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4307,7 +5313,9 @@
       }
     },
     "node_modules/html-entities": {
-      "version": "2.4.0",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
       "dev": true,
       "funding": [
         {
@@ -4323,11 +5331,15 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/htmlhint": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.1.4.tgz",
+      "integrity": "sha512-tSKPefhIaaWDk/vKxAOQbN+QwZmDeJCq3bZZGbJMoMQAfTjepudC+MkuT9MOBbuQI3dLLzDWbmU7fLV3JASC7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4344,24 +5356,10 @@
         "htmlhint": "bin/htmlhint"
       }
     },
-    "node_modules/htmlhint/node_modules/commander": {
-      "version": "9.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/htmlhint/node_modules/strip-json-comments": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4383,12 +5381,16 @@
       }
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.8",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+      "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4415,7 +5417,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4437,19 +5441,10 @@
         }
       }
     },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/http-server": {
       "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4476,17 +5471,19 @@
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -4495,6 +5492,8 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4502,11 +5501,13 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -4514,6 +5515,8 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true,
       "funding": [
         {
@@ -4532,14 +5535,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -4554,13 +5561,17 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/import-local": {
-      "version": "3.1.0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4579,6 +5590,8 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -4586,6 +5599,8 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4594,6 +5609,9 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -4602,10 +5620,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4626,15 +5648,10 @@
         "node": ">= 12"
       }
     },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ipaddr.js": {
-      "version": "2.1.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4642,12 +5659,14 @@
       }
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4665,6 +5684,8 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4676,6 +5697,8 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4686,11 +5709,16 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4698,6 +5726,8 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4712,6 +5742,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4719,6 +5751,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4726,11 +5760,16 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4741,6 +5780,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4751,6 +5792,8 @@
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4776,21 +5819,30 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "2.1.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4800,8 +5852,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4812,11 +5885,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.12",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4827,11 +5902,15 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4843,6 +5922,8 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4851,6 +5932,8 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4862,15 +5945,21 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4878,7 +5967,9 @@
       }
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.0",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4887,6 +5978,8 @@
     },
     "node_modules/istanbul-lib-hook": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4898,6 +5991,8 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4912,6 +6007,8 @@
     },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4927,31 +6024,53 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report/node_modules/supports-color": {
-      "version": "7.2.0",
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4964,7 +6083,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4980,6 +6101,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -4989,13 +6111,33 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5012,31 +6154,47 @@
       "license": "MIT"
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5049,23 +6207,22 @@
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "license": "MIT",
       "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5073,16 +6230,20 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.6.0",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
+      "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
-        "shell-quote": "^1.7.3"
+        "shell-quote": "^1.8.1"
       }
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -5101,6 +6262,8 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5109,6 +6272,8 @@
     },
     "node_modules/loader-utils": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5121,32 +6286,44 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "5.0.0",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5161,15 +6338,19 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.6",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5181,12 +6362,15 @@
       "resolved": "https://registry.npmjs.org/luaparse/-/luaparse-0.3.1.tgz",
       "integrity": "sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "luaparse": "bin/luaparse"
       }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5201,11 +6385,25 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5226,6 +6424,8 @@
     },
     "node_modules/memfs": {
       "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
       "dev": true,
       "license": "Unlicense",
       "dependencies": {
@@ -5247,11 +6447,15 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5260,6 +6464,8 @@
     },
     "node_modules/methods": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5282,6 +6488,8 @@
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5293,12 +6501,16 @@
       }
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mime": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5310,6 +6522,8 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5318,6 +6532,8 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5329,6 +6545,8 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5337,16 +6555,22 @@
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5357,6 +6581,8 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5372,6 +6598,8 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5382,31 +6610,32 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.2.0",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
@@ -5414,73 +6643,55 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/find-up": {
-      "version": "5.0.0",
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/mocha/node_modules/glob": {
-      "version": "7.2.0",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha/node_modules/locate-path": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5490,61 +6701,64 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
+    "node_modules/mocha/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mocha/node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mocha/node_modules/p-locate": {
-      "version": "5.0.0",
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^3.0.2"
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/mocha/node_modules/serialize-javascript": {
-      "version": "6.0.0",
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT",
       "dependencies": {
-        "randombytes": "^2.1.0"
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5555,23 +6769,16 @@
         "multicast-dns": "cli.js"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5580,6 +6787,8 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5594,7 +6803,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5614,6 +6825,8 @@
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
@@ -5622,6 +6835,8 @@
     },
     "node_modules/node-polyfill-webpack-plugin": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-1.1.4.tgz",
+      "integrity": "sha512-Z0XTKj1wRWO8o/Vjobsw5iOJCN+Sua3EZEUc2Ziy9CyVvmHKu6o+t4gUH9GOE0czyPR94LI6ZCV/PpcM8b5yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5659,6 +6874,8 @@
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5669,13 +6886,16 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5684,6 +6904,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5695,6 +6917,8 @@
     },
     "node_modules/nyc": {
       "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5735,6 +6959,8 @@
     },
     "node_modules/nyc/node_modules/cliui": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5743,8 +6969,66 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/nyc/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nyc/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nyc/node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5758,11 +7042,15 @@
     },
     "node_modules/nyc/node_modules/y18n": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/yargs": {
       "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5784,6 +7072,8 @@
     },
     "node_modules/nyc/node_modules/yargs-parser": {
       "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5795,9 +7085,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5808,12 +7098,14 @@
       }
     },
     "node_modules/object-is": {
-      "version": "1.1.5",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5824,14 +7116,39 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5850,6 +7167,8 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5858,6 +7177,8 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5865,6 +7186,8 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5879,6 +7202,8 @@
     },
     "node_modules/open": {
       "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5895,6 +7220,8 @@
     },
     "node_modules/opener": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -5902,15 +7229,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "license": "MIT",
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -5918,36 +7247,45 @@
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "license": "MIT",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "4.1.0",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5959,6 +7297,8 @@
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5971,6 +7311,8 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5978,20 +7320,20 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.4"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -6013,6 +7355,8 @@
     },
     "node_modules/package-hash": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6027,11 +7371,15 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -6041,15 +7389,21 @@
       }
     },
     "node_modules/parse-asn1": {
-      "version": "5.1.6",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "asn1.js": "^5.2.0",
-        "browserify-aes": "^1.0.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/parse-json": {
@@ -6073,6 +7427,8 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6081,10 +7437,14 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6092,6 +7452,8 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6099,6 +7461,8 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6106,18 +7470,22 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6126,6 +7494,8 @@
     },
     "node_modules/pathval": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6134,6 +7504,8 @@
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6155,13 +7527,16 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6173,6 +7548,8 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6182,46 +7559,107 @@
         "node": ">=8"
       }
     },
-    "node_modules/portfinder": {
-      "version": "1.0.32",
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "async": "^2.6.4",
-        "debug": "^3.2.7",
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.34.tgz",
+      "integrity": "sha512-aTyliYB9lpGRx0iUzgbLpCz3xiCEBsPOiukSp1X8fOnHalHCKNxxpv2cSc00Cc49mpWUtlyRVFHRSaRJF8ew3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6",
         "mkdirp": "^0.5.6"
       },
       "engines": {
-        "node": ">= 0.12.0"
+        "node": ">= 6.0"
       }
     },
     "node_modules/portfinder/node_modules/async": {
-      "version": "2.6.4",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "license": "MIT"
     },
-    "node_modules/portfinder/node_modules/debug": {
-      "version": "3.2.7",
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6236,6 +7674,8 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6244,11 +7684,15 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/process-on-spawn": {
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+      "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6270,6 +7714,8 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6282,6 +7728,8 @@
     },
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6289,20 +7737,20 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
+        "pac-proxy-agent": "^7.1.0",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -6327,6 +7775,8 @@
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6339,7 +7789,9 @@
       }
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6355,25 +7807,27 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.4.0.tgz",
-      "integrity": "sha512-FxgFFJI7NAsX8uebiEDSjS86vufz9TaqERQHShQT0lCbSRI3jUPEcz/0HdwLiYvfYNsc1zGjqY3NsGZya4PvUA==",
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.11.1.tgz",
+      "integrity": "sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.4.0",
-        "chromium-bidi": "0.6.5",
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1342118",
-        "puppeteer-core": "23.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.11.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -6384,16 +7838,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.4.0.tgz",
-      "integrity": "sha512-fqkIP5FOcb38jfBj/OcBz1wFaI9nk40uQKSORvnXws6wCbep2dg8yxZ3ddJxBIfQsxoiEOvnrykFinUScrB/ew==",
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.4.0",
-        "chromium-bidi": "0.6.5",
-        "debug": "^4.3.7",
-        "devtools-protocol": "0.0.1342118",
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.0"
       },
@@ -6401,39 +7855,14 @@
         "node": ">=18"
       }
     },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -6444,6 +7873,8 @@
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -6451,6 +7882,8 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
           "type": "github",
@@ -6467,15 +7900,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6484,6 +7912,8 @@
     },
     "node_modules/randomfill": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6493,6 +7923,8 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6515,31 +7947,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/raw-body/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/raw-loader": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6559,6 +7970,8 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6572,6 +7985,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6583,6 +7998,8 @@
     },
     "node_modules/rechoir": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6594,11 +8011,15 @@
     },
     "node_modules/regexp-to-ast": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6610,11 +8031,15 @@
     },
     "node_modules/request-light": {
       "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6623,6 +8048,8 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6631,25 +8058,34 @@
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6657,6 +8093,8 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6668,6 +8106,8 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6676,6 +8116,8 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6683,7 +8125,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6692,6 +8136,9 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -6705,6 +8152,8 @@
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6714,6 +8163,8 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
           "type": "github",
@@ -6735,6 +8186,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -6752,13 +8205,35 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6776,19 +8251,26 @@
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/selfsigned": {
-      "version": "2.1.1",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node-forge": "^1.3.0",
         "node-forge": "^1"
       },
       "engines": {
@@ -6797,6 +8279,8 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6855,15 +8339,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6872,6 +8351,8 @@
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6889,6 +8370,8 @@
     },
     "node_modules/serve-index/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6897,6 +8380,8 @@
     },
     "node_modules/serve-index/node_modules/depd": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6905,6 +8390,8 @@
     },
     "node_modules/serve-index/node_modules/http-errors": {
       "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6919,21 +8406,29 @@
     },
     "node_modules/serve-index/node_modules/inherits": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/serve-index/node_modules/setprototypeof": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/serve-index/node_modules/statuses": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6958,6 +8453,8 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
     },
@@ -6981,6 +8478,8 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6993,6 +8492,8 @@
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
@@ -7005,6 +8506,8 @@
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7016,6 +8519,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7026,15 +8531,22 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7044,6 +8556,7 @@
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
       "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0"
       },
@@ -7055,25 +8568,74 @@
         "url": "https://www.paypal.me/tiviesantos"
       }
     },
-    "node_modules/showdown/node_modules/commander": {
-      "version": "9.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7084,11 +8646,15 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7108,6 +8674,8 @@
     },
     "node_modules/sockjs": {
       "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
+      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7117,9 +8685,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7132,13 +8700,13 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -7148,6 +8716,8 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7159,6 +8729,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7166,6 +8737,8 @@
     },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7182,6 +8755,8 @@
     },
     "node_modules/spdy": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7197,6 +8772,8 @@
     },
     "node_modules/spdy-transport": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7209,7 +8786,9 @@
       }
     },
     "node_modules/sprintf-js": {
-      "version": "1.0.3",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -7225,6 +8804,8 @@
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7234,6 +8815,8 @@
     },
     "node_modules/stream-http": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7244,14 +8827,13 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
-      "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
@@ -7260,6 +8842,8 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7268,6 +8852,8 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7281,6 +8867,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7291,6 +8879,8 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7299,6 +8889,8 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7306,31 +8898,31 @@
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7341,9 +8933,14 @@
       }
     },
     "node_modules/swc-loader": {
-      "version": "0.2.3",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.6.tgz",
+      "integrity": "sha512-9Zi9UP2YmDpgmQVbyOPJClY0dwf58JDyDMQ7uRc4krmc72twNI2fvlBWHLqVekBpPc7h5NJkGVT1zNDxFrqhvg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      },
       "peerDependencies": {
         "@swc/core": "^1.2.147",
         "webpack": ">=2"
@@ -7354,14 +8951,15 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7369,8 +8967,8 @@
         "tar-stream": "^3.1.5"
       },
       "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
@@ -7386,10 +8984,11 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
-      "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -7404,16 +9003,17 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
+      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.20",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.26.0"
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -7437,8 +9037,74 @@
         }
       }
     },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7451,9 +9117,9 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.0.tgz",
-      "integrity": "sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7464,10 +9130,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/text-loader/-/text-loader-0.0.1.tgz",
       "integrity": "sha512-y2GvBFB9hibaHBRWE9xQhdENU1KppXnM9DCf6NueYPB/lnNX8ZzP3JLs1R1p3ObItcs+y8DBiPwelkJf8txe+g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "license": "MIT"
     },
     "node_modules/through": {
@@ -7479,11 +9148,15 @@
     },
     "node_modules/thunky": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7491,14 +9164,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -7526,11 +9191,15 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7573,6 +9242,8 @@
     },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7580,19 +9251,23 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -7602,7 +9277,9 @@
       }
     },
     "node_modules/type-detect": {
-      "version": "4.0.8",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7610,13 +9287,13 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/type-is": {
@@ -7642,6 +9319,8 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7649,9 +9328,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7697,24 +9376,23 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/union": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
       "dev": true,
       "dependencies": {
         "qs": "^6.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -7728,9 +9406,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
         {
@@ -7746,9 +9424,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -7759,39 +9438,45 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/url": {
-      "version": "0.11.1",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^1.4.1",
-        "qs": "^6.11.0"
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/url-join": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/urlpattern-polyfill": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/util": {
       "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7804,11 +9489,15 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7817,6 +9506,8 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7825,11 +9516,15 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7838,35 +9533,41 @@
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-css-languageservice": {
-      "version": "6.2.6",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.2.tgz",
+      "integrity": "sha512-GEpPxrUTAeXWdZWHev1OJU9lz2Q2/PPBxQ2TIRmLGvQiH3WZbqaNoute0n0ewxlgtjzTW3AKZT+NHySk5Rf4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.14",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/vscode-html-languageservice": {
-      "version": "5.0.6",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
+      "integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.14",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/vscode-json-languageservice": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.4.1.tgz",
-      "integrity": "sha512-5czFGNyVPxz3ZJYl8R3a3SuIj5gjhmGF4Wv05MRPvD4DEnHK6b8km4VbNMJNHBlTCh7A0aHzUbPVzo+0C18mCA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.4.3.tgz",
+      "integrity": "sha512-NVSEQDloP9NYccuqKg4eI46kutZpwucBY4csBB6FCxbM7AZVoBt0oxTItPVA+ZwhnG1bg/fmiBRAwcGJyNQoPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7876,13 +9577,6 @@
         "vscode-languageserver-types": "^3.17.5",
         "vscode-uri": "^3.0.8"
       }
-    },
-    "node_modules/vscode-json-languageservice/node_modules/@vscode/l10n": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
-      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -7930,11 +9624,15 @@
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.8",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7963,10 +9661,11 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
-      "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -7977,6 +9676,8 @@
     },
     "node_modules/wbuf": {
       "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7985,23 +9686,25 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+      "version": "5.98.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
@@ -8013,9 +9716,9 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
+        "schema-utils": "^4.3.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
+        "terser-webpack-plugin": "^5.3.11",
         "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
@@ -8037,6 +9740,8 @@
     },
     "node_modules/webpack-cli": {
       "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8083,6 +9788,8 @@
     },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8114,14 +9821,16 @@
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -8130,6 +9839,8 @@
     },
     "node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8141,11 +9852,15 @@
     },
     "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
-      "version": "4.2.0",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8155,7 +9870,7 @@
         "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8163,7 +9878,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.1",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+      "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8195,7 +9912,7 @@
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^5.3.1",
+        "webpack-dev-middleware": "^5.3.4",
         "ws": "^8.13.0"
       },
       "bin": {
@@ -8221,14 +9938,16 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -8237,6 +9956,8 @@
     },
     "node_modules/webpack-dev-server/node_modules/ajv-keywords": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8248,11 +9969,15 @@
     },
     "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {
-      "version": "4.2.0",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8262,7 +9987,7 @@
         "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8270,11 +9995,14 @@
       }
     },
     "node_modules/webpack-merge": {
-      "version": "5.9.0",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
         "wildcard": "^2.0.0"
       },
       "engines": {
@@ -8283,14 +10011,75 @@
     },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/webpack/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8304,6 +10093,8 @@
     },
     "node_modules/websocket-extensions": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -8312,6 +10103,8 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8321,8 +10114,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8332,6 +10140,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8345,19 +10155,25 @@
     },
     "node_modules/which-module": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.11",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8368,16 +10184,31 @@
     },
     "node_modules/wildcard": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/workerpool": {
-      "version": "6.2.1",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8394,10 +10225,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8408,9 +10243,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8431,11 +10266,15 @@
     },
     "node_modules/xml": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8444,6 +10283,8 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8452,11 +10293,15 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8464,14 +10309,13 @@
       }
     },
     "node_modules/yaml-language-server": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.16.0.tgz",
-      "integrity": "sha512-Kr8ezZSib9mKIypgmvGZzIgBPV0ty2RYfBd39YDc5Iw8wbhKTz2rGMAUW0DwqAuModvxg8KOdc1Tvp4Xpr2nbw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.17.0.tgz",
+      "integrity": "sha512-cGgjTUNsR/mPGq2NrsNuJYEG3eKMOUro46Kk+qG4pib5LIJUDdn2h+eZPmi1E1DUr5wGvnZuh9IC6OhtsuyfLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
-        "ajv-draft-04": "^1.0.0",
         "lodash": "4.17.21",
         "prettier": "^3.0.0",
         "request-light": "^0.5.7",
@@ -8504,21 +10348,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -8544,24 +10373,28 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8570,6 +10403,8 @@
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8584,6 +10419,8 @@
     },
     "node_modules/yargs-unparser/node_modules/camelcase": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8595,6 +10432,8 @@
     },
     "node_modules/yargs-unparser/node_modules/decamelize": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8602,6 +10441,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yauzl": {
@@ -8617,6 +10476,8 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8625,6 +10486,8 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8706,6 +10569,17 @@
         "vscode-ws-jsonrpc": "^3.4.0"
       }
     },
+    "packages/ace-linters/node_modules/@types/eslint": {
+      "version": "8.56.12",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "packages/ace-lua-linter": {
       "version": "1.1.0",
       "license": "MIT",
@@ -8738,13 +10612,13 @@
       }
     },
     "packages/ace-zig-linter": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@wasm-fmt/zig_fmt": "^0.0.5"
       },
       "peerDependencies": {
-        "ace-linters": "^1.3.4"
+        "ace-linters": "^1.5.0"
       }
     },
     "packages/demo": {

--- a/packages/ace-linters/src/services/javascript/lib/index.js
+++ b/packages/ace-linters/src/services/javascript/lib/index.js
@@ -484,7 +484,7 @@ var require_shams = __commonJS({
       }
       var symVal = 42;
       obj[sym] = symVal;
-      for (sym in obj) {
+      for (var _ in obj) {
         return false;
       }
       if (typeof Object.keys === "function" && Object.keys(obj).length !== 0) {
@@ -501,7 +501,10 @@ var require_shams = __commonJS({
         return false;
       }
       if (typeof Object.getOwnPropertyDescriptor === "function") {
-        var descriptor = Object.getOwnPropertyDescriptor(obj, sym);
+        var descriptor = (
+          /** @type {PropertyDescriptor} */
+          Object.getOwnPropertyDescriptor(obj, sym)
+        );
         if (descriptor.value !== symVal || descriptor.enumerable !== true) {
           return false;
         }
@@ -519,6 +522,14 @@ var require_shams2 = __commonJS({
     module.exports = function hasToStringTagShams() {
       return hasSymbols() && !!Symbol.toStringTag;
     };
+  }
+});
+
+// ../../node_modules/es-object-atoms/index.js
+var require_es_object_atoms = __commonJS({
+  "../../node_modules/es-object-atoms/index.js"(exports, module) {
+    "use strict";
+    module.exports = Object;
   }
 });
 
@@ -578,6 +589,118 @@ var require_uri = __commonJS({
   }
 });
 
+// ../../node_modules/math-intrinsics/abs.js
+var require_abs = __commonJS({
+  "../../node_modules/math-intrinsics/abs.js"(exports, module) {
+    "use strict";
+    module.exports = Math.abs;
+  }
+});
+
+// ../../node_modules/math-intrinsics/floor.js
+var require_floor = __commonJS({
+  "../../node_modules/math-intrinsics/floor.js"(exports, module) {
+    "use strict";
+    module.exports = Math.floor;
+  }
+});
+
+// ../../node_modules/math-intrinsics/max.js
+var require_max = __commonJS({
+  "../../node_modules/math-intrinsics/max.js"(exports, module) {
+    "use strict";
+    module.exports = Math.max;
+  }
+});
+
+// ../../node_modules/math-intrinsics/min.js
+var require_min = __commonJS({
+  "../../node_modules/math-intrinsics/min.js"(exports, module) {
+    "use strict";
+    module.exports = Math.min;
+  }
+});
+
+// ../../node_modules/math-intrinsics/pow.js
+var require_pow = __commonJS({
+  "../../node_modules/math-intrinsics/pow.js"(exports, module) {
+    "use strict";
+    module.exports = Math.pow;
+  }
+});
+
+// ../../node_modules/math-intrinsics/round.js
+var require_round = __commonJS({
+  "../../node_modules/math-intrinsics/round.js"(exports, module) {
+    "use strict";
+    module.exports = Math.round;
+  }
+});
+
+// ../../node_modules/math-intrinsics/isNaN.js
+var require_isNaN = __commonJS({
+  "../../node_modules/math-intrinsics/isNaN.js"(exports, module) {
+    "use strict";
+    module.exports = Number.isNaN || function isNaN2(a) {
+      return a !== a;
+    };
+  }
+});
+
+// ../../node_modules/math-intrinsics/sign.js
+var require_sign = __commonJS({
+  "../../node_modules/math-intrinsics/sign.js"(exports, module) {
+    "use strict";
+    var $isNaN = require_isNaN();
+    module.exports = function sign(number) {
+      if ($isNaN(number) || number === 0) {
+        return number;
+      }
+      return number < 0 ? -1 : 1;
+    };
+  }
+});
+
+// ../../node_modules/gopd/gOPD.js
+var require_gOPD = __commonJS({
+  "../../node_modules/gopd/gOPD.js"(exports, module) {
+    "use strict";
+    module.exports = Object.getOwnPropertyDescriptor;
+  }
+});
+
+// ../../node_modules/gopd/index.js
+var require_gopd = __commonJS({
+  "../../node_modules/gopd/index.js"(exports, module) {
+    "use strict";
+    var $gOPD = require_gOPD();
+    if ($gOPD) {
+      try {
+        $gOPD([], "length");
+      } catch (e) {
+        $gOPD = null;
+      }
+    }
+    module.exports = $gOPD;
+  }
+});
+
+// ../../node_modules/es-define-property/index.js
+var require_es_define_property = __commonJS({
+  "../../node_modules/es-define-property/index.js"(exports, module) {
+    "use strict";
+    var $defineProperty = Object.defineProperty || false;
+    if ($defineProperty) {
+      try {
+        $defineProperty({}, "a", { value: 1 });
+      } catch (e) {
+        $defineProperty = false;
+      }
+    }
+    module.exports = $defineProperty;
+  }
+});
+
 // ../../node_modules/has-symbols/index.js
 var require_has_symbols = __commonJS({
   "../../node_modules/has-symbols/index.js"(exports, module) {
@@ -602,17 +725,20 @@ var require_has_symbols = __commonJS({
   }
 });
 
-// ../../node_modules/has-proto/index.js
-var require_has_proto = __commonJS({
-  "../../node_modules/has-proto/index.js"(exports, module) {
+// ../../node_modules/get-proto/Reflect.getPrototypeOf.js
+var require_Reflect_getPrototypeOf = __commonJS({
+  "../../node_modules/get-proto/Reflect.getPrototypeOf.js"(exports, module) {
     "use strict";
-    var test = {
-      foo: {}
-    };
-    var $Object = Object;
-    module.exports = function hasProto() {
-      return { __proto__: test }.foo === test.foo && !({ __proto__: null } instanceof $Object);
-    };
+    module.exports = typeof Reflect !== "undefined" && Reflect.getPrototypeOf || null;
+  }
+});
+
+// ../../node_modules/get-proto/Object.getPrototypeOf.js
+var require_Object_getPrototypeOf = __commonJS({
+  "../../node_modules/get-proto/Object.getPrototypeOf.js"(exports, module) {
+    "use strict";
+    var $Object = require_es_object_atoms();
+    module.exports = $Object.getPrototypeOf || null;
   }
 });
 
@@ -701,6 +827,110 @@ var require_function_bind = __commonJS({
   }
 });
 
+// ../../node_modules/call-bind-apply-helpers/functionCall.js
+var require_functionCall = __commonJS({
+  "../../node_modules/call-bind-apply-helpers/functionCall.js"(exports, module) {
+    "use strict";
+    module.exports = Function.prototype.call;
+  }
+});
+
+// ../../node_modules/call-bind-apply-helpers/functionApply.js
+var require_functionApply = __commonJS({
+  "../../node_modules/call-bind-apply-helpers/functionApply.js"(exports, module) {
+    "use strict";
+    module.exports = Function.prototype.apply;
+  }
+});
+
+// ../../node_modules/call-bind-apply-helpers/reflectApply.js
+var require_reflectApply = __commonJS({
+  "../../node_modules/call-bind-apply-helpers/reflectApply.js"(exports, module) {
+    "use strict";
+    module.exports = typeof Reflect !== "undefined" && Reflect && Reflect.apply;
+  }
+});
+
+// ../../node_modules/call-bind-apply-helpers/actualApply.js
+var require_actualApply = __commonJS({
+  "../../node_modules/call-bind-apply-helpers/actualApply.js"(exports, module) {
+    "use strict";
+    var bind = require_function_bind();
+    var $apply = require_functionApply();
+    var $call = require_functionCall();
+    var $reflectApply = require_reflectApply();
+    module.exports = $reflectApply || bind.call($call, $apply);
+  }
+});
+
+// ../../node_modules/call-bind-apply-helpers/index.js
+var require_call_bind_apply_helpers = __commonJS({
+  "../../node_modules/call-bind-apply-helpers/index.js"(exports, module) {
+    "use strict";
+    var bind = require_function_bind();
+    var $TypeError = require_type();
+    var $call = require_functionCall();
+    var $actualApply = require_actualApply();
+    module.exports = function callBindBasic(args) {
+      if (args.length < 1 || typeof args[0] !== "function") {
+        throw new $TypeError("a function is required");
+      }
+      return $actualApply(bind, $call, args);
+    };
+  }
+});
+
+// ../../node_modules/dunder-proto/get.js
+var require_get = __commonJS({
+  "../../node_modules/dunder-proto/get.js"(exports, module) {
+    "use strict";
+    var callBind = require_call_bind_apply_helpers();
+    var gOPD = require_gopd();
+    var hasProtoAccessor;
+    try {
+      hasProtoAccessor = /** @type {{ __proto__?: typeof Array.prototype }} */
+      [].__proto__ === Array.prototype;
+    } catch (e) {
+      if (!e || typeof e !== "object" || !("code" in e) || e.code !== "ERR_PROTO_ACCESS") {
+        throw e;
+      }
+    }
+    var desc = !!hasProtoAccessor && gOPD && gOPD(
+      Object.prototype,
+      /** @type {keyof typeof Object.prototype} */
+      "__proto__"
+    );
+    var $Object = Object;
+    var $getPrototypeOf = $Object.getPrototypeOf;
+    module.exports = desc && typeof desc.get === "function" ? callBind([desc.get]) : typeof $getPrototypeOf === "function" ? (
+      /** @type {import('./get')} */
+      function getDunder(value) {
+        return $getPrototypeOf(value == null ? value : $Object(value));
+      }
+    ) : false;
+  }
+});
+
+// ../../node_modules/get-proto/index.js
+var require_get_proto = __commonJS({
+  "../../node_modules/get-proto/index.js"(exports, module) {
+    "use strict";
+    var reflectGetProto = require_Reflect_getPrototypeOf();
+    var originalGetProto = require_Object_getPrototypeOf();
+    var getDunderProto = require_get();
+    module.exports = reflectGetProto ? function getProto(O) {
+      return reflectGetProto(O);
+    } : originalGetProto ? function getProto(O) {
+      if (!O || typeof O !== "object" && typeof O !== "function") {
+        throw new TypeError("getProto: not an object");
+      }
+      return originalGetProto(O);
+    } : getDunderProto ? function getProto(O) {
+      return getDunderProto(O);
+    } : null;
+  }
+});
+
 // ../../node_modules/hasown/index.js
 var require_hasown = __commonJS({
   "../../node_modules/hasown/index.js"(exports, module) {
@@ -717,6 +947,7 @@ var require_get_intrinsic = __commonJS({
   "../../node_modules/get-intrinsic/index.js"(exports, module) {
     "use strict";
     var undefined2;
+    var $Object = require_es_object_atoms();
     var $Error = require_es_errors();
     var $EvalError = require_eval();
     var $RangeError = require_range();
@@ -724,6 +955,13 @@ var require_get_intrinsic = __commonJS({
     var $SyntaxError = require_syntax();
     var $TypeError = require_type();
     var $URIError = require_uri();
+    var abs = require_abs();
+    var floor = require_floor();
+    var max = require_max();
+    var min = require_min();
+    var pow = require_pow();
+    var round = require_round();
+    var sign = require_sign();
     var $Function = Function;
     var getEvalledConstructor = function(expressionSyntax) {
       try {
@@ -731,14 +969,8 @@ var require_get_intrinsic = __commonJS({
       } catch (e) {
       }
     };
-    var $gOPD = Object.getOwnPropertyDescriptor;
-    if ($gOPD) {
-      try {
-        $gOPD({}, "");
-      } catch (e) {
-        $gOPD = null;
-      }
-    }
+    var $gOPD = require_gopd();
+    var $defineProperty = require_es_define_property();
     var throwTypeError = function() {
       throw new $TypeError();
     };
@@ -755,10 +987,11 @@ var require_get_intrinsic = __commonJS({
       }
     }() : throwTypeError;
     var hasSymbols = require_has_symbols()();
-    var hasProto = require_has_proto()();
-    var getProto = Object.getPrototypeOf || (hasProto ? function(x) {
-      return x.__proto__;
-    } : null);
+    var getProto = require_get_proto();
+    var $ObjectGPO = require_Object_getPrototypeOf();
+    var $ReflectGPO = require_Reflect_getPrototypeOf();
+    var $apply = require_functionApply();
+    var $call = require_functionCall();
     var needsEval = {};
     var TypedArray = typeof Uint8Array === "undefined" || !getProto ? undefined2 : getProto(Uint8Array);
     var INTRINSICS = {
@@ -787,6 +1020,7 @@ var require_get_intrinsic = __commonJS({
       "%eval%": eval,
       // eslint-disable-line no-eval
       "%EvalError%": $EvalError,
+      "%Float16Array%": typeof Float16Array === "undefined" ? undefined2 : Float16Array,
       "%Float32Array%": typeof Float32Array === "undefined" ? undefined2 : Float32Array,
       "%Float64Array%": typeof Float64Array === "undefined" ? undefined2 : Float64Array,
       "%FinalizationRegistry%": typeof FinalizationRegistry === "undefined" ? undefined2 : FinalizationRegistry,
@@ -803,7 +1037,8 @@ var require_get_intrinsic = __commonJS({
       "%MapIteratorPrototype%": typeof Map === "undefined" || !hasSymbols || !getProto ? undefined2 : getProto((/* @__PURE__ */ new Map())[Symbol.iterator]()),
       "%Math%": Math,
       "%Number%": Number,
-      "%Object%": Object,
+      "%Object%": $Object,
+      "%Object.getOwnPropertyDescriptor%": $gOPD,
       "%parseFloat%": parseFloat,
       "%parseInt%": parseInt,
       "%Promise%": typeof Promise === "undefined" ? undefined2 : Promise,
@@ -829,7 +1064,19 @@ var require_get_intrinsic = __commonJS({
       "%URIError%": $URIError,
       "%WeakMap%": typeof WeakMap === "undefined" ? undefined2 : WeakMap,
       "%WeakRef%": typeof WeakRef === "undefined" ? undefined2 : WeakRef,
-      "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet
+      "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet,
+      "%Function.prototype.call%": $call,
+      "%Function.prototype.apply%": $apply,
+      "%Object.defineProperty%": $defineProperty,
+      "%Object.getPrototypeOf%": $ObjectGPO,
+      "%Math.abs%": abs,
+      "%Math.floor%": floor,
+      "%Math.max%": max,
+      "%Math.min%": min,
+      "%Math.pow%": pow,
+      "%Math.round%": round,
+      "%Math.sign%": sign,
+      "%Reflect.getPrototypeOf%": $ReflectGPO
     };
     if (getProto) {
       try {
@@ -918,11 +1165,11 @@ var require_get_intrinsic = __commonJS({
     };
     var bind = require_function_bind();
     var hasOwn = require_hasown();
-    var $concat = bind.call(Function.call, Array.prototype.concat);
-    var $spliceApply = bind.call(Function.apply, Array.prototype.splice);
-    var $replace = bind.call(Function.call, String.prototype.replace);
-    var $strSlice = bind.call(Function.call, String.prototype.slice);
-    var $exec = bind.call(Function.call, RegExp.prototype.exec);
+    var $concat = bind.call($call, Array.prototype.concat);
+    var $spliceApply = bind.call($apply, Array.prototype.splice);
+    var $replace = bind.call($call, String.prototype.replace);
+    var $strSlice = bind.call($call, String.prototype.slice);
+    var $exec = bind.call($call, RegExp.prototype.exec);
     var rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
     var reEscapeChar = /\\(\\)?/g;
     var stringToPath = function stringToPath2(string) {
@@ -1026,209 +1273,23 @@ var require_get_intrinsic = __commonJS({
   }
 });
 
-// ../../node_modules/es-define-property/index.js
-var require_es_define_property = __commonJS({
-  "../../node_modules/es-define-property/index.js"(exports, module) {
+// ../../node_modules/call-bound/index.js
+var require_call_bound = __commonJS({
+  "../../node_modules/call-bound/index.js"(exports, module) {
     "use strict";
     var GetIntrinsic = require_get_intrinsic();
-    var $defineProperty = GetIntrinsic("%Object.defineProperty%", true) || false;
-    if ($defineProperty) {
-      try {
-        $defineProperty({}, "a", { value: 1 });
-      } catch (e) {
-        $defineProperty = false;
-      }
-    }
-    module.exports = $defineProperty;
-  }
-});
-
-// ../../node_modules/gopd/index.js
-var require_gopd = __commonJS({
-  "../../node_modules/gopd/index.js"(exports, module) {
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var $gOPD = GetIntrinsic("%Object.getOwnPropertyDescriptor%", true);
-    if ($gOPD) {
-      try {
-        $gOPD([], "length");
-      } catch (e) {
-        $gOPD = null;
-      }
-    }
-    module.exports = $gOPD;
-  }
-});
-
-// ../../node_modules/define-data-property/index.js
-var require_define_data_property = __commonJS({
-  "../../node_modules/define-data-property/index.js"(exports, module) {
-    "use strict";
-    var $defineProperty = require_es_define_property();
-    var $SyntaxError = require_syntax();
-    var $TypeError = require_type();
-    var gopd = require_gopd();
-    module.exports = function defineDataProperty(obj, property, value) {
-      if (!obj || typeof obj !== "object" && typeof obj !== "function") {
-        throw new $TypeError("`obj` must be an object or a function`");
-      }
-      if (typeof property !== "string" && typeof property !== "symbol") {
-        throw new $TypeError("`property` must be a string or a symbol`");
-      }
-      if (arguments.length > 3 && typeof arguments[3] !== "boolean" && arguments[3] !== null) {
-        throw new $TypeError("`nonEnumerable`, if provided, must be a boolean or null");
-      }
-      if (arguments.length > 4 && typeof arguments[4] !== "boolean" && arguments[4] !== null) {
-        throw new $TypeError("`nonWritable`, if provided, must be a boolean or null");
-      }
-      if (arguments.length > 5 && typeof arguments[5] !== "boolean" && arguments[5] !== null) {
-        throw new $TypeError("`nonConfigurable`, if provided, must be a boolean or null");
-      }
-      if (arguments.length > 6 && typeof arguments[6] !== "boolean") {
-        throw new $TypeError("`loose`, if provided, must be a boolean");
-      }
-      var nonEnumerable = arguments.length > 3 ? arguments[3] : null;
-      var nonWritable = arguments.length > 4 ? arguments[4] : null;
-      var nonConfigurable = arguments.length > 5 ? arguments[5] : null;
-      var loose = arguments.length > 6 ? arguments[6] : false;
-      var desc = !!gopd && gopd(obj, property);
-      if ($defineProperty) {
-        $defineProperty(obj, property, {
-          configurable: nonConfigurable === null && desc ? desc.configurable : !nonConfigurable,
-          enumerable: nonEnumerable === null && desc ? desc.enumerable : !nonEnumerable,
-          value,
-          writable: nonWritable === null && desc ? desc.writable : !nonWritable
-        });
-      } else if (loose || !nonEnumerable && !nonWritable && !nonConfigurable) {
-        obj[property] = value;
-      } else {
-        throw new $SyntaxError("This environment does not support defining a property as non-configurable, non-writable, or non-enumerable.");
-      }
-    };
-  }
-});
-
-// ../../node_modules/has-property-descriptors/index.js
-var require_has_property_descriptors = __commonJS({
-  "../../node_modules/has-property-descriptors/index.js"(exports, module) {
-    "use strict";
-    var $defineProperty = require_es_define_property();
-    var hasPropertyDescriptors = function hasPropertyDescriptors2() {
-      return !!$defineProperty;
-    };
-    hasPropertyDescriptors.hasArrayLengthDefineBug = function hasArrayLengthDefineBug() {
-      if (!$defineProperty) {
-        return null;
-      }
-      try {
-        return $defineProperty([], "length", { value: 1 }).length !== 1;
-      } catch (e) {
-        return true;
-      }
-    };
-    module.exports = hasPropertyDescriptors;
-  }
-});
-
-// ../../node_modules/set-function-length/index.js
-var require_set_function_length = __commonJS({
-  "../../node_modules/set-function-length/index.js"(exports, module) {
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var define2 = require_define_data_property();
-    var hasDescriptors = require_has_property_descriptors()();
-    var gOPD = require_gopd();
-    var $TypeError = require_type();
-    var $floor = GetIntrinsic("%Math.floor%");
-    module.exports = function setFunctionLength(fn, length) {
-      if (typeof fn !== "function") {
-        throw new $TypeError("`fn` is not a function");
-      }
-      if (typeof length !== "number" || length < 0 || length > 4294967295 || $floor(length) !== length) {
-        throw new $TypeError("`length` must be a positive 32-bit integer");
-      }
-      var loose = arguments.length > 2 && !!arguments[2];
-      var functionLengthIsConfigurable = true;
-      var functionLengthIsWritable = true;
-      if ("length" in fn && gOPD) {
-        var desc = gOPD(fn, "length");
-        if (desc && !desc.configurable) {
-          functionLengthIsConfigurable = false;
-        }
-        if (desc && !desc.writable) {
-          functionLengthIsWritable = false;
-        }
-      }
-      if (functionLengthIsConfigurable || functionLengthIsWritable || !loose) {
-        if (hasDescriptors) {
-          define2(
-            /** @type {Parameters<define>[0]} */
-            fn,
-            "length",
-            length,
-            true,
-            true
-          );
-        } else {
-          define2(
-            /** @type {Parameters<define>[0]} */
-            fn,
-            "length",
-            length
-          );
-        }
-      }
-      return fn;
-    };
-  }
-});
-
-// ../../node_modules/call-bind/index.js
-var require_call_bind = __commonJS({
-  "../../node_modules/call-bind/index.js"(exports, module) {
-    "use strict";
-    var bind = require_function_bind();
-    var GetIntrinsic = require_get_intrinsic();
-    var setFunctionLength = require_set_function_length();
-    var $TypeError = require_type();
-    var $apply = GetIntrinsic("%Function.prototype.apply%");
-    var $call = GetIntrinsic("%Function.prototype.call%");
-    var $reflectApply = GetIntrinsic("%Reflect.apply%", true) || bind.call($call, $apply);
-    var $defineProperty = require_es_define_property();
-    var $max = GetIntrinsic("%Math.max%");
-    module.exports = function callBind(originalFunction) {
-      if (typeof originalFunction !== "function") {
-        throw new $TypeError("a function is required");
-      }
-      var func = $reflectApply(bind, $call, arguments);
-      return setFunctionLength(
-        func,
-        1 + $max(0, originalFunction.length - (arguments.length - 1)),
-        true
-      );
-    };
-    var applyBind = function applyBind2() {
-      return $reflectApply(bind, $apply, arguments);
-    };
-    if ($defineProperty) {
-      $defineProperty(module.exports, "apply", { value: applyBind });
-    } else {
-      module.exports.apply = applyBind;
-    }
-  }
-});
-
-// ../../node_modules/call-bind/callBound.js
-var require_callBound = __commonJS({
-  "../../node_modules/call-bind/callBound.js"(exports, module) {
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var callBind = require_call_bind();
-    var $indexOf = callBind(GetIntrinsic("String.prototype.indexOf"));
+    var callBindBasic = require_call_bind_apply_helpers();
+    var $indexOf = callBindBasic([GetIntrinsic("%String.prototype.indexOf%")]);
     module.exports = function callBoundIntrinsic(name, allowMissing) {
-      var intrinsic = GetIntrinsic(name, !!allowMissing);
+      var intrinsic = (
+        /** @type {(this: unknown, ...args: unknown[]) => unknown} */
+        GetIntrinsic(name, !!allowMissing)
+      );
       if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
-        return callBind(intrinsic);
+        return callBindBasic(
+          /** @type {const} */
+          [intrinsic]
+        );
       }
       return intrinsic;
     };
@@ -1240,7 +1301,7 @@ var require_is_arguments = __commonJS({
   "../../node_modules/is-arguments/index.js"(exports, module) {
     "use strict";
     var hasToStringTag = require_shams2()();
-    var callBound = require_callBound();
+    var callBound = require_call_bound();
     var $toString = callBound("Object.prototype.toString");
     var isStandardArguments = function isArguments(value) {
       if (hasToStringTag && value && typeof value === "object" && Symbol.toStringTag in value) {
@@ -1252,7 +1313,7 @@ var require_is_arguments = __commonJS({
       if (isStandardArguments(value)) {
         return true;
       }
-      return value !== null && typeof value === "object" && typeof value.length === "number" && value.length >= 0 && $toString(value) !== "[object Array]" && $toString(value.callee) === "[object Function]";
+      return value !== null && typeof value === "object" && "length" in value && typeof value.length === "number" && value.length >= 0 && $toString(value) !== "[object Array]" && "callee" in value && $toString(value.callee) === "[object Function]";
     };
     var supportsStandardArguments = function() {
       return isStandardArguments(arguments);
@@ -1262,15 +1323,105 @@ var require_is_arguments = __commonJS({
   }
 });
 
+// ../../node_modules/is-regex/index.js
+var require_is_regex = __commonJS({
+  "../../node_modules/is-regex/index.js"(exports, module) {
+    "use strict";
+    var callBound = require_call_bound();
+    var hasToStringTag = require_shams2()();
+    var hasOwn = require_hasown();
+    var gOPD = require_gopd();
+    var fn;
+    if (hasToStringTag) {
+      $exec = callBound("RegExp.prototype.exec");
+      isRegexMarker = {};
+      throwRegexMarker = function() {
+        throw isRegexMarker;
+      };
+      badStringifier = {
+        toString: throwRegexMarker,
+        valueOf: throwRegexMarker
+      };
+      if (typeof Symbol.toPrimitive === "symbol") {
+        badStringifier[Symbol.toPrimitive] = throwRegexMarker;
+      }
+      fn = function isRegex(value) {
+        if (!value || typeof value !== "object") {
+          return false;
+        }
+        var descriptor = (
+          /** @type {NonNullable<typeof gOPD>} */
+          gOPD(
+            /** @type {{ lastIndex?: unknown }} */
+            value,
+            "lastIndex"
+          )
+        );
+        var hasLastIndexDataProperty = descriptor && hasOwn(descriptor, "value");
+        if (!hasLastIndexDataProperty) {
+          return false;
+        }
+        try {
+          $exec(
+            value,
+            /** @type {string} */
+            /** @type {unknown} */
+            badStringifier
+          );
+        } catch (e) {
+          return e === isRegexMarker;
+        }
+      };
+    } else {
+      $toString = callBound("Object.prototype.toString");
+      regexClass = "[object RegExp]";
+      fn = function isRegex(value) {
+        if (!value || typeof value !== "object" && typeof value !== "function") {
+          return false;
+        }
+        return $toString(value) === regexClass;
+      };
+    }
+    var $exec;
+    var isRegexMarker;
+    var throwRegexMarker;
+    var badStringifier;
+    var $toString;
+    var regexClass;
+    module.exports = fn;
+  }
+});
+
+// ../../node_modules/safe-regex-test/index.js
+var require_safe_regex_test = __commonJS({
+  "../../node_modules/safe-regex-test/index.js"(exports, module) {
+    "use strict";
+    var callBound = require_call_bound();
+    var isRegex = require_is_regex();
+    var $exec = callBound("RegExp.prototype.exec");
+    var $TypeError = require_type();
+    module.exports = function regexTester(regex) {
+      if (!isRegex(regex)) {
+        throw new $TypeError("`regex` must be a RegExp");
+      }
+      return function test(s) {
+        return $exec(regex, s) !== null;
+      };
+    };
+  }
+});
+
 // ../../node_modules/is-generator-function/index.js
 var require_is_generator_function = __commonJS({
   "../../node_modules/is-generator-function/index.js"(exports, module) {
     "use strict";
-    var toStr = Object.prototype.toString;
-    var fnToStr = Function.prototype.toString;
-    var isFnRegex = /^\s*(?:function)?\*/;
+    var callBound = require_call_bound();
+    var safeRegexTest = require_safe_regex_test();
+    var isFnRegex = safeRegexTest(/^\s*(?:function)?\*/);
     var hasToStringTag = require_shams2()();
-    var getProto = Object.getPrototypeOf;
+    var getProto = require_get_proto();
+    var toStr = callBound("Object.prototype.toString");
+    var fnToStr = callBound("Function.prototype.toString");
     var getGeneratorFunc = function() {
       if (!hasToStringTag) {
         return false;
@@ -1285,11 +1436,11 @@ var require_is_generator_function = __commonJS({
       if (typeof fn !== "function") {
         return false;
       }
-      if (isFnRegex.test(fnToStr.call(fn))) {
+      if (isFnRegex(fnToStr(fn))) {
         return true;
       }
       if (!hasToStringTag) {
-        var str = toStr.call(fn);
+        var str = toStr(fn);
         return str === "[object GeneratorFunction]";
       }
       if (!getProto) {
@@ -1297,7 +1448,10 @@ var require_is_generator_function = __commonJS({
       }
       if (typeof GeneratorFunction === "undefined") {
         var generatorFunc = getGeneratorFunc();
-        GeneratorFunction = generatorFunc ? getProto(generatorFunc) : false;
+        GeneratorFunction = generatorFunc ? (
+          /** @type {GeneratorFunctionConstructor} */
+          getProto(generatorFunc)
+        ) : false;
       }
       return getProto(fn) === GeneratorFunction;
     };
@@ -1460,7 +1614,10 @@ var require_for_each = __commonJS({
         }
       }
     };
-    var forEach = function forEach2(list, iterator, thisArg) {
+    function isArray(x) {
+      return toStr.call(x) === "[object Array]";
+    }
+    module.exports = function forEach(list, iterator, thisArg) {
       if (!isCallable(iterator)) {
         throw new TypeError("iterator must be a function");
       }
@@ -1468,7 +1625,7 @@ var require_for_each = __commonJS({
       if (arguments.length >= 3) {
         receiver = thisArg;
       }
-      if (toStr.call(list) === "[object Array]") {
+      if (isArray(list)) {
         forEachArray(list, iterator, receiver);
       } else if (typeof list === "string") {
         forEachString(list, iterator, receiver);
@@ -1476,7 +1633,27 @@ var require_for_each = __commonJS({
         forEachObject(list, iterator, receiver);
       }
     };
-    module.exports = forEach;
+  }
+});
+
+// ../../node_modules/possible-typed-array-names/index.js
+var require_possible_typed_array_names = __commonJS({
+  "../../node_modules/possible-typed-array-names/index.js"(exports, module) {
+    "use strict";
+    module.exports = [
+      "Float16Array",
+      "Float32Array",
+      "Float64Array",
+      "Int8Array",
+      "Int16Array",
+      "Int32Array",
+      "Uint8Array",
+      "Uint8ClampedArray",
+      "Uint16Array",
+      "Uint32Array",
+      "BigInt64Array",
+      "BigUint64Array"
+    ];
   }
 });
 
@@ -1484,19 +1661,7 @@ var require_for_each = __commonJS({
 var require_available_typed_arrays = __commonJS({
   "../../node_modules/available-typed-arrays/index.js"(exports, module) {
     "use strict";
-    var possibleNames = [
-      "BigInt64Array",
-      "BigUint64Array",
-      "Float32Array",
-      "Float64Array",
-      "Int16Array",
-      "Int32Array",
-      "Int8Array",
-      "Uint16Array",
-      "Uint32Array",
-      "Uint8Array",
-      "Uint8ClampedArray"
-    ];
+    var possibleNames = require_possible_typed_array_names();
     var g = typeof globalThis === "undefined" ? global : globalThis;
     module.exports = function availableTypedArrays() {
       var out = [];
@@ -1510,6 +1675,167 @@ var require_available_typed_arrays = __commonJS({
   }
 });
 
+// ../../node_modules/define-data-property/index.js
+var require_define_data_property = __commonJS({
+  "../../node_modules/define-data-property/index.js"(exports, module) {
+    "use strict";
+    var $defineProperty = require_es_define_property();
+    var $SyntaxError = require_syntax();
+    var $TypeError = require_type();
+    var gopd = require_gopd();
+    module.exports = function defineDataProperty(obj, property, value) {
+      if (!obj || typeof obj !== "object" && typeof obj !== "function") {
+        throw new $TypeError("`obj` must be an object or a function`");
+      }
+      if (typeof property !== "string" && typeof property !== "symbol") {
+        throw new $TypeError("`property` must be a string or a symbol`");
+      }
+      if (arguments.length > 3 && typeof arguments[3] !== "boolean" && arguments[3] !== null) {
+        throw new $TypeError("`nonEnumerable`, if provided, must be a boolean or null");
+      }
+      if (arguments.length > 4 && typeof arguments[4] !== "boolean" && arguments[4] !== null) {
+        throw new $TypeError("`nonWritable`, if provided, must be a boolean or null");
+      }
+      if (arguments.length > 5 && typeof arguments[5] !== "boolean" && arguments[5] !== null) {
+        throw new $TypeError("`nonConfigurable`, if provided, must be a boolean or null");
+      }
+      if (arguments.length > 6 && typeof arguments[6] !== "boolean") {
+        throw new $TypeError("`loose`, if provided, must be a boolean");
+      }
+      var nonEnumerable = arguments.length > 3 ? arguments[3] : null;
+      var nonWritable = arguments.length > 4 ? arguments[4] : null;
+      var nonConfigurable = arguments.length > 5 ? arguments[5] : null;
+      var loose = arguments.length > 6 ? arguments[6] : false;
+      var desc = !!gopd && gopd(obj, property);
+      if ($defineProperty) {
+        $defineProperty(obj, property, {
+          configurable: nonConfigurable === null && desc ? desc.configurable : !nonConfigurable,
+          enumerable: nonEnumerable === null && desc ? desc.enumerable : !nonEnumerable,
+          value,
+          writable: nonWritable === null && desc ? desc.writable : !nonWritable
+        });
+      } else if (loose || !nonEnumerable && !nonWritable && !nonConfigurable) {
+        obj[property] = value;
+      } else {
+        throw new $SyntaxError("This environment does not support defining a property as non-configurable, non-writable, or non-enumerable.");
+      }
+    };
+  }
+});
+
+// ../../node_modules/has-property-descriptors/index.js
+var require_has_property_descriptors = __commonJS({
+  "../../node_modules/has-property-descriptors/index.js"(exports, module) {
+    "use strict";
+    var $defineProperty = require_es_define_property();
+    var hasPropertyDescriptors = function hasPropertyDescriptors2() {
+      return !!$defineProperty;
+    };
+    hasPropertyDescriptors.hasArrayLengthDefineBug = function hasArrayLengthDefineBug() {
+      if (!$defineProperty) {
+        return null;
+      }
+      try {
+        return $defineProperty([], "length", { value: 1 }).length !== 1;
+      } catch (e) {
+        return true;
+      }
+    };
+    module.exports = hasPropertyDescriptors;
+  }
+});
+
+// ../../node_modules/set-function-length/index.js
+var require_set_function_length = __commonJS({
+  "../../node_modules/set-function-length/index.js"(exports, module) {
+    "use strict";
+    var GetIntrinsic = require_get_intrinsic();
+    var define2 = require_define_data_property();
+    var hasDescriptors = require_has_property_descriptors()();
+    var gOPD = require_gopd();
+    var $TypeError = require_type();
+    var $floor = GetIntrinsic("%Math.floor%");
+    module.exports = function setFunctionLength(fn, length) {
+      if (typeof fn !== "function") {
+        throw new $TypeError("`fn` is not a function");
+      }
+      if (typeof length !== "number" || length < 0 || length > 4294967295 || $floor(length) !== length) {
+        throw new $TypeError("`length` must be a positive 32-bit integer");
+      }
+      var loose = arguments.length > 2 && !!arguments[2];
+      var functionLengthIsConfigurable = true;
+      var functionLengthIsWritable = true;
+      if ("length" in fn && gOPD) {
+        var desc = gOPD(fn, "length");
+        if (desc && !desc.configurable) {
+          functionLengthIsConfigurable = false;
+        }
+        if (desc && !desc.writable) {
+          functionLengthIsWritable = false;
+        }
+      }
+      if (functionLengthIsConfigurable || functionLengthIsWritable || !loose) {
+        if (hasDescriptors) {
+          define2(
+            /** @type {Parameters<define>[0]} */
+            fn,
+            "length",
+            length,
+            true,
+            true
+          );
+        } else {
+          define2(
+            /** @type {Parameters<define>[0]} */
+            fn,
+            "length",
+            length
+          );
+        }
+      }
+      return fn;
+    };
+  }
+});
+
+// ../../node_modules/call-bind-apply-helpers/applyBind.js
+var require_applyBind = __commonJS({
+  "../../node_modules/call-bind-apply-helpers/applyBind.js"(exports, module) {
+    "use strict";
+    var bind = require_function_bind();
+    var $apply = require_functionApply();
+    var actualApply = require_actualApply();
+    module.exports = function applyBind() {
+      return actualApply(bind, $apply, arguments);
+    };
+  }
+});
+
+// ../../node_modules/call-bind/index.js
+var require_call_bind = __commonJS({
+  "../../node_modules/call-bind/index.js"(exports, module) {
+    "use strict";
+    var setFunctionLength = require_set_function_length();
+    var $defineProperty = require_es_define_property();
+    var callBindBasic = require_call_bind_apply_helpers();
+    var applyBind = require_applyBind();
+    module.exports = function callBind(originalFunction) {
+      var func = callBindBasic(arguments);
+      var adjustedLength = originalFunction.length - (arguments.length - 1);
+      return setFunctionLength(
+        func,
+        1 + (adjustedLength > 0 ? adjustedLength : 0),
+        true
+      );
+    };
+    if ($defineProperty) {
+      $defineProperty(module.exports, "apply", { value: applyBind });
+    } else {
+      module.exports.apply = applyBind;
+    }
+  }
+});
+
 // ../../node_modules/which-typed-array/index.js
 var require_which_typed_array = __commonJS({
   "../../node_modules/which-typed-array/index.js"(exports, module) {
@@ -1517,14 +1843,14 @@ var require_which_typed_array = __commonJS({
     var forEach = require_for_each();
     var availableTypedArrays = require_available_typed_arrays();
     var callBind = require_call_bind();
-    var callBound = require_callBound();
+    var callBound = require_call_bound();
     var gOPD = require_gopd();
+    var getProto = require_get_proto();
     var $toString = callBound("Object.prototype.toString");
     var hasToStringTag = require_shams2()();
     var g = typeof globalThis === "undefined" ? global : globalThis;
     var typedArrays = availableTypedArrays();
     var $slice = callBound("String.prototype.slice");
-    var getPrototypeOf = Object.getPrototypeOf;
     var $indexOf = callBound("Array.prototype.indexOf", true) || function indexOf(array, value) {
       for (var i = 0; i < array.length; i += 1) {
         if (array[i] === value) {
@@ -1534,14 +1860,14 @@ var require_which_typed_array = __commonJS({
       return -1;
     };
     var cache = { __proto__: null };
-    if (hasToStringTag && gOPD && getPrototypeOf) {
+    if (hasToStringTag && gOPD && getProto) {
       forEach(typedArrays, function(typedArray) {
         var arr = new g[typedArray]();
-        if (Symbol.toStringTag in arr) {
-          var proto = getPrototypeOf(arr);
+        if (Symbol.toStringTag in arr && getProto) {
+          var proto = getProto(arr);
           var descriptor = gOPD(proto, Symbol.toStringTag);
-          if (!descriptor) {
-            var superProto = getPrototypeOf(proto);
+          if (!descriptor && proto) {
+            var superProto = getProto(proto);
             descriptor = gOPD(superProto, Symbol.toStringTag);
           }
           cache["$" + typedArray] = callBind(descriptor.get);
@@ -1550,34 +1876,54 @@ var require_which_typed_array = __commonJS({
     } else {
       forEach(typedArrays, function(typedArray) {
         var arr = new g[typedArray]();
-        cache["$" + typedArray] = callBind(arr.slice);
+        var fn = arr.slice || arr.set;
+        if (fn) {
+          cache[
+            /** @type {`$${import('.').TypedArrayName}`} */
+            "$" + typedArray
+          ] = /** @type {import('./types').BoundSlice | import('./types').BoundSet} */
+          // @ts-expect-error TODO FIXME
+          callBind(fn);
+        }
       });
     }
     var tryTypedArrays = function tryAllTypedArrays(value) {
       var found = false;
-      forEach(cache, function(getter, typedArray) {
-        if (!found) {
-          try {
-            if ("$" + getter(value) === typedArray) {
-              found = $slice(typedArray, 1);
+      forEach(
+        /** @type {Record<`\$${import('.').TypedArrayName}`, Getter>} */
+        cache,
+        /** @type {(getter: Getter, name: `\$${import('.').TypedArrayName}`) => void} */
+        function(getter, typedArray) {
+          if (!found) {
+            try {
+              if ("$" + getter(value) === typedArray) {
+                found = /** @type {import('.').TypedArrayName} */
+                $slice(typedArray, 1);
+              }
+            } catch (e) {
             }
-          } catch (e) {
           }
         }
-      });
+      );
       return found;
     };
     var trySlices = function tryAllSlices(value) {
       var found = false;
-      forEach(cache, function(getter, name) {
-        if (!found) {
-          try {
-            getter(value);
-            found = $slice(name, 1);
-          } catch (e) {
+      forEach(
+        /** @type {Record<`\$${import('.').TypedArrayName}`, Getter>} */
+        cache,
+        /** @type {(getter: Getter, name: `\$${import('.').TypedArrayName}`) => void} */
+        function(getter, name) {
+          if (!found) {
+            try {
+              getter(value);
+              found = /** @type {import('.').TypedArrayName} */
+              $slice(name, 1);
+            } catch (e) {
+            }
           }
         }
-      });
+      );
       return found;
     };
     module.exports = function whichTypedArray(value) {
@@ -2459,26 +2805,87 @@ var require_util = __commonJS({
 var require_errors = __commonJS({
   "../../node_modules/assert/build/internal/errors.js"(exports, module) {
     "use strict";
-    function _typeof(obj) {
-      if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-        _typeof = function _typeof2(obj2) {
-          return typeof obj2;
-        };
-      } else {
-        _typeof = function _typeof2(obj2) {
-          return obj2 && typeof Symbol === "function" && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
-        };
+    function _typeof(o) {
+      "@babel/helpers - typeof";
+      return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(o2) {
+        return typeof o2;
+      } : function(o2) {
+        return o2 && "function" == typeof Symbol && o2.constructor === Symbol && o2 !== Symbol.prototype ? "symbol" : typeof o2;
+      }, _typeof(o);
+    }
+    function _defineProperties(target, props) {
+      for (var i = 0; i < props.length; i++) {
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if ("value" in descriptor)
+          descriptor.writable = true;
+        Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor);
       }
-      return _typeof(obj);
+    }
+    function _createClass(Constructor, protoProps, staticProps) {
+      if (protoProps)
+        _defineProperties(Constructor.prototype, protoProps);
+      if (staticProps)
+        _defineProperties(Constructor, staticProps);
+      Object.defineProperty(Constructor, "prototype", { writable: false });
+      return Constructor;
+    }
+    function _toPropertyKey(arg) {
+      var key = _toPrimitive(arg, "string");
+      return _typeof(key) === "symbol" ? key : String(key);
+    }
+    function _toPrimitive(input, hint) {
+      if (_typeof(input) !== "object" || input === null)
+        return input;
+      var prim = input[Symbol.toPrimitive];
+      if (prim !== void 0) {
+        var res = prim.call(input, hint || "default");
+        if (_typeof(res) !== "object")
+          return res;
+        throw new TypeError("@@toPrimitive must return a primitive value.");
+      }
+      return (hint === "string" ? String : Number)(input);
     }
     function _classCallCheck(instance, Constructor) {
       if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
       }
     }
+    function _inherits(subClass, superClass) {
+      if (typeof superClass !== "function" && superClass !== null) {
+        throw new TypeError("Super expression must either be null or a function");
+      }
+      subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } });
+      Object.defineProperty(subClass, "prototype", { writable: false });
+      if (superClass)
+        _setPrototypeOf(subClass, superClass);
+    }
+    function _setPrototypeOf(o, p) {
+      _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function _setPrototypeOf2(o2, p2) {
+        o2.__proto__ = p2;
+        return o2;
+      };
+      return _setPrototypeOf(o, p);
+    }
+    function _createSuper(Derived) {
+      var hasNativeReflectConstruct = _isNativeReflectConstruct();
+      return function _createSuperInternal() {
+        var Super = _getPrototypeOf(Derived), result;
+        if (hasNativeReflectConstruct) {
+          var NewTarget = _getPrototypeOf(this).constructor;
+          result = Reflect.construct(Super, arguments, NewTarget);
+        } else {
+          result = Super.apply(this, arguments);
+        }
+        return _possibleConstructorReturn(this, result);
+      };
+    }
     function _possibleConstructorReturn(self2, call) {
       if (call && (_typeof(call) === "object" || typeof call === "function")) {
         return call;
+      } else if (call !== void 0) {
+        throw new TypeError("Derived constructors may only return object or undefined");
       }
       return _assertThisInitialized(self2);
     }
@@ -2488,26 +2895,26 @@ var require_errors = __commonJS({
       }
       return self2;
     }
+    function _isNativeReflectConstruct() {
+      if (typeof Reflect === "undefined" || !Reflect.construct)
+        return false;
+      if (Reflect.construct.sham)
+        return false;
+      if (typeof Proxy === "function")
+        return true;
+      try {
+        Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function() {
+        }));
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
     function _getPrototypeOf(o) {
-      _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf2(o2) {
+      _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function _getPrototypeOf2(o2) {
         return o2.__proto__ || Object.getPrototypeOf(o2);
       };
       return _getPrototypeOf(o);
-    }
-    function _inherits(subClass, superClass) {
-      if (typeof superClass !== "function" && superClass !== null) {
-        throw new TypeError("Super expression must either be null or a function");
-      }
-      subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } });
-      if (superClass)
-        _setPrototypeOf(subClass, superClass);
-    }
-    function _setPrototypeOf(o, p) {
-      _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf2(o2, p2) {
-        o2.__proto__ = p2;
-        return o2;
-      };
-      return _setPrototypeOf(o, p);
     }
     var codes = {};
     var assert;
@@ -2525,14 +2932,15 @@ var require_errors = __commonJS({
       }
       var NodeError = /* @__PURE__ */ function(_Base) {
         _inherits(NodeError2, _Base);
+        var _super = _createSuper(NodeError2);
         function NodeError2(arg1, arg2, arg3) {
           var _this;
           _classCallCheck(this, NodeError2);
-          _this = _possibleConstructorReturn(this, _getPrototypeOf(NodeError2).call(this, getMessage(arg1, arg2, arg3)));
+          _this = _super.call(this, getMessage(arg1, arg2, arg3));
           _this.code = code;
           return _this;
         }
-        return NodeError2;
+        return _createClass(NodeError2);
       }(Base);
       codes[code] = NodeError;
     }
@@ -2647,22 +3055,29 @@ var require_errors = __commonJS({
 var require_assertion_error = __commonJS({
   "../../node_modules/assert/build/internal/assert/assertion_error.js"(exports, module) {
     "use strict";
-    function _objectSpread(target) {
-      for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i] != null ? arguments[i] : {};
-        var ownKeys = Object.keys(source);
-        if (typeof Object.getOwnPropertySymbols === "function") {
-          ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function(sym) {
-            return Object.getOwnPropertyDescriptor(source, sym).enumerable;
-          }));
-        }
-        ownKeys.forEach(function(key) {
-          _defineProperty(target, key, source[key]);
+    function ownKeys(e, r) {
+      var t = Object.keys(e);
+      if (Object.getOwnPropertySymbols) {
+        var o = Object.getOwnPropertySymbols(e);
+        r && (o = o.filter(function(r2) {
+          return Object.getOwnPropertyDescriptor(e, r2).enumerable;
+        })), t.push.apply(t, o);
+      }
+      return t;
+    }
+    function _objectSpread(e) {
+      for (var r = 1; r < arguments.length; r++) {
+        var t = null != arguments[r] ? arguments[r] : {};
+        r % 2 ? ownKeys(Object(t), true).forEach(function(r2) {
+          _defineProperty(e, r2, t[r2]);
+        }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function(r2) {
+          Object.defineProperty(e, r2, Object.getOwnPropertyDescriptor(t, r2));
         });
       }
-      return target;
+      return e;
     }
     function _defineProperty(obj, key, value) {
+      key = _toPropertyKey(key);
       if (key in obj) {
         Object.defineProperty(obj, key, { value, enumerable: true, configurable: true, writable: true });
       } else {
@@ -2682,7 +3097,7 @@ var require_assertion_error = __commonJS({
         descriptor.configurable = true;
         if ("value" in descriptor)
           descriptor.writable = true;
-        Object.defineProperty(target, descriptor.key, descriptor);
+        Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor);
       }
     }
     function _createClass(Constructor, protoProps, staticProps) {
@@ -2690,11 +3105,52 @@ var require_assertion_error = __commonJS({
         _defineProperties(Constructor.prototype, protoProps);
       if (staticProps)
         _defineProperties(Constructor, staticProps);
+      Object.defineProperty(Constructor, "prototype", { writable: false });
       return Constructor;
+    }
+    function _toPropertyKey(arg) {
+      var key = _toPrimitive(arg, "string");
+      return _typeof(key) === "symbol" ? key : String(key);
+    }
+    function _toPrimitive(input, hint) {
+      if (_typeof(input) !== "object" || input === null)
+        return input;
+      var prim = input[Symbol.toPrimitive];
+      if (prim !== void 0) {
+        var res = prim.call(input, hint || "default");
+        if (_typeof(res) !== "object")
+          return res;
+        throw new TypeError("@@toPrimitive must return a primitive value.");
+      }
+      return (hint === "string" ? String : Number)(input);
+    }
+    function _inherits(subClass, superClass) {
+      if (typeof superClass !== "function" && superClass !== null) {
+        throw new TypeError("Super expression must either be null or a function");
+      }
+      subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } });
+      Object.defineProperty(subClass, "prototype", { writable: false });
+      if (superClass)
+        _setPrototypeOf(subClass, superClass);
+    }
+    function _createSuper(Derived) {
+      var hasNativeReflectConstruct = _isNativeReflectConstruct();
+      return function _createSuperInternal() {
+        var Super = _getPrototypeOf(Derived), result;
+        if (hasNativeReflectConstruct) {
+          var NewTarget = _getPrototypeOf(this).constructor;
+          result = Reflect.construct(Super, arguments, NewTarget);
+        } else {
+          result = Super.apply(this, arguments);
+        }
+        return _possibleConstructorReturn(this, result);
+      };
     }
     function _possibleConstructorReturn(self2, call) {
       if (call && (_typeof(call) === "object" || typeof call === "function")) {
         return call;
+      } else if (call !== void 0) {
+        throw new TypeError("Derived constructors may only return object or undefined");
       }
       return _assertThisInitialized(self2);
     }
@@ -2703,14 +3159,6 @@ var require_assertion_error = __commonJS({
         throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
       }
       return self2;
-    }
-    function _inherits(subClass, superClass) {
-      if (typeof superClass !== "function" && superClass !== null) {
-        throw new TypeError("Super expression must either be null or a function");
-      }
-      subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } });
-      if (superClass)
-        _setPrototypeOf(subClass, superClass);
     }
     function _wrapNativeSuper(Class) {
       var _cache = typeof Map === "function" ? /* @__PURE__ */ new Map() : void 0;
@@ -2733,24 +3181,9 @@ var require_assertion_error = __commonJS({
       };
       return _wrapNativeSuper(Class);
     }
-    function isNativeReflectConstruct() {
-      if (typeof Reflect === "undefined" || !Reflect.construct)
-        return false;
-      if (Reflect.construct.sham)
-        return false;
-      if (typeof Proxy === "function")
-        return true;
-      try {
-        Date.prototype.toString.call(Reflect.construct(Date, [], function() {
-        }));
-        return true;
-      } catch (e) {
-        return false;
-      }
-    }
     function _construct(Parent, args, Class) {
-      if (isNativeReflectConstruct()) {
-        _construct = Reflect.construct;
+      if (_isNativeReflectConstruct()) {
+        _construct = Reflect.construct.bind();
       } else {
         _construct = function _construct2(Parent2, args2, Class2) {
           var a = [null];
@@ -2764,33 +3197,44 @@ var require_assertion_error = __commonJS({
       }
       return _construct.apply(null, arguments);
     }
+    function _isNativeReflectConstruct() {
+      if (typeof Reflect === "undefined" || !Reflect.construct)
+        return false;
+      if (Reflect.construct.sham)
+        return false;
+      if (typeof Proxy === "function")
+        return true;
+      try {
+        Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function() {
+        }));
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
     function _isNativeFunction(fn) {
       return Function.toString.call(fn).indexOf("[native code]") !== -1;
     }
     function _setPrototypeOf(o, p) {
-      _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf2(o2, p2) {
+      _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function _setPrototypeOf2(o2, p2) {
         o2.__proto__ = p2;
         return o2;
       };
       return _setPrototypeOf(o, p);
     }
     function _getPrototypeOf(o) {
-      _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf2(o2) {
+      _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function _getPrototypeOf2(o2) {
         return o2.__proto__ || Object.getPrototypeOf(o2);
       };
       return _getPrototypeOf(o);
     }
-    function _typeof(obj) {
-      if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-        _typeof = function _typeof2(obj2) {
-          return typeof obj2;
-        };
-      } else {
-        _typeof = function _typeof2(obj2) {
-          return obj2 && typeof Symbol === "function" && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
-        };
-      }
-      return _typeof(obj);
+    function _typeof(o) {
+      "@babel/helpers - typeof";
+      return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(o2) {
+        return typeof o2;
+      } : function(o2) {
+        return o2 && "function" == typeof Symbol && o2.constructor === Symbol && o2 !== Symbol.prototype ? "symbol" : typeof o2;
+      }, _typeof(o);
     }
     var _require = require_util();
     var inspect = _require.inspect;
@@ -3006,8 +3450,9 @@ var require_assertion_error = __commonJS({
       }
       return "".concat(msg).concat(skipped ? skippedMsg : "", "\n").concat(res).concat(other).concat(end).concat(indicator);
     }
-    var AssertionError = /* @__PURE__ */ function(_Error) {
+    var AssertionError = /* @__PURE__ */ function(_Error, _inspect$custom) {
       _inherits(AssertionError2, _Error);
+      var _super = _createSuper(AssertionError2);
       function AssertionError2(options) {
         var _this;
         _classCallCheck(this, AssertionError2);
@@ -3019,7 +3464,7 @@ var require_assertion_error = __commonJS({
         var limit = Error.stackTraceLimit;
         Error.stackTraceLimit = 0;
         if (message != null) {
-          _this = _possibleConstructorReturn(this, _getPrototypeOf(AssertionError2).call(this, String(message)));
+          _this = _super.call(this, String(message));
         } else {
           if (process.stderr && process.stderr.isTTY) {
             if (process.stderr && process.stderr.getColorDepth && process.stderr.getColorDepth() !== 1) {
@@ -3039,7 +3484,7 @@ var require_assertion_error = __commonJS({
             expected = copyError(expected);
           }
           if (operator === "deepStrictEqual" || operator === "strictEqual") {
-            _this = _possibleConstructorReturn(this, _getPrototypeOf(AssertionError2).call(this, createErrDiff(actual, expected, operator)));
+            _this = _super.call(this, createErrDiff(actual, expected, operator));
           } else if (operator === "notDeepStrictEqual" || operator === "notStrictEqual") {
             var base = kReadableOperator[operator];
             var res = inspectValue(actual).split("\n");
@@ -3053,9 +3498,9 @@ var require_assertion_error = __commonJS({
               }
             }
             if (res.length === 1) {
-              _this = _possibleConstructorReturn(this, _getPrototypeOf(AssertionError2).call(this, "".concat(base, " ").concat(res[0])));
+              _this = _super.call(this, "".concat(base, " ").concat(res[0]));
             } else {
-              _this = _possibleConstructorReturn(this, _getPrototypeOf(AssertionError2).call(this, "".concat(base, "\n\n").concat(res.join("\n"), "\n")));
+              _this = _super.call(this, "".concat(base, "\n\n").concat(res.join("\n"), "\n"));
             }
           } else {
             var _res = inspectValue(actual);
@@ -3080,7 +3525,7 @@ var require_assertion_error = __commonJS({
                 other = " ".concat(operator, " ").concat(other);
               }
             }
-            _this = _possibleConstructorReturn(this, _getPrototypeOf(AssertionError2).call(this, "".concat(_res).concat(other)));
+            _this = _super.call(this, "".concat(_res).concat(other));
           }
         }
         Error.stackTraceLimit = limit;
@@ -3108,59 +3553,17 @@ var require_assertion_error = __commonJS({
           return "".concat(this.name, " [").concat(this.code, "]: ").concat(this.message);
         }
       }, {
-        key: inspect.custom,
+        key: _inspect$custom,
         value: function value(recurseTimes, ctx) {
-          return inspect(this, _objectSpread({}, ctx, {
+          return inspect(this, _objectSpread(_objectSpread({}, ctx), {}, {
             customInspect: false,
             depth: 0
           }));
         }
       }]);
       return AssertionError2;
-    }(_wrapNativeSuper(Error));
+    }(/* @__PURE__ */ _wrapNativeSuper(Error), inspect.custom);
     module.exports = AssertionError;
-  }
-});
-
-// ../../node_modules/es6-object-assign/index.js
-var require_es6_object_assign = __commonJS({
-  "../../node_modules/es6-object-assign/index.js"(exports, module) {
-    "use strict";
-    function assign(target, firstSource) {
-      if (target === void 0 || target === null) {
-        throw new TypeError("Cannot convert first argument to object");
-      }
-      var to = Object(target);
-      for (var i = 1; i < arguments.length; i++) {
-        var nextSource = arguments[i];
-        if (nextSource === void 0 || nextSource === null) {
-          continue;
-        }
-        var keysArray = Object.keys(Object(nextSource));
-        for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
-          var nextKey = keysArray[nextIndex];
-          var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
-          if (desc !== void 0 && desc.enumerable) {
-            to[nextKey] = nextSource[nextKey];
-          }
-        }
-      }
-      return to;
-    }
-    function polyfill() {
-      if (!Object.assign) {
-        Object.defineProperty(Object, "assign", {
-          enumerable: false,
-          configurable: true,
-          writable: true,
-          value: assign
-        });
-      }
-    }
-    module.exports = {
-      assign,
-      polyfill
-    };
   }
 });
 
@@ -3346,58 +3749,102 @@ var require_object_keys = __commonJS({
   }
 });
 
-// ../../node_modules/define-properties/index.js
-var require_define_properties = __commonJS({
-  "../../node_modules/define-properties/index.js"(exports, module) {
+// ../../node_modules/object.assign/implementation.js
+var require_implementation3 = __commonJS({
+  "../../node_modules/object.assign/implementation.js"(exports, module) {
     "use strict";
-    var keys = require_object_keys();
-    var hasSymbols = typeof Symbol === "function" && typeof Symbol("foo") === "symbol";
-    var toStr = Object.prototype.toString;
-    var concat = Array.prototype.concat;
-    var origDefineProperty = Object.defineProperty;
-    var isFunction = function(fn) {
-      return typeof fn === "function" && toStr.call(fn) === "[object Function]";
-    };
-    var hasPropertyDescriptors = require_has_property_descriptors()();
-    var supportsDescriptors = origDefineProperty && hasPropertyDescriptors;
-    var defineProperty = function(object, name, value, predicate) {
-      if (name in object) {
-        if (predicate === true) {
-          if (object[name] === value) {
-            return;
+    var objectKeys = require_object_keys();
+    var hasSymbols = require_shams()();
+    var callBound = require_call_bound();
+    var $Object = require_es_object_atoms();
+    var $push = callBound("Array.prototype.push");
+    var $propIsEnumerable = callBound("Object.prototype.propertyIsEnumerable");
+    var originalGetSymbols = hasSymbols ? $Object.getOwnPropertySymbols : null;
+    module.exports = function assign(target, source1) {
+      if (target == null) {
+        throw new TypeError("target must be an object");
+      }
+      var to = $Object(target);
+      if (arguments.length === 1) {
+        return to;
+      }
+      for (var s = 1; s < arguments.length; ++s) {
+        var from = $Object(arguments[s]);
+        var keys = objectKeys(from);
+        var getSymbols = hasSymbols && ($Object.getOwnPropertySymbols || originalGetSymbols);
+        if (getSymbols) {
+          var syms = getSymbols(from);
+          for (var j = 0; j < syms.length; ++j) {
+            var key = syms[j];
+            if ($propIsEnumerable(from, key)) {
+              $push(keys, key);
+            }
           }
-        } else if (!isFunction(predicate) || !predicate()) {
-          return;
+        }
+        for (var i = 0; i < keys.length; ++i) {
+          var nextKey = keys[i];
+          if ($propIsEnumerable(from, nextKey)) {
+            var propValue = from[nextKey];
+            to[nextKey] = propValue;
+          }
         }
       }
-      if (supportsDescriptors) {
-        origDefineProperty(object, name, {
-          configurable: true,
-          enumerable: false,
-          value,
-          writable: true
-        });
-      } else {
-        object[name] = value;
-      }
+      return to;
     };
-    var defineProperties = function(object, map) {
-      var predicates = arguments.length > 2 ? arguments[2] : {};
-      var props = keys(map);
-      if (hasSymbols) {
-        props = concat.call(props, Object.getOwnPropertySymbols(map));
+  }
+});
+
+// ../../node_modules/object.assign/polyfill.js
+var require_polyfill = __commonJS({
+  "../../node_modules/object.assign/polyfill.js"(exports, module) {
+    "use strict";
+    var implementation = require_implementation3();
+    var lacksProperEnumerationOrder = function() {
+      if (!Object.assign) {
+        return false;
       }
-      for (var i = 0; i < props.length; i += 1) {
-        defineProperty(object, props[i], map[props[i]], predicates[props[i]]);
+      var str = "abcdefghijklmnopqrst";
+      var letters = str.split("");
+      var map = {};
+      for (var i = 0; i < letters.length; ++i) {
+        map[letters[i]] = letters[i];
       }
+      var obj = Object.assign({}, map);
+      var actual = "";
+      for (var k in obj) {
+        actual += k;
+      }
+      return str !== actual;
     };
-    defineProperties.supportsDescriptors = !!supportsDescriptors;
-    module.exports = defineProperties;
+    var assignHasPendingExceptions = function() {
+      if (!Object.assign || !Object.preventExtensions) {
+        return false;
+      }
+      var thrower = Object.preventExtensions({ 1: 2 });
+      try {
+        Object.assign(thrower, "xy");
+      } catch (e) {
+        return thrower[1] === "y";
+      }
+      return false;
+    };
+    module.exports = function getPolyfill() {
+      if (!Object.assign) {
+        return implementation;
+      }
+      if (lacksProperEnumerationOrder()) {
+        return implementation;
+      }
+      if (assignHasPendingExceptions()) {
+        return implementation;
+      }
+      return Object.assign;
+    };
   }
 });
 
 // ../../node_modules/object-is/implementation.js
-var require_implementation3 = __commonJS({
+var require_implementation4 = __commonJS({
   "../../node_modules/object-is/implementation.js"(exports, module) {
     "use strict";
     var numberIsNaN = function(value) {
@@ -3419,13 +3866,74 @@ var require_implementation3 = __commonJS({
 });
 
 // ../../node_modules/object-is/polyfill.js
-var require_polyfill = __commonJS({
+var require_polyfill2 = __commonJS({
   "../../node_modules/object-is/polyfill.js"(exports, module) {
     "use strict";
-    var implementation = require_implementation3();
+    var implementation = require_implementation4();
     module.exports = function getPolyfill() {
       return typeof Object.is === "function" ? Object.is : implementation;
     };
+  }
+});
+
+// ../../node_modules/call-bind/callBound.js
+var require_callBound = __commonJS({
+  "../../node_modules/call-bind/callBound.js"(exports, module) {
+    "use strict";
+    var GetIntrinsic = require_get_intrinsic();
+    var callBind = require_call_bind();
+    var $indexOf = callBind(GetIntrinsic("String.prototype.indexOf"));
+    module.exports = function callBoundIntrinsic(name, allowMissing) {
+      var intrinsic = GetIntrinsic(name, !!allowMissing);
+      if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
+        return callBind(intrinsic);
+      }
+      return intrinsic;
+    };
+  }
+});
+
+// ../../node_modules/define-properties/index.js
+var require_define_properties = __commonJS({
+  "../../node_modules/define-properties/index.js"(exports, module) {
+    "use strict";
+    var keys = require_object_keys();
+    var hasSymbols = typeof Symbol === "function" && typeof Symbol("foo") === "symbol";
+    var toStr = Object.prototype.toString;
+    var concat = Array.prototype.concat;
+    var defineDataProperty = require_define_data_property();
+    var isFunction = function(fn) {
+      return typeof fn === "function" && toStr.call(fn) === "[object Function]";
+    };
+    var supportsDescriptors = require_has_property_descriptors()();
+    var defineProperty = function(object, name, value, predicate) {
+      if (name in object) {
+        if (predicate === true) {
+          if (object[name] === value) {
+            return;
+          }
+        } else if (!isFunction(predicate) || !predicate()) {
+          return;
+        }
+      }
+      if (supportsDescriptors) {
+        defineDataProperty(object, name, value, true);
+      } else {
+        defineDataProperty(object, name, value);
+      }
+    };
+    var defineProperties = function(object, map) {
+      var predicates = arguments.length > 2 ? arguments[2] : {};
+      var props = keys(map);
+      if (hasSymbols) {
+        props = concat.call(props, Object.getOwnPropertySymbols(map));
+      }
+      for (var i = 0; i < props.length; i += 1) {
+        defineProperty(object, props[i], map[props[i]], predicates[props[i]]);
+      }
+    };
+    defineProperties.supportsDescriptors = !!supportsDescriptors;
+    module.exports = defineProperties;
   }
 });
 
@@ -3433,7 +3941,7 @@ var require_polyfill = __commonJS({
 var require_shim = __commonJS({
   "../../node_modules/object-is/shim.js"(exports, module) {
     "use strict";
-    var getPolyfill = require_polyfill();
+    var getPolyfill = require_polyfill2();
     var define2 = require_define_properties();
     module.exports = function shimObjectIs() {
       var polyfill = getPolyfill();
@@ -3453,8 +3961,8 @@ var require_object_is = __commonJS({
     "use strict";
     var define2 = require_define_properties();
     var callBind = require_call_bind();
-    var implementation = require_implementation3();
-    var getPolyfill = require_polyfill();
+    var implementation = require_implementation4();
+    var getPolyfill = require_polyfill2();
     var shim = require_shim();
     var polyfill = callBind(getPolyfill(), Object);
     define2(polyfill, {
@@ -3467,7 +3975,7 @@ var require_object_is = __commonJS({
 });
 
 // ../../node_modules/is-nan/implementation.js
-var require_implementation4 = __commonJS({
+var require_implementation5 = __commonJS({
   "../../node_modules/is-nan/implementation.js"(exports, module) {
     "use strict";
     module.exports = function isNaN2(value) {
@@ -3477,10 +3985,10 @@ var require_implementation4 = __commonJS({
 });
 
 // ../../node_modules/is-nan/polyfill.js
-var require_polyfill2 = __commonJS({
+var require_polyfill3 = __commonJS({
   "../../node_modules/is-nan/polyfill.js"(exports, module) {
     "use strict";
-    var implementation = require_implementation4();
+    var implementation = require_implementation5();
     module.exports = function getPolyfill() {
       if (Number.isNaN && Number.isNaN(NaN) && !Number.isNaN("a")) {
         return Number.isNaN;
@@ -3495,7 +4003,7 @@ var require_shim2 = __commonJS({
   "../../node_modules/is-nan/shim.js"(exports, module) {
     "use strict";
     var define2 = require_define_properties();
-    var getPolyfill = require_polyfill2();
+    var getPolyfill = require_polyfill3();
     module.exports = function shimNumberIsNaN() {
       var polyfill = getPolyfill();
       define2(Number, { isNaN: polyfill }, {
@@ -3514,8 +4022,8 @@ var require_is_nan = __commonJS({
     "use strict";
     var callBind = require_call_bind();
     var define2 = require_define_properties();
-    var implementation = require_implementation4();
-    var getPolyfill = require_polyfill2();
+    var implementation = require_implementation5();
+    var getPolyfill = require_polyfill3();
     var shim = require_shim2();
     var polyfill = callBind(getPolyfill(), Number);
     define2(polyfill, {
@@ -3532,51 +4040,68 @@ var require_comparisons = __commonJS({
   "../../node_modules/assert/build/internal/util/comparisons.js"(exports, module) {
     "use strict";
     function _slicedToArray(arr, i) {
-      return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest();
+      return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest();
     }
     function _nonIterableRest() {
-      throw new TypeError("Invalid attempt to destructure non-iterable instance");
+      throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
     }
-    function _iterableToArrayLimit(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = void 0;
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
-          if (i && _arr.length === i)
-            break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
+    function _unsupportedIterableToArray(o, minLen) {
+      if (!o)
+        return;
+      if (typeof o === "string")
+        return _arrayLikeToArray(o, minLen);
+      var n = Object.prototype.toString.call(o).slice(8, -1);
+      if (n === "Object" && o.constructor)
+        n = o.constructor.name;
+      if (n === "Map" || n === "Set")
+        return Array.from(o);
+      if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))
+        return _arrayLikeToArray(o, minLen);
+    }
+    function _arrayLikeToArray(arr, len) {
+      if (len == null || len > arr.length)
+        len = arr.length;
+      for (var i = 0, arr2 = new Array(len); i < len; i++)
+        arr2[i] = arr[i];
+      return arr2;
+    }
+    function _iterableToArrayLimit(r, l) {
+      var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"];
+      if (null != t) {
+        var e, n, i, u, a = [], f = true, o = false;
         try {
-          if (!_n && _i["return"] != null)
-            _i["return"]();
+          if (i = (t = t.call(r)).next, 0 === l) {
+            if (Object(t) !== t)
+              return;
+            f = false;
+          } else
+            for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = true)
+              ;
+        } catch (r2) {
+          o = true, n = r2;
         } finally {
-          if (_d)
-            throw _e;
+          try {
+            if (!f && null != t.return && (u = t.return(), Object(u) !== u))
+              return;
+          } finally {
+            if (o)
+              throw n;
+          }
         }
+        return a;
       }
-      return _arr;
     }
     function _arrayWithHoles(arr) {
       if (Array.isArray(arr))
         return arr;
     }
-    function _typeof(obj) {
-      if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-        _typeof = function _typeof2(obj2) {
-          return typeof obj2;
-        };
-      } else {
-        _typeof = function _typeof2(obj2) {
-          return obj2 && typeof Symbol === "function" && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
-        };
-      }
-      return _typeof(obj);
+    function _typeof(o) {
+      "@babel/helpers - typeof";
+      return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(o2) {
+        return typeof o2;
+      } : function(o2) {
+        return o2 && "function" == typeof Symbol && o2.constructor === Symbol && o2 !== Symbol.prototype ? "symbol" : typeof o2;
+      }, _typeof(o);
     }
     var regexFlagsSupported = /a/g.flags !== void 0;
     var arrayFromSet = function arrayFromSet2(set) {
@@ -3984,11 +4509,11 @@ var require_comparisons = __commonJS({
       if (set !== null) {
         var bEntries = arrayFromMap(b);
         for (var _i2 = 0; _i2 < bEntries.length; _i2++) {
-          var _bEntries$_i = _slicedToArray(bEntries[_i2], 2), key = _bEntries$_i[0], item = _bEntries$_i[1];
-          if (_typeof(key) === "object" && key !== null) {
-            if (!mapHasEqualEntry(set, a, key, item, strict, memo))
+          var _bEntries$_i = _slicedToArray(bEntries[_i2], 2), _key = _bEntries$_i[0], item = _bEntries$_i[1];
+          if (_typeof(_key) === "object" && _key !== null) {
+            if (!mapHasEqualEntry(set, a, _key, item, strict, memo))
               return false;
-          } else if (!strict && (!a.has(key) || !innerDeepEqual(a.get(key), item, false, memo)) && !mapHasEqualEntry(set, a, key, item, false, memo)) {
+          } else if (!strict && (!a.has(_key) || !innerDeepEqual(a.get(_key), item, false, memo)) && !mapHasEqualEntry(set, a, _key, item, false, memo)) {
             return false;
           }
         }
@@ -4030,8 +4555,8 @@ var require_comparisons = __commonJS({
         }
       }
       for (i = 0; i < keys.length; i++) {
-        var _key = keys[i];
-        if (!innerDeepEqual(a[_key], b[_key], strict, memos)) {
+        var _key2 = keys[i];
+        if (!innerDeepEqual(a[_key2], b[_key2], strict, memos)) {
           return false;
         }
       }
@@ -4054,17 +4579,47 @@ var require_comparisons = __commonJS({
 var require_assert = __commonJS({
   "../../node_modules/assert/build/assert.js"(exports, module) {
     "use strict";
-    function _typeof(obj) {
-      if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-        _typeof = function _typeof2(obj2) {
-          return typeof obj2;
-        };
-      } else {
-        _typeof = function _typeof2(obj2) {
-          return obj2 && typeof Symbol === "function" && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
-        };
+    function _typeof(o) {
+      "@babel/helpers - typeof";
+      return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(o2) {
+        return typeof o2;
+      } : function(o2) {
+        return o2 && "function" == typeof Symbol && o2.constructor === Symbol && o2 !== Symbol.prototype ? "symbol" : typeof o2;
+      }, _typeof(o);
+    }
+    function _defineProperties(target, props) {
+      for (var i = 0; i < props.length; i++) {
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if ("value" in descriptor)
+          descriptor.writable = true;
+        Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor);
       }
-      return _typeof(obj);
+    }
+    function _createClass(Constructor, protoProps, staticProps) {
+      if (protoProps)
+        _defineProperties(Constructor.prototype, protoProps);
+      if (staticProps)
+        _defineProperties(Constructor, staticProps);
+      Object.defineProperty(Constructor, "prototype", { writable: false });
+      return Constructor;
+    }
+    function _toPropertyKey(arg) {
+      var key = _toPrimitive(arg, "string");
+      return _typeof(key) === "symbol" ? key : String(key);
+    }
+    function _toPrimitive(input, hint) {
+      if (_typeof(input) !== "object" || input === null)
+        return input;
+      var prim = input[Symbol.toPrimitive];
+      if (prim !== void 0) {
+        var res = prim.call(input, hint || "default");
+        if (_typeof(res) !== "object")
+          return res;
+        throw new TypeError("@@toPrimitive must return a primitive value.");
+      }
+      return (hint === "string" ? String : Number)(input);
     }
     function _classCallCheck(instance, Constructor) {
       if (!(instance instanceof Constructor)) {
@@ -4084,8 +4639,9 @@ var require_assert = __commonJS({
     var _require$types = require_util().types;
     var isPromise = _require$types.isPromise;
     var isRegExp = _require$types.isRegExp;
-    var objectAssign = Object.assign ? Object.assign : require_es6_object_assign().assign;
-    var objectIs = Object.is ? Object.is : require_object_is();
+    var objectAssign = require_polyfill()();
+    var objectIs = require_polyfill2()();
+    var RegExpPrototypeTest = require_callBound()("RegExp.prototype.test");
     var isDeepEqual;
     var isDeepStrictEqual;
     function lazyLoadComparison() {
@@ -4286,19 +4842,19 @@ var require_assert = __commonJS({
         });
       }
     };
-    var Comparison = function Comparison2(obj, keys, actual) {
+    var Comparison = /* @__PURE__ */ _createClass(function Comparison2(obj, keys, actual) {
       var _this = this;
       _classCallCheck(this, Comparison2);
       keys.forEach(function(key) {
         if (key in obj) {
-          if (actual !== void 0 && typeof actual[key] === "string" && isRegExp(obj[key]) && obj[key].test(actual[key])) {
+          if (actual !== void 0 && typeof actual[key] === "string" && isRegExp(obj[key]) && RegExpPrototypeTest(obj[key], actual[key])) {
             _this[key] = actual[key];
           } else {
             _this[key] = obj[key];
           }
         }
       });
-    };
+    });
     function compareExceptionKey(actual, expected, key, message, keys, fn) {
       if (!(key in actual) || !isDeepStrictEqual(actual[key], expected[key])) {
         if (!message) {
@@ -4327,7 +4883,7 @@ var require_assert = __commonJS({
     function expectedException(actual, expected, msg, fn) {
       if (typeof expected !== "function") {
         if (isRegExp(expected))
-          return expected.test(actual);
+          return RegExpPrototypeTest(expected, actual);
         if (arguments.length === 2) {
           throw new ERR_INVALID_ARG_TYPE("expected", ["Function", "RegExp"], expected);
         }
@@ -4351,7 +4907,7 @@ var require_assert = __commonJS({
         if (isDeepEqual === void 0)
           lazyLoadComparison();
         keys.forEach(function(key) {
-          if (typeof actual[key] === "string" && isRegExp(expected[key]) && expected[key].test(actual[key])) {
+          if (typeof actual[key] === "string" && isRegExp(expected[key]) && RegExpPrototypeTest(expected[key], actual[key])) {
             return;
           }
           compareExceptionKey(actual, expected, key, msg, keys, fn);
@@ -4521,6 +5077,34 @@ var require_assert = __commonJS({
         }
         throw newErr;
       }
+    };
+    function internalMatch(string, regexp, message, fn, fnName) {
+      if (!isRegExp(regexp)) {
+        throw new ERR_INVALID_ARG_TYPE("regexp", "RegExp", regexp);
+      }
+      var match = fnName === "match";
+      if (typeof string !== "string" || RegExpPrototypeTest(regexp, string) !== match) {
+        if (message instanceof Error) {
+          throw message;
+        }
+        var generatedMessage = !message;
+        message = message || (typeof string !== "string" ? 'The "string" argument must be of type string. Received type ' + "".concat(_typeof(string), " (").concat(inspect(string), ")") : (match ? "The input did not match the regular expression " : "The input was expected to not match the regular expression ") + "".concat(inspect(regexp), ". Input:\n\n").concat(inspect(string), "\n"));
+        var err = new AssertionError({
+          actual: string,
+          expected: regexp,
+          message,
+          operator: fnName,
+          stackStartFn: fn
+        });
+        err.generatedMessage = generatedMessage;
+        throw err;
+      }
+    }
+    assert.match = function match(string, regexp, message) {
+      internalMatch(string, regexp, message, match, "match");
+    };
+    assert.doesNotMatch = function doesNotMatch(string, regexp, message) {
+      internalMatch(string, regexp, message, doesNotMatch, "doesNotMatch");
     };
     function strict() {
       for (var _len6 = arguments.length, args = new Array(_len6), _key6 = 0; _key6 < _len6; _key6++) {
@@ -7199,7 +7783,7 @@ var require_eslint_scope = __commonJS({
       MetaProperty() {
       }
     };
-    var version = "7.2.1";
+    var version = "7.2.2";
     function defaultOptions() {
       return {
         optimistic: false,
@@ -7604,10 +8188,10 @@ var require_acorn = __commonJS({
       typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global2 = typeof globalThis !== "undefined" ? globalThis : global2 || self, factory(global2.acorn = {}));
     })(exports, function(exports2) {
       "use strict";
-      var astralIdentifierCodes = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 81, 2, 71, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 3, 0, 158, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 10, 1, 2, 0, 49, 6, 4, 4, 14, 9, 5351, 0, 7, 14, 13835, 9, 87, 9, 39, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4706, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 101, 0, 161, 6, 10, 9, 357, 0, 62, 13, 499, 13, 983, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
-      var astralIdentifierStartCodes = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 68, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 20, 1, 64, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 16, 0, 2, 12, 2, 33, 125, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1071, 18, 5, 4026, 582, 8634, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8936, 3, 2, 6, 2, 1, 2, 290, 16, 0, 30, 2, 3, 0, 15, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 7, 5, 262, 61, 147, 44, 11, 6, 17, 0, 322, 29, 19, 43, 485, 27, 757, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4153, 7, 221, 3, 5761, 15, 7472, 3104, 541, 1507, 4938, 6, 4191];
-      var nonASCIIidentifierChars = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0898-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0CF3\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECE\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F";
-      var nonASCIIidentifierStartChars = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CA\uA7D0\uA7D1\uA7D3\uA7D5-\uA7D9\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+      var astralIdentifierCodes = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 7, 9, 32, 4, 318, 1, 80, 3, 71, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 3, 0, 158, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 68, 8, 2, 0, 3, 0, 2, 3, 2, 4, 2, 0, 15, 1, 83, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 7, 19, 58, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 343, 9, 54, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 10, 1, 2, 0, 49, 6, 4, 4, 14, 10, 5350, 0, 7, 14, 11465, 27, 2343, 9, 87, 9, 39, 4, 60, 6, 26, 9, 535, 9, 470, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4178, 9, 519, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 101, 0, 161, 6, 10, 9, 357, 0, 62, 13, 499, 13, 245, 1, 2, 9, 726, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+      var astralIdentifierStartCodes = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 4, 51, 13, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 39, 27, 10, 22, 251, 41, 7, 1, 17, 2, 60, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 20, 1, 64, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 31, 9, 2, 0, 3, 0, 2, 37, 2, 0, 26, 0, 2, 0, 45, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 200, 32, 32, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 16, 0, 2, 12, 2, 33, 125, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1071, 18, 5, 26, 3994, 6, 582, 6842, 29, 1763, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 433, 44, 212, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 42, 9, 8936, 3, 2, 6, 2, 1, 2, 290, 16, 0, 30, 2, 3, 0, 15, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 7, 5, 262, 61, 147, 44, 11, 6, 17, 0, 322, 29, 19, 43, 485, 27, 229, 29, 3, 0, 496, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4153, 7, 221, 3, 5761, 15, 7472, 16, 621, 2467, 541, 1507, 4938, 6, 4191];
+      var nonASCIIidentifierChars = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0897-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0CF3\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECE\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u200C\u200D\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\u30FB\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F\uFF65";
+      var nonASCIIidentifierStartChars = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C8A\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CD\uA7D0\uA7D1\uA7D3\uA7D5-\uA7DC\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
       var reservedWords = {
         3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
         5: "class enum extends super const export import",
@@ -7832,8 +8416,9 @@ var require_acorn = __commonJS({
       var isArray = Array.isArray || function(obj) {
         return toString.call(obj) === "[object Array]";
       };
+      var regexpCache = /* @__PURE__ */ Object.create(null);
       function wordsRegexp(words) {
-        return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+        return regexpCache[words] || (regexpCache[words] = new RegExp("^(?:" + words.replace(/ /g, "|") + ")$"));
       }
       function codePointToString(code) {
         if (code <= 65535) {
@@ -7879,11 +8464,11 @@ var require_acorn = __commonJS({
         // Can be either `"script"` or `"module"`. This influences global
         // strict mode and parsing of `import` and `export` declarations.
         sourceType: "script",
-        // `onInsertedSemicolon` can be a callback that will be called
-        // when a semicolon is automatically inserted. It will be passed
-        // the position of the comma as an offset, and if `locations` is
-        // enabled, it is given the location as a `{line, column}` object
-        // as second argument.
+        // `onInsertedSemicolon` can be a callback that will be called when
+        // a semicolon is automatically inserted. It will be passed the
+        // position of the inserted semicolon as an offset, and if
+        // `locations` is enabled, it is given the location as a `{line,
+        // column}` object as second argument.
         onInsertedSemicolon: null,
         // `onTrailingComma` is similar to `onInsertedSemicolon`, but for
         // trailing commas.
@@ -7936,6 +8521,8 @@ var require_acorn = __commonJS({
         // passed, the full `{line, column}` locations of the start and
         // end of the comments. Note that you are not allowed to call the
         // parser from the callback—that will corrupt its internal state.
+        // When this option has an array as value, objects representing the
+        // comments are pushed to it.
         onComment: null,
         // Nodes have their start and end characters offsets recorded in
         // `start` and `end` properties (directly on the node, rather than
@@ -8013,7 +8600,7 @@ var require_acorn = __commonJS({
           array.push(comment);
         };
       }
-      var SCOPE_TOP = 1, SCOPE_FUNCTION = 2, SCOPE_ASYNC = 4, SCOPE_GENERATOR = 8, SCOPE_ARROW = 16, SCOPE_SIMPLE_CATCH = 32, SCOPE_SUPER = 64, SCOPE_DIRECT_SUPER = 128, SCOPE_CLASS_STATIC_BLOCK = 256, SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK;
+      var SCOPE_TOP = 1, SCOPE_FUNCTION = 2, SCOPE_ASYNC = 4, SCOPE_GENERATOR = 8, SCOPE_ARROW = 16, SCOPE_SIMPLE_CATCH = 32, SCOPE_SUPER = 64, SCOPE_DIRECT_SUPER = 128, SCOPE_CLASS_STATIC_BLOCK = 256, SCOPE_CLASS_FIELD_INIT = 512, SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK;
       function functionFlags(async, generator) {
         return SCOPE_FUNCTION | (async ? SCOPE_ASYNC : 0) | (generator ? SCOPE_GENERATOR : 0);
       }
@@ -8076,19 +8663,20 @@ var require_acorn = __commonJS({
         return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
       };
       prototypeAccessors.inGenerator.get = function() {
-        return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0 && !this.currentVarScope().inClassFieldInit;
+        return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0;
       };
       prototypeAccessors.inAsync.get = function() {
-        return (this.currentVarScope().flags & SCOPE_ASYNC) > 0 && !this.currentVarScope().inClassFieldInit;
+        return (this.currentVarScope().flags & SCOPE_ASYNC) > 0;
       };
       prototypeAccessors.canAwait.get = function() {
         for (var i2 = this.scopeStack.length - 1; i2 >= 0; i2--) {
-          var scope = this.scopeStack[i2];
-          if (scope.inClassFieldInit || scope.flags & SCOPE_CLASS_STATIC_BLOCK) {
+          var ref2 = this.scopeStack[i2];
+          var flags = ref2.flags;
+          if (flags & (SCOPE_CLASS_STATIC_BLOCK | SCOPE_CLASS_FIELD_INIT)) {
             return false;
           }
-          if (scope.flags & SCOPE_FUNCTION) {
-            return (scope.flags & SCOPE_ASYNC) > 0;
+          if (flags & SCOPE_FUNCTION) {
+            return (flags & SCOPE_ASYNC) > 0;
           }
         }
         return this.inModule && this.options.ecmaVersion >= 13 || this.options.allowAwaitOutsideFunction;
@@ -8096,8 +8684,7 @@ var require_acorn = __commonJS({
       prototypeAccessors.allowSuper.get = function() {
         var ref2 = this.currentThisScope();
         var flags = ref2.flags;
-        var inClassFieldInit = ref2.inClassFieldInit;
-        return (flags & SCOPE_SUPER) > 0 || inClassFieldInit || this.options.allowSuperOutsideMethod;
+        return (flags & SCOPE_SUPER) > 0 || this.options.allowSuperOutsideMethod;
       };
       prototypeAccessors.allowDirectSuper.get = function() {
         return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0;
@@ -8106,10 +8693,14 @@ var require_acorn = __commonJS({
         return this.treatFunctionsAsVarInScope(this.currentScope());
       };
       prototypeAccessors.allowNewDotTarget.get = function() {
-        var ref2 = this.currentThisScope();
-        var flags = ref2.flags;
-        var inClassFieldInit = ref2.inClassFieldInit;
-        return (flags & (SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK)) > 0 || inClassFieldInit;
+        for (var i2 = this.scopeStack.length - 1; i2 >= 0; i2--) {
+          var ref2 = this.scopeStack[i2];
+          var flags = ref2.flags;
+          if (flags & (SCOPE_CLASS_STATIC_BLOCK | SCOPE_CLASS_FIELD_INIT) || flags & SCOPE_FUNCTION && !(flags & SCOPE_ARROW)) {
+            return true;
+          }
+        }
+        return false;
       };
       prototypeAccessors.inClassStaticBlock.get = function() {
         return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK) > 0;
@@ -8137,7 +8728,7 @@ var require_acorn = __commonJS({
       };
       Object.defineProperties(Parser.prototype, prototypeAccessors);
       var pp$9 = Parser.prototype;
-      var literal = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/;
+      var literal = /^(?:'((?:\\[^]|[^'\\])*?)'|"((?:\\[^]|[^"\\])*?)")/;
       pp$9.strictDirective = function(start) {
         if (this.options.ecmaVersion < 5) {
           return false;
@@ -8495,16 +9086,21 @@ var require_acorn = __commonJS({
           return this.parseFor(node, init$1);
         }
         var startsWithLet = this.isContextual("let"), isForOf = false;
+        var containsEsc = this.containsEsc;
         var refDestructuringErrors = new DestructuringErrors();
-        var init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors);
+        var initPos = this.start;
+        var init = awaitAt > -1 ? this.parseExprSubscripts(refDestructuringErrors, "await") : this.parseExpression(true, refDestructuringErrors);
         if (this.type === types$1._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
-          if (this.options.ecmaVersion >= 9) {
+          if (awaitAt > -1) {
             if (this.type === types$1._in) {
-              if (awaitAt > -1) {
-                this.unexpected(awaitAt);
-              }
-            } else {
-              node.await = awaitAt > -1;
+              this.unexpected(awaitAt);
+            }
+            node.await = true;
+          } else if (isForOf && this.options.ecmaVersion >= 8) {
+            if (init.start === initPos && !containsEsc && init.type === "Identifier" && init.name === "async") {
+              this.unexpected();
+            } else if (this.options.ecmaVersion >= 9) {
+              node.await = false;
             }
           }
           if (startsWithLet && isForOf) {
@@ -8942,11 +9538,9 @@ var require_acorn = __commonJS({
           this.raise(field.key.start, "Classes can't have a static field named 'prototype'");
         }
         if (this.eat(types$1.eq)) {
-          var scope = this.currentThisScope();
-          var inClassFieldInit = scope.inClassFieldInit;
-          scope.inClassFieldInit = true;
+          this.enterScope(SCOPE_CLASS_FIELD_INIT | SCOPE_SUPER);
           field.value = this.parseMaybeAssign();
-          scope.inClassFieldInit = inClassFieldInit;
+          this.exitScope();
         } else {
           field.value = null;
         }
@@ -9044,6 +9638,9 @@ var require_acorn = __commonJS({
           this.unexpected();
         }
         node.source = this.parseExprAtom();
+        if (this.options.ecmaVersion >= 16) {
+          node.attributes = this.parseWithClause();
+        }
         this.semicolon();
         return this.finishNode(node, "ExportAllDeclaration");
       };
@@ -9066,6 +9663,9 @@ var require_acorn = __commonJS({
           }
           node.specifiers = [];
           node.source = null;
+          if (this.options.ecmaVersion >= 16) {
+            node.attributes = [];
+          }
         } else {
           node.declaration = null;
           node.specifiers = this.parseExportSpecifiers(exports3);
@@ -9074,6 +9674,9 @@ var require_acorn = __commonJS({
               this.unexpected();
             }
             node.source = this.parseExprAtom();
+            if (this.options.ecmaVersion >= 16) {
+              node.attributes = this.parseWithClause();
+            }
           } else {
             for (var i2 = 0, list2 = node.specifiers; i2 < list2.length; i2 += 1) {
               var spec = list2[i2];
@@ -9084,6 +9687,9 @@ var require_acorn = __commonJS({
               }
             }
             node.source = null;
+            if (this.options.ecmaVersion >= 16) {
+              node.attributes = [];
+            }
           }
           this.semicolon();
         }
@@ -9144,8 +9750,6 @@ var require_acorn = __commonJS({
           this.checkPatternExport(exports3, pat.left);
         } else if (type === "RestElement") {
           this.checkPatternExport(exports3, pat.argument);
-        } else if (type === "ParenthesizedExpression") {
-          this.checkPatternExport(exports3, pat.expression);
         }
       };
       pp$8.checkVariableExport = function(exports3, decls) {
@@ -9196,6 +9800,9 @@ var require_acorn = __commonJS({
           node.specifiers = this.parseImportSpecifiers();
           this.expectContextual("from");
           node.source = this.type === types$1.string ? this.parseExprAtom() : this.unexpected();
+        }
+        if (this.options.ecmaVersion >= 16) {
+          node.attributes = this.parseWithClause();
         }
         this.semicolon();
         return this.finishNode(node, "ImportDeclaration");
@@ -9251,6 +9858,43 @@ var require_acorn = __commonJS({
           nodes.push(this.parseImportSpecifier());
         }
         return nodes;
+      };
+      pp$8.parseWithClause = function() {
+        var nodes = [];
+        if (!this.eat(types$1._with)) {
+          return nodes;
+        }
+        this.expect(types$1.braceL);
+        var attributeKeys = {};
+        var first = true;
+        while (!this.eat(types$1.braceR)) {
+          if (!first) {
+            this.expect(types$1.comma);
+            if (this.afterTrailingComma(types$1.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var attr = this.parseImportAttribute();
+          var keyName = attr.key.type === "Identifier" ? attr.key.name : attr.key.value;
+          if (hasOwn(attributeKeys, keyName)) {
+            this.raiseRecoverable(attr.key.start, "Duplicate attribute key '" + keyName + "'");
+          }
+          attributeKeys[keyName] = true;
+          nodes.push(attr);
+        }
+        return nodes;
+      };
+      pp$8.parseImportAttribute = function() {
+        var node = this.startNode();
+        node.key = this.type === types$1.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+        this.expect(types$1.colon);
+        if (this.type !== types$1.string) {
+          this.unexpected();
+        }
+        node.value = this.parseExprAtom();
+        return this.finishNode(node, "ImportAttribute");
       };
       pp$8.parseModuleExportName = function() {
         if (this.options.ecmaVersion >= 13 && this.type === types$1.string) {
@@ -9622,6 +10266,12 @@ var require_acorn = __commonJS({
         }
         this.exprAllowed = false;
       };
+      types$1.colon.updateContext = function() {
+        if (this.curContext().token === "function") {
+          this.context.pop();
+        }
+        this.exprAllowed = true;
+      };
       types$1.backQuote.updateContext = function() {
         if (this.curContext() === types.q_tmpl) {
           this.context.pop();
@@ -9854,7 +10504,7 @@ var require_acorn = __commonJS({
           this.checkExpressionErrors(refDestructuringErrors, true);
           if (update) {
             this.checkLValSimple(node.argument);
-          } else if (this.strict && node.operator === "delete" && node.argument.type === "Identifier") {
+          } else if (this.strict && node.operator === "delete" && isLocalVariableAccess(node.argument)) {
             this.raiseRecoverable(node.start, "Deleting local variable in strict mode");
           } else if (node.operator === "delete" && isPrivateFieldAccess(node.argument)) {
             this.raiseRecoverable(node.start, "Private fields can not be deleted");
@@ -9895,8 +10545,11 @@ var require_acorn = __commonJS({
           return expr;
         }
       };
+      function isLocalVariableAccess(node) {
+        return node.type === "Identifier" || node.type === "ParenthesizedExpression" && isLocalVariableAccess(node.expression);
+      }
       function isPrivateFieldAccess(node) {
-        return node.type === "MemberExpression" && node.property.type === "PrivateIdentifier" || node.type === "ChainExpression" && isPrivateFieldAccess(node.expression);
+        return node.type === "MemberExpression" && node.property.type === "PrivateIdentifier" || node.type === "ChainExpression" && isPrivateFieldAccess(node.expression) || node.type === "ParenthesizedExpression" && isPrivateFieldAccess(node.expression);
       }
       pp$5.parseExprSubscripts = function(refDestructuringErrors, forInit) {
         var startPos = this.start, startLoc = this.startLoc;
@@ -10111,11 +10764,13 @@ var require_acorn = __commonJS({
         if (this.containsEsc) {
           this.raiseRecoverable(this.start, "Escape sequence in keyword import");
         }
-        var meta = this.parseIdent(true);
+        this.next();
         if (this.type === types$1.parenL && !forNew) {
           return this.parseDynamicImport(node);
         } else if (this.type === types$1.dot) {
-          node.meta = meta;
+          var meta = this.startNodeAt(node.start, node.loc && node.loc.start);
+          meta.name = "import";
+          node.meta = this.finishNode(meta, "Identifier");
           return this.parseImportMeta(node);
         } else {
           this.unexpected();
@@ -10124,12 +10779,31 @@ var require_acorn = __commonJS({
       pp$5.parseDynamicImport = function(node) {
         this.next();
         node.source = this.parseMaybeAssign();
-        if (!this.eat(types$1.parenR)) {
-          var errorPos = this.start;
-          if (this.eat(types$1.comma) && this.eat(types$1.parenR)) {
-            this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+        if (this.options.ecmaVersion >= 16) {
+          if (!this.eat(types$1.parenR)) {
+            this.expect(types$1.comma);
+            if (!this.afterTrailingComma(types$1.parenR)) {
+              node.options = this.parseMaybeAssign();
+              if (!this.eat(types$1.parenR)) {
+                this.expect(types$1.comma);
+                if (!this.afterTrailingComma(types$1.parenR)) {
+                  this.unexpected();
+                }
+              }
+            } else {
+              node.options = null;
+            }
           } else {
-            this.unexpected(errorPos);
+            node.options = null;
+          }
+        } else {
+          if (!this.eat(types$1.parenR)) {
+            var errorPos = this.start;
+            if (this.eat(types$1.comma) && this.eat(types$1.parenR)) {
+              this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+            } else {
+              this.unexpected(errorPos);
+            }
           }
         }
         return this.finishNode(node, "ImportExpression");
@@ -10244,9 +10918,12 @@ var require_acorn = __commonJS({
           this.raiseRecoverable(this.start, "Escape sequence in keyword new");
         }
         var node = this.startNode();
-        var meta = this.parseIdent(true);
-        if (this.options.ecmaVersion >= 6 && this.eat(types$1.dot)) {
-          node.meta = meta;
+        this.next();
+        if (this.options.ecmaVersion >= 6 && this.type === types$1.dot) {
+          var meta = this.startNodeAt(node.start, node.loc && node.loc.start);
+          meta.name = "new";
+          node.meta = this.finishNode(meta, "Identifier");
+          this.next();
           var containsEsc = this.containsEsc;
           node.property = this.parseIdent(true);
           if (node.property.name !== "target") {
@@ -10277,7 +10954,7 @@ var require_acorn = __commonJS({
             this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
           }
           elem.value = {
-            raw: this.value,
+            raw: this.value.replace(/\r\n?/g, "\n"),
             cooked: null
           };
         } else {
@@ -10377,9 +11054,10 @@ var require_acorn = __commonJS({
         return this.finishNode(prop, "Property");
       };
       pp$5.parseGetterSetter = function(prop) {
-        prop.kind = prop.key.name;
+        var kind = prop.key.name;
         this.parsePropertyName(prop);
         prop.value = this.parseMethod(false);
+        prop.kind = kind;
         var paramCount = prop.kind === "get" ? 0 : 1;
         if (prop.value.params.length !== paramCount) {
           var start = prop.value.start;
@@ -10405,9 +11083,9 @@ var require_acorn = __commonJS({
           if (isPattern) {
             this.unexpected();
           }
-          prop.kind = "init";
           prop.method = true;
           prop.value = this.parseMethod(isGenerator, isAsync);
+          prop.kind = "init";
         } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types$1.comma && this.type !== types$1.braceR && this.type !== types$1.eq)) {
           if (isGenerator || isAsync) {
             this.unexpected();
@@ -10421,7 +11099,6 @@ var require_acorn = __commonJS({
           if (prop.key.name === "await" && !this.awaitIdentPos) {
             this.awaitIdentPos = startPos;
           }
-          prop.kind = "init";
           if (isPattern) {
             prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
           } else if (this.type === types$1.eq && refDestructuringErrors) {
@@ -10432,6 +11109,7 @@ var require_acorn = __commonJS({
           } else {
             prop.value = this.copyNode(prop.key);
           }
+          prop.kind = "init";
           prop.shorthand = true;
         } else {
           this.unexpected();
@@ -10581,7 +11259,7 @@ var require_acorn = __commonJS({
         if (this.inAsync && name === "await") {
           this.raiseRecoverable(start, "Cannot use 'await' as identifier inside an async function");
         }
-        if (this.currentThisScope().inClassFieldInit && name === "arguments") {
+        if (!(this.currentThisScope().flags & SCOPE_VAR) && name === "arguments") {
           this.raiseRecoverable(start, "Cannot use 'arguments' in class field initializer");
         }
         if (this.inClassStaticBlock && (name === "arguments" || name === "await")) {
@@ -10622,6 +11300,7 @@ var require_acorn = __commonJS({
           if ((node.name === "class" || node.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
             this.context.pop();
           }
+          this.type = types$1.name;
         } else {
           this.unexpected();
         }
@@ -10673,6 +11352,9 @@ var require_acorn = __commonJS({
       pp$4.raise = function(pos, message) {
         var loc = getLineInfo(this.input, pos);
         message += " (" + loc.line + ":" + loc.column + ")";
+        if (this.sourceFile) {
+          message += " in " + this.sourceFile;
+        }
         var err = new SyntaxError(message);
         err.pos = pos;
         err.loc = loc;
@@ -10691,7 +11373,6 @@ var require_acorn = __commonJS({
         this.var = [];
         this.lexical = [];
         this.functions = [];
-        this.inClassFieldInit = false;
       };
       pp$3.enterScope = function(flags) {
         this.scopeStack.push(new Scope(flags));
@@ -10753,7 +11434,7 @@ var require_acorn = __commonJS({
       pp$3.currentVarScope = function() {
         for (var i2 = this.scopeStack.length - 1; ; i2--) {
           var scope = this.scopeStack[i2];
-          if (scope.flags & SCOPE_VAR) {
+          if (scope.flags & (SCOPE_VAR | SCOPE_CLASS_FIELD_INIT | SCOPE_CLASS_STATIC_BLOCK)) {
             return scope;
           }
         }
@@ -10761,7 +11442,7 @@ var require_acorn = __commonJS({
       pp$3.currentThisScope = function() {
         for (var i2 = this.scopeStack.length - 1; ; i2--) {
           var scope = this.scopeStack[i2];
-          if (scope.flags & SCOPE_VAR && !(scope.flags & SCOPE_ARROW)) {
+          if (scope.flags & (SCOPE_VAR | SCOPE_CLASS_FIELD_INIT | SCOPE_CLASS_STATIC_BLOCK) && !(scope.flags & SCOPE_ARROW)) {
             return scope;
           }
         }
@@ -10811,6 +11492,7 @@ var require_acorn = __commonJS({
         }
         return newNode;
       };
+      var scriptValuesAddedInUnicode = "Gara Garay Gukh Gurung_Khema Hrkt Katakana_Or_Hiragana Kawi Kirat_Rai Krai Nag_Mundari Nagm Ol_Onal Onao Sunu Sunuwar Todhri Todr Tulu_Tigalari Tutg Unknown Zzzz";
       var ecma9BinaryProperties = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
       var ecma10BinaryProperties = ecma9BinaryProperties + " Extended_Pictographic";
       var ecma11BinaryProperties = ecma10BinaryProperties;
@@ -10840,7 +11522,7 @@ var require_acorn = __commonJS({
       var ecma11ScriptValues = ecma10ScriptValues + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
       var ecma12ScriptValues = ecma11ScriptValues + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi";
       var ecma13ScriptValues = ecma12ScriptValues + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith";
-      var ecma14ScriptValues = ecma13ScriptValues + " Hrkt Katakana_Or_Hiragana Kawi Nag_Mundari Nagm Unknown Zzzz";
+      var ecma14ScriptValues = ecma13ScriptValues + " " + scriptValuesAddedInUnicode;
       var unicodeScriptValues = {
         9: ecma9ScriptValues,
         10: ecma10ScriptValues,
@@ -10869,6 +11551,23 @@ var require_acorn = __commonJS({
         buildUnicodeData(ecmaVersion);
       }
       var pp$1 = Parser.prototype;
+      var BranchID = function BranchID2(parent, base) {
+        this.parent = parent;
+        this.base = base || this;
+      };
+      BranchID.prototype.separatedFrom = function separatedFrom(alt) {
+        for (var self2 = this; self2; self2 = self2.parent) {
+          for (var other = alt; other; other = other.parent) {
+            if (self2.base === other.base && self2 !== other) {
+              return true;
+            }
+          }
+        }
+        return false;
+      };
+      BranchID.prototype.sibling = function sibling() {
+        return new BranchID(this.parent, this.base);
+      };
       var RegExpValidationState = function RegExpValidationState2(parser) {
         this.parser = parser;
         this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "") + (parser.options.ecmaVersion >= 13 ? "d" : "") + (parser.options.ecmaVersion >= 15 ? "v" : "");
@@ -10885,8 +11584,9 @@ var require_acorn = __commonJS({
         this.lastAssertionIsQuantifiable = false;
         this.numCapturingParens = 0;
         this.maxBackReference = 0;
-        this.groupNames = [];
+        this.groupNames = /* @__PURE__ */ Object.create(null);
         this.backReferenceNames = [];
+        this.branchID = null;
       };
       RegExpValidationState.prototype.reset = function reset(start, pattern, flags) {
         var unicodeSets = flags.indexOf("v") !== -1;
@@ -10999,9 +11699,15 @@ var require_acorn = __commonJS({
           this.raise(state.start, "Invalid regular expression flag");
         }
       };
+      function hasProp(obj) {
+        for (var _ in obj) {
+          return true;
+        }
+        return false;
+      }
       pp$1.validateRegExpPattern = function(state) {
         this.regexp_pattern(state);
-        if (!state.switchN && this.options.ecmaVersion >= 9 && state.groupNames.length > 0) {
+        if (!state.switchN && this.options.ecmaVersion >= 9 && hasProp(state.groupNames)) {
           state.switchN = true;
           this.regexp_pattern(state);
         }
@@ -11013,8 +11719,9 @@ var require_acorn = __commonJS({
         state.lastAssertionIsQuantifiable = false;
         state.numCapturingParens = 0;
         state.maxBackReference = 0;
-        state.groupNames.length = 0;
+        state.groupNames = /* @__PURE__ */ Object.create(null);
         state.backReferenceNames.length = 0;
+        state.branchID = null;
         this.regexp_disjunction(state);
         if (state.pos !== state.source.length) {
           if (state.eat(
@@ -11038,18 +11745,28 @@ var require_acorn = __commonJS({
         }
         for (var i2 = 0, list2 = state.backReferenceNames; i2 < list2.length; i2 += 1) {
           var name = list2[i2];
-          if (state.groupNames.indexOf(name) === -1) {
+          if (!state.groupNames[name]) {
             state.raise("Invalid named capture referenced");
           }
         }
       };
       pp$1.regexp_disjunction = function(state) {
+        var trackDisjunction = this.options.ecmaVersion >= 16;
+        if (trackDisjunction) {
+          state.branchID = new BranchID(state.branchID, null);
+        }
         this.regexp_alternative(state);
         while (state.eat(
           124
           /* | */
         )) {
+          if (trackDisjunction) {
+            state.branchID = state.branchID.sibling();
+          }
           this.regexp_alternative(state);
+        }
+        if (trackDisjunction) {
+          state.branchID = state.branchID.parent;
         }
         if (this.regexp_eatQuantifier(state, true)) {
           state.raise("Nothing to repeat");
@@ -11226,18 +11943,47 @@ var require_acorn = __commonJS({
           if (state.eat(
             63
             /* ? */
-          ) && state.eat(
-            58
-            /* : */
           )) {
-            this.regexp_disjunction(state);
-            if (state.eat(
-              41
-              /* ) */
-            )) {
-              return true;
+            if (this.options.ecmaVersion >= 16) {
+              var addModifiers = this.regexp_eatModifiers(state);
+              var hasHyphen = state.eat(
+                45
+                /* - */
+              );
+              if (addModifiers || hasHyphen) {
+                for (var i2 = 0; i2 < addModifiers.length; i2++) {
+                  var modifier = addModifiers.charAt(i2);
+                  if (addModifiers.indexOf(modifier, i2 + 1) > -1) {
+                    state.raise("Duplicate regular expression modifiers");
+                  }
+                }
+                if (hasHyphen) {
+                  var removeModifiers = this.regexp_eatModifiers(state);
+                  if (!addModifiers && !removeModifiers && state.current() === 58) {
+                    state.raise("Invalid regular expression modifiers");
+                  }
+                  for (var i$1 = 0; i$1 < removeModifiers.length; i$1++) {
+                    var modifier$1 = removeModifiers.charAt(i$1);
+                    if (removeModifiers.indexOf(modifier$1, i$1 + 1) > -1 || addModifiers.indexOf(modifier$1) > -1) {
+                      state.raise("Duplicate regular expression modifiers");
+                    }
+                  }
+                }
+              }
             }
-            state.raise("Unterminated group");
+            if (state.eat(
+              58
+              /* : */
+            )) {
+              this.regexp_disjunction(state);
+              if (state.eat(
+                41
+                /* ) */
+              )) {
+                return true;
+              }
+              state.raise("Unterminated group");
+            }
           }
           state.pos = start;
         }
@@ -11265,6 +12011,18 @@ var require_acorn = __commonJS({
         }
         return false;
       };
+      pp$1.regexp_eatModifiers = function(state) {
+        var modifiers = "";
+        var ch = 0;
+        while ((ch = state.current()) !== -1 && isRegularExpressionModifier(ch)) {
+          modifiers += codePointToString(ch);
+          state.advance();
+        }
+        return modifiers;
+      };
+      function isRegularExpressionModifier(ch) {
+        return ch === 105 || ch === 109 || ch === 115;
+      }
       pp$1.regexp_eatExtendedAtom = function(state) {
         return state.eat(
           46
@@ -11310,14 +12068,28 @@ var require_acorn = __commonJS({
           63
           /* ? */
         )) {
-          if (this.regexp_eatGroupName(state)) {
-            if (state.groupNames.indexOf(state.lastStringValue) !== -1) {
+          if (!this.regexp_eatGroupName(state)) {
+            state.raise("Invalid group");
+          }
+          var trackDisjunction = this.options.ecmaVersion >= 16;
+          var known = state.groupNames[state.lastStringValue];
+          if (known) {
+            if (trackDisjunction) {
+              for (var i2 = 0, list2 = known; i2 < list2.length; i2 += 1) {
+                var altID = list2[i2];
+                if (!altID.separatedFrom(state.branchID)) {
+                  state.raise("Duplicate capture group name");
+                }
+              }
+            } else {
               state.raise("Duplicate capture group name");
             }
-            state.groupNames.push(state.lastStringValue);
-            return;
           }
-          state.raise("Invalid group");
+          if (trackDisjunction) {
+            (known || (state.groupNames[state.lastStringValue] = [])).push(state.branchID);
+          } else {
+            state.groupNames[state.lastStringValue] = true;
+          }
         }
       };
       pp$1.regexp_eatGroupName = function(state) {
@@ -12773,6 +13545,16 @@ var require_acorn = __commonJS({
               }
             case "`":
               return this.finishToken(types$1.invalidTemplate, this.input.slice(this.start, this.pos));
+            case "\r":
+              if (this.input[this.pos + 1] === "\n") {
+                ++this.pos;
+              }
+            case "\n":
+            case "\u2028":
+            case "\u2029":
+              ++this.curLine;
+              this.lineStart = this.pos + 1;
+              break;
           }
         }
         this.raise(this.start, "Unterminated template");
@@ -12841,6 +13623,10 @@ var require_acorn = __commonJS({
               return String.fromCharCode(octal);
             }
             if (isNewLine(ch)) {
+              if (this.options.locations) {
+                this.lineStart = this.pos;
+                ++this.curLine;
+              }
               return "";
             }
             return String.fromCharCode(ch);
@@ -12891,7 +13677,7 @@ var require_acorn = __commonJS({
         }
         return this.finishToken(type, word);
       };
-      var version = "8.10.0";
+      var version = "8.14.1";
       Parser.acorn = {
         Parser,
         version,
@@ -14934,7 +15720,7 @@ var require_package2 = __commonJS({
   "../../node_modules/eslint/package.json"(exports, module) {
     module.exports = {
       name: "eslint",
-      version: "8.45.0",
+      version: "8.57.1",
       author: "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
       description: "An AST-based pattern checker for JavaScript.",
       bin: {
@@ -14953,11 +15739,13 @@ var require_package2 = __commonJS({
         "build:readme": "node tools/update-readme.js",
         lint: "node Makefile.js lint",
         "lint:docs:js": "node Makefile.js lintDocsJS",
+        "lint:docs:rule-examples": "node Makefile.js checkRuleExamples",
         "lint:fix": "node Makefile.js lint -- fix",
         "lint:fix:docs:js": "node Makefile.js lintDocsJS -- fix",
         "release:generate:alpha": "node Makefile.js generatePrerelease -- alpha",
         "release:generate:beta": "node Makefile.js generatePrerelease -- beta",
-        "release:generate:latest": "node Makefile.js generateRelease",
+        "release:generate:latest": "node Makefile.js generateRelease -- latest",
+        "release:generate:maintenance": "node Makefile.js generateRelease -- maintenance",
         "release:generate:rc": "node Makefile.js generatePrerelease -- rc",
         "release:publish": "node Makefile.js publishRelease",
         test: "node Makefile.js test",
@@ -14976,6 +15764,7 @@ var require_package2 = __commonJS({
           "git add packages/js/src/configs/eslint-all.js"
         ],
         "docs/src/rules/*.md": [
+          "node tools/check-rule-examples.js",
           "node tools/fetch-docs-links.js",
           "git add docs/src/_data/further_reading_links.json"
         ],
@@ -14995,21 +15784,22 @@ var require_package2 = __commonJS({
       bugs: "https://github.com/eslint/eslint/issues/",
       dependencies: {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        ajv: "^6.10.0",
+        "@ungap/structured-clone": "^1.2.0",
+        ajv: "^6.12.4",
         chalk: "^4.0.0",
         "cross-spawn": "^7.0.2",
         debug: "^4.3.2",
         doctrine: "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        espree: "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        espree: "^9.6.1",
         esquery: "^1.4.2",
         esutils: "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -15035,6 +15825,12 @@ var require_package2 = __commonJS({
       devDependencies: {
         "@babel/core": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@wdio/browser-runner": "^8.14.6",
+        "@wdio/cli": "^8.14.6",
+        "@wdio/concise-reporter": "^8.14.0",
+        "@wdio/globals": "^8.14.6",
+        "@wdio/mocha-framework": "^8.14.0",
         "babel-loader": "^8.0.5",
         c8: "^7.12.0",
         chai: "^4.0.1",
@@ -15045,12 +15841,12 @@ var require_package2 = __commonJS({
         eslint: "file:.",
         "eslint-config-eslint": "file:packages/eslint-config-eslint",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-eslint-plugin": "^5.1.0",
+        "eslint-plugin-eslint-plugin": "^5.2.1",
         "eslint-plugin-internal-rules": "file:tools/internal-rules",
         "eslint-plugin-jsdoc": "^46.2.5",
-        "eslint-plugin-n": "^16.0.0",
-        "eslint-plugin-unicorn": "^42.0.0",
-        "eslint-release": "^3.2.0",
+        "eslint-plugin-n": "^16.6.0",
+        "eslint-plugin-unicorn": "^49.0.0",
+        "eslint-release": "^3.3.0",
         eslump: "^3.0.0",
         esprima: "^4.0.1",
         "fast-glob": "^3.2.11",
@@ -15058,15 +15854,12 @@ var require_package2 = __commonJS({
         glob: "^7.1.6",
         got: "^11.8.3",
         "gray-matter": "^4.0.3",
-        karma: "^6.1.1",
-        "karma-chrome-launcher": "^3.1.0",
-        "karma-mocha": "^2.0.1",
-        "karma-mocha-reporter": "^2.2.5",
-        "karma-webpack": "^5.0.0",
         "lint-staged": "^11.0.0",
         "load-perf": "^0.2.0",
-        markdownlint: "^0.25.1",
-        "markdownlint-cli": "^0.31.1",
+        "markdown-it": "^12.2.0",
+        "markdown-it-container": "^3.0.0",
+        markdownlint: "^0.32.0",
+        "markdownlint-cli": "^0.37.0",
         marked: "^4.0.8",
         memfs: "^3.0.1",
         metascraper: "^5.25.7",
@@ -15082,12 +15875,14 @@ var require_package2 = __commonJS({
         pirates: "^4.0.5",
         progress: "^2.0.3",
         proxyquire: "^2.0.1",
-        puppeteer: "^13.7.0",
-        recast: "^0.20.4",
-        "regenerator-runtime": "^0.13.2",
+        recast: "^0.23.0",
+        "regenerator-runtime": "^0.14.0",
+        "rollup-plugin-node-polyfills": "^0.2.1",
         semver: "^7.5.3",
         shelljs: "^0.8.2",
         sinon: "^11.0.0",
+        "vite-plugin-commonjs": "0.10.1",
+        webdriverio: "^8.14.6",
         webpack: "^5.23.0",
         "webpack-cli": "^4.5.0",
         yorkie: "^2.0.0"
@@ -21510,9 +22305,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../node_modules/globals/globals.json
+// ../../node_modules/@eslint/eslintrc/node_modules/globals/globals.json
 var require_globals = __commonJS({
-  "../../node_modules/globals/globals.json"(exports, module) {
+  "../../node_modules/@eslint/eslintrc/node_modules/globals/globals.json"(exports, module) {
     module.exports = {
       builtin: {
         AggregateError: false,
@@ -21940,6 +22735,7 @@ var require_globals = __commonJS({
         CloseEvent: false,
         Comment: false,
         CompositionEvent: false,
+        CompressionStream: false,
         confirm: false,
         console: false,
         ConstantSourceNode: false,
@@ -21982,6 +22778,7 @@ var require_globals = __commonJS({
         DataTransfer: false,
         DataTransferItem: false,
         DataTransferItemList: false,
+        DecompressionStream: false,
         defaultstatus: false,
         defaultStatus: false,
         DelayNode: false,
@@ -22172,6 +22969,7 @@ var require_globals = __commonJS({
         MediaStream: false,
         MediaStreamAudioDestinationNode: false,
         MediaStreamAudioSourceNode: false,
+        MediaStreamConstraints: false,
         MediaStreamEvent: false,
         MediaStreamTrack: false,
         MediaStreamTrackEvent: false,
@@ -22369,7 +23167,12 @@ var require_globals = __commonJS({
         queueMicrotask: false,
         RadioNodeList: false,
         Range: false,
+        ReadableByteStreamController: false,
         ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
         registerProcessor: false,
         RemotePlayback: false,
         removeEventListener: false,
@@ -22543,7 +23346,9 @@ var require_globals = __commonJS({
         TaskAttributionTiming: false,
         Text: false,
         TextDecoder: false,
+        TextDecoderStream: false,
         TextEncoder: false,
+        TextEncoderStream: false,
         TextEvent: false,
         TextMetrics: false,
         TextTrack: false,
@@ -22551,6 +23356,7 @@ var require_globals = __commonJS({
         TextTrackCueList: false,
         TextTrackList: false,
         TimeRanges: false,
+        ToggleEvent: false,
         toolbar: false,
         top: false,
         Touch: false,
@@ -22558,6 +23364,7 @@ var require_globals = __commonJS({
         TouchList: false,
         TrackEvent: false,
         TransformStream: false,
+        TransformStreamDefaultController: false,
         TransitionEvent: false,
         TreeWalker: false,
         UIEvent: false,
@@ -22592,6 +23399,8 @@ var require_globals = __commonJS({
         Window: false,
         Worker: false,
         WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false,
         XMLDocument: false,
         XMLHttpRequest: false,
         XMLHttpRequestEventTarget: false,
@@ -22600,6 +23409,30 @@ var require_globals = __commonJS({
         XPathEvaluator: false,
         XPathExpression: false,
         XPathResult: false,
+        XRAnchor: false,
+        XRBoundedReferenceSpace: false,
+        XRCPUDepthInformation: false,
+        XRDepthInformation: false,
+        XRFrame: false,
+        XRInputSource: false,
+        XRInputSourceArray: false,
+        XRInputSourceEvent: false,
+        XRInputSourcesChangeEvent: false,
+        XRPose: false,
+        XRReferenceSpace: false,
+        XRReferenceSpaceEvent: false,
+        XRRenderState: false,
+        XRRigidTransform: false,
+        XRSession: false,
+        XRSessionEvent: false,
+        XRSpace: false,
+        XRSystem: false,
+        XRView: false,
+        XRViewerPose: false,
+        XRViewport: false,
+        XRWebGLBinding: false,
+        XRWebGLDepthInformation: false,
+        XRWebGLLayer: false,
         XSLTProcessor: false
       },
       worker: {
@@ -22609,16 +23442,24 @@ var require_globals = __commonJS({
         Blob: false,
         BroadcastChannel: false,
         btoa: false,
+        ByteLengthQueuingStrategy: false,
         Cache: false,
         caches: false,
         clearInterval: false,
         clearTimeout: false,
         close: true,
+        CompressionStream: false,
         console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
         CustomEvent: false,
+        DecompressionStream: false,
         ErrorEvent: false,
         Event: false,
         fetch: false,
+        File: false,
         FileReaderSync: false,
         FormData: false,
         Headers: false,
@@ -22658,11 +23499,19 @@ var require_globals = __commonJS({
         PerformanceMark: false,
         PerformanceMeasure: false,
         PerformanceNavigation: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
         PerformanceResourceTiming: false,
         PerformanceTiming: false,
         postMessage: true,
         Promise: false,
         queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
         removeEventListener: false,
         reportError: false,
         Request: false,
@@ -22671,13 +23520,22 @@ var require_globals = __commonJS({
         ServiceWorkerRegistration: false,
         setInterval: false,
         setTimeout: false,
+        SubtleCrypto: false,
         TextDecoder: false,
+        TextDecoderStream: false,
         TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
         URL: false,
         URLSearchParams: false,
+        WebAssembly: false,
         WebSocket: false,
         Worker: false,
         WorkerGlobalScope: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false,
         XMLHttpRequest: false
       },
       node: {
@@ -22686,17 +23544,28 @@ var require_globals = __commonJS({
         AbortController: false,
         AbortSignal: false,
         atob: false,
+        Blob: false,
+        BroadcastChannel: false,
         btoa: false,
         Buffer: false,
+        ByteLengthQueuingStrategy: false,
         clearImmediate: false,
         clearInterval: false,
         clearTimeout: false,
+        CompressionStream: false,
         console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
         DOMException: false,
         Event: false,
         EventTarget: false,
         exports: true,
         fetch: false,
+        File: false,
         FormData: false,
         global: false,
         Headers: false,
@@ -22706,8 +23575,20 @@ var require_globals = __commonJS({
         MessagePort: false,
         module: false,
         performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
         process: false,
         queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
         Request: false,
         require: false,
         Response: false,
@@ -22715,25 +23596,45 @@ var require_globals = __commonJS({
         setInterval: false,
         setTimeout: false,
         structuredClone: false,
+        SubtleCrypto: false,
         TextDecoder: false,
+        TextDecoderStream: false,
         TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
         URL: false,
-        URLSearchParams: false
+        URLSearchParams: false,
+        WebAssembly: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false
       },
       nodeBuiltin: {
         AbortController: false,
         AbortSignal: false,
         atob: false,
+        Blob: false,
+        BroadcastChannel: false,
         btoa: false,
         Buffer: false,
+        ByteLengthQueuingStrategy: false,
         clearImmediate: false,
         clearInterval: false,
         clearTimeout: false,
+        CompressionStream: false,
         console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
         DOMException: false,
         Event: false,
         EventTarget: false,
         fetch: false,
+        File: false,
         FormData: false,
         global: false,
         Headers: false,
@@ -22742,18 +23643,39 @@ var require_globals = __commonJS({
         MessageEvent: false,
         MessagePort: false,
         performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
         process: false,
         queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
         Request: false,
         Response: false,
         setImmediate: false,
         setInterval: false,
         setTimeout: false,
         structuredClone: false,
+        SubtleCrypto: false,
         TextDecoder: false,
+        TextDecoderStream: false,
         TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
         URL: false,
-        URLSearchParams: false
+        URLSearchParams: false,
+        WebAssembly: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false
       },
       commonjs: {
         exports: true,
@@ -23103,6 +24025,7 @@ var require_globals = __commonJS({
         Blob: false,
         BroadcastChannel: false,
         btoa: false,
+        ByteLengthQueuingStrategy: false,
         Cache: false,
         caches: false,
         CacheStorage: false,
@@ -23112,14 +24035,21 @@ var require_globals = __commonJS({
         clients: false,
         Clients: false,
         close: true,
+        CompressionStream: false,
         console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
         CustomEvent: false,
+        DecompressionStream: false,
         ErrorEvent: false,
         Event: false,
         ExtendableEvent: false,
         ExtendableMessageEvent: false,
         fetch: false,
         FetchEvent: false,
+        File: false,
         FileReaderSync: false,
         FormData: false,
         Headers: false,
@@ -23167,11 +24097,19 @@ var require_globals = __commonJS({
         PerformanceMark: false,
         PerformanceMeasure: false,
         PerformanceNavigation: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
         PerformanceResourceTiming: false,
         PerformanceTiming: false,
         postMessage: true,
         Promise: false,
         queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
         registration: false,
         removeEventListener: false,
         Request: false,
@@ -23185,14 +24123,23 @@ var require_globals = __commonJS({
         setInterval: false,
         setTimeout: false,
         skipWaiting: false,
+        SubtleCrypto: false,
         TextDecoder: false,
+        TextDecoderStream: false,
         TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
         URL: false,
         URLSearchParams: false,
+        WebAssembly: false,
         WebSocket: false,
         WindowClient: false,
         Worker: false,
         WorkerGlobalScope: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false,
         XMLHttpRequest: false
       },
       atomtest: {
@@ -23236,14 +24183,25 @@ var require_globals = __commonJS({
         AbortController: false,
         AbortSignal: false,
         atob: false,
+        Blob: false,
+        BroadcastChannel: false,
         btoa: false,
+        ByteLengthQueuingStrategy: false,
         clearInterval: false,
         clearTimeout: false,
+        CompressionStream: false,
         console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
         DOMException: false,
         Event: false,
         EventTarget: false,
         fetch: false,
+        File: false,
         FormData: false,
         Headers: false,
         Intl: false,
@@ -23251,16 +24209,37 @@ var require_globals = __commonJS({
         MessageEvent: false,
         MessagePort: false,
         performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
         queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
         Request: false,
         Response: false,
         setInterval: false,
         setTimeout: false,
         structuredClone: false,
+        SubtleCrypto: false,
         TextDecoder: false,
+        TextDecoderStream: false,
         TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
         URL: false,
-        URLSearchParams: false
+        URLSearchParams: false,
+        WebAssembly: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false
       },
       webextensions: {
         browser: false,
@@ -23330,9 +24309,9 @@ var require_globals = __commonJS({
   }
 });
 
-// ../../node_modules/globals/index.js
+// ../../node_modules/@eslint/eslintrc/node_modules/globals/index.js
 var require_globals2 = __commonJS({
-  "../../node_modules/globals/index.js"(exports, module) {
+  "../../node_modules/@eslint/eslintrc/node_modules/globals/index.js"(exports, module) {
     "use strict";
     module.exports = require_globals();
   }
@@ -24379,49 +25358,63 @@ var require_common = __commonJS({
         createDebug.namespaces = namespaces;
         createDebug.names = [];
         createDebug.skips = [];
-        let i;
-        const split = (typeof namespaces === "string" ? namespaces : "").split(/[\s,]+/);
-        const len = split.length;
-        for (i = 0; i < len; i++) {
-          if (!split[i]) {
-            continue;
-          }
-          namespaces = split[i].replace(/\*/g, ".*?");
-          if (namespaces[0] === "-") {
-            createDebug.skips.push(new RegExp("^" + namespaces.slice(1) + "$"));
+        const split = (typeof namespaces === "string" ? namespaces : "").trim().replace(" ", ",").split(",").filter(Boolean);
+        for (const ns of split) {
+          if (ns[0] === "-") {
+            createDebug.skips.push(ns.slice(1));
           } else {
-            createDebug.names.push(new RegExp("^" + namespaces + "$"));
+            createDebug.names.push(ns);
           }
         }
       }
+      function matchesTemplate(search, template) {
+        let searchIndex = 0;
+        let templateIndex = 0;
+        let starIndex = -1;
+        let matchIndex = 0;
+        while (searchIndex < search.length) {
+          if (templateIndex < template.length && (template[templateIndex] === search[searchIndex] || template[templateIndex] === "*")) {
+            if (template[templateIndex] === "*") {
+              starIndex = templateIndex;
+              matchIndex = searchIndex;
+              templateIndex++;
+            } else {
+              searchIndex++;
+              templateIndex++;
+            }
+          } else if (starIndex !== -1) {
+            templateIndex = starIndex + 1;
+            matchIndex++;
+            searchIndex = matchIndex;
+          } else {
+            return false;
+          }
+        }
+        while (templateIndex < template.length && template[templateIndex] === "*") {
+          templateIndex++;
+        }
+        return templateIndex === template.length;
+      }
       function disable() {
         const namespaces = [
-          ...createDebug.names.map(toNamespace),
-          ...createDebug.skips.map(toNamespace).map((namespace) => "-" + namespace)
+          ...createDebug.names,
+          ...createDebug.skips.map((namespace) => "-" + namespace)
         ].join(",");
         createDebug.enable("");
         return namespaces;
       }
       function enabled(name) {
-        if (name[name.length - 1] === "*") {
-          return true;
-        }
-        let i;
-        let len;
-        for (i = 0, len = createDebug.skips.length; i < len; i++) {
-          if (createDebug.skips[i].test(name)) {
+        for (const skip of createDebug.skips) {
+          if (matchesTemplate(name, skip)) {
             return false;
           }
         }
-        for (i = 0, len = createDebug.names.length; i < len; i++) {
-          if (createDebug.names[i].test(name)) {
+        for (const ns of createDebug.names) {
+          if (matchesTemplate(name, ns)) {
             return true;
           }
         }
         return false;
-      }
-      function toNamespace(regexp) {
-        return regexp.toString().substring(2, regexp.toString().length - 2).replace(/\.\*\?$/, "*");
       }
       function coerce(val) {
         if (val instanceof Error) {
@@ -24541,10 +25534,11 @@ var require_browser = __commonJS({
       if (typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/(edge|trident)\/(\d+)/)) {
         return false;
       }
+      let m;
       return typeof document !== "undefined" && document.documentElement && document.documentElement.style && document.documentElement.style.WebkitAppearance || // Is firebug? http://stackoverflow.com/a/398120/376773
       typeof window !== "undefined" && window.console && (window.console.firebug || window.console.exception && window.console.table) || // Is firefox >= v31?
       // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
-      typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31 || // Double check webkit in userAgent just in case we are in a worker
+      typeof navigator !== "undefined" && navigator.userAgent && (m = navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/)) && parseInt(m[1], 10) >= 31 || // Double check webkit in userAgent just in case we are in a worker
       typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/);
     }
     function formatArgs(args) {
@@ -24794,11 +25788,8 @@ var require_eslint_utils = __commonJS({
       }
       return null;
     }
-    function negate0(token) {
-      return !this(token);
-    }
     function negate(f) {
-      return negate0.bind(f);
+      return (token) => !f(token);
     }
     function isPunctuatorTokenWithValue(token, value) {
       return token.type === "Punctuator" && token.value === value;
@@ -25964,6 +26955,15 @@ var require_eslint_utils = __commonJS({
             }
           }
         }
+      }
+      /**
+       * Iterate the property references for a given expression AST node.
+       * @param {object} node The expression AST node to iterate property references.
+       * @param {object} traceMap The trace map.
+       * @returns {IterableIterator<{node:Node,path:string[],type:symbol,info:any}>} The iterator to iterate property references.
+       */
+      *iteratePropertyReferences(node, traceMap) {
+        yield* this._iteratePropertyReferences(node, [], traceMap);
       }
       /**
        * Iterate the references for a given variable.
@@ -27221,2865 +28221,131 @@ var require_token_store = __commonJS({
   }
 });
 
-// ../../node_modules/eslint/lib/source-code/source-code.js
-var require_source_code = __commonJS({
-  "../../node_modules/eslint/lib/source-code/source-code.js"(exports, module) {
+// ../../node_modules/eslint/conf/globals.js
+var require_globals3 = __commonJS({
+  "../../node_modules/eslint/conf/globals.js"(exports, module) {
     "use strict";
-    var { isCommentToken } = require_eslint_utils();
-    var TokenStore = require_token_store();
-    var astUtils = require_ast_utils();
-    var Traverser = require_traverser();
-    function validate(ast) {
-      if (!ast.tokens) {
-        throw new Error("AST is missing the tokens array.");
-      }
-      if (!ast.comments) {
-        throw new Error("AST is missing the comments array.");
-      }
-      if (!ast.loc) {
-        throw new Error("AST is missing location information.");
-      }
-      if (!ast.range) {
-        throw new Error("AST is missing range information");
-      }
-    }
-    function looksLikeExport(astNode) {
-      return astNode.type === "ExportDefaultDeclaration" || astNode.type === "ExportNamedDeclaration" || astNode.type === "ExportAllDeclaration" || astNode.type === "ExportSpecifier";
-    }
-    function sortedMerge(tokens, comments) {
-      const result = [];
-      let tokenIndex = 0;
-      let commentIndex = 0;
-      while (tokenIndex < tokens.length || commentIndex < comments.length) {
-        if (commentIndex >= comments.length || tokenIndex < tokens.length && tokens[tokenIndex].range[0] < comments[commentIndex].range[0]) {
-          result.push(tokens[tokenIndex++]);
-        } else {
-          result.push(comments[commentIndex++]);
-        }
-      }
-      return result;
-    }
-    function nodesOrTokensOverlap(first, second) {
-      return first.range[0] <= second.range[0] && first.range[1] >= second.range[0] || second.range[0] <= first.range[0] && second.range[1] >= first.range[0];
-    }
-    function isSpaceBetween(sourceCode, first, second, checkInsideOfJSXText) {
-      if (nodesOrTokensOverlap(first, second)) {
-        return false;
-      }
-      const [startingNodeOrToken, endingNodeOrToken] = first.range[1] <= second.range[0] ? [first, second] : [second, first];
-      const firstToken = sourceCode.getLastToken(startingNodeOrToken) || startingNodeOrToken;
-      const finalToken = sourceCode.getFirstToken(endingNodeOrToken) || endingNodeOrToken;
-      let currentToken = firstToken;
-      while (currentToken !== finalToken) {
-        const nextToken = sourceCode.getTokenAfter(currentToken, { includeComments: true });
-        if (currentToken.range[1] !== nextToken.range[0] || /*
-         * For backward compatibility, check spaces in JSXText.
-         * https://github.com/eslint/eslint/issues/12614
-         */
-        checkInsideOfJSXText && nextToken !== finalToken && nextToken.type === "JSXText" && /\s/u.test(nextToken.value)) {
-          return true;
-        }
-        currentToken = nextToken;
-      }
-      return false;
-    }
-    var caches = Symbol("caches");
-    var SourceCode = class extends TokenStore {
-      /**
-       * @param {string|Object} textOrConfig The source code text or config object.
-       * @param {string} textOrConfig.text The source code text.
-       * @param {ASTNode} textOrConfig.ast The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
-       * @param {Object|null} textOrConfig.parserServices The parser services.
-       * @param {ScopeManager|null} textOrConfig.scopeManager The scope of this source code.
-       * @param {Object|null} textOrConfig.visitorKeys The visitor keys to traverse AST.
-       * @param {ASTNode} [astIfNoConfig] The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
-       */
-      constructor(textOrConfig, astIfNoConfig) {
-        let text, ast, parserServices, scopeManager, visitorKeys;
-        if (typeof textOrConfig === "string") {
-          text = textOrConfig;
-          ast = astIfNoConfig;
-        } else if (typeof textOrConfig === "object" && textOrConfig !== null) {
-          text = textOrConfig.text;
-          ast = textOrConfig.ast;
-          parserServices = textOrConfig.parserServices;
-          scopeManager = textOrConfig.scopeManager;
-          visitorKeys = textOrConfig.visitorKeys;
-        }
-        validate(ast);
-        super(ast.tokens, ast.comments);
-        this[caches] = /* @__PURE__ */ new Map([
-          ["scopes", /* @__PURE__ */ new WeakMap()]
-        ]);
-        this.hasBOM = text.charCodeAt(0) === 65279;
-        this.text = this.hasBOM ? text.slice(1) : text;
-        this.ast = ast;
-        this.parserServices = parserServices || {};
-        this.scopeManager = scopeManager || null;
-        this.visitorKeys = visitorKeys || Traverser.DEFAULT_VISITOR_KEYS;
-        const shebangMatched = this.text.match(astUtils.shebangPattern);
-        const hasShebang = shebangMatched && ast.comments.length && ast.comments[0].value === shebangMatched[1];
-        if (hasShebang) {
-          ast.comments[0].type = "Shebang";
-        }
-        this.tokensAndComments = sortedMerge(ast.tokens, ast.comments);
-        this.lines = [];
-        this.lineStartIndices = [0];
-        const lineEndingPattern = astUtils.createGlobalLinebreakMatcher();
-        let match;
-        while (match = lineEndingPattern.exec(this.text)) {
-          this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1], match.index));
-          this.lineStartIndices.push(match.index + match[0].length);
-        }
-        this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1]));
-        this._commentCache = /* @__PURE__ */ new WeakMap();
-        Object.freeze(this);
-        Object.freeze(this.lines);
-      }
-      /**
-       * Split the source code into multiple lines based on the line delimiters.
-       * @param {string} text Source code as a string.
-       * @returns {string[]} Array of source code lines.
-       * @public
-       */
-      static splitLines(text) {
-        return text.split(astUtils.createGlobalLinebreakMatcher());
-      }
-      /**
-       * Gets the source code for the given node.
-       * @param {ASTNode} [node] The AST node to get the text for.
-       * @param {int} [beforeCount] The number of characters before the node to retrieve.
-       * @param {int} [afterCount] The number of characters after the node to retrieve.
-       * @returns {string} The text representing the AST node.
-       * @public
-       */
-      getText(node, beforeCount, afterCount) {
-        if (node) {
-          return this.text.slice(
-            Math.max(node.range[0] - (beforeCount || 0), 0),
-            node.range[1] + (afterCount || 0)
-          );
-        }
-        return this.text;
-      }
-      /**
-       * Gets the entire source text split into an array of lines.
-       * @returns {Array} The source text as an array of lines.
-       * @public
-       */
-      getLines() {
-        return this.lines;
-      }
-      /**
-       * Retrieves an array containing all comments in the source code.
-       * @returns {ASTNode[]} An array of comment nodes.
-       * @public
-       */
-      getAllComments() {
-        return this.ast.comments;
-      }
-      /**
-       * Gets all comments for the given node.
-       * @param {ASTNode} node The AST node to get the comments for.
-       * @returns {Object} An object containing a leading and trailing array
-       *      of comments indexed by their position.
-       * @public
-       * @deprecated replaced by getCommentsBefore(), getCommentsAfter(), and getCommentsInside().
-       */
-      getComments(node) {
-        if (this._commentCache.has(node)) {
-          return this._commentCache.get(node);
-        }
-        const comments = {
-          leading: [],
-          trailing: []
-        };
-        if (node.type === "Program") {
-          if (node.body.length === 0) {
-            comments.leading = node.comments;
-          }
-        } else {
-          if ((node.type === "BlockStatement" || node.type === "ClassBody") && node.body.length === 0 || node.type === "ObjectExpression" && node.properties.length === 0 || node.type === "ArrayExpression" && node.elements.length === 0 || node.type === "SwitchStatement" && node.cases.length === 0) {
-            comments.trailing = this.getTokens(node, {
-              includeComments: true,
-              filter: isCommentToken
-            });
-          }
-          let currentToken = this.getTokenBefore(node, { includeComments: true });
-          while (currentToken && isCommentToken(currentToken)) {
-            if (node.parent && node.parent.type !== "Program" && currentToken.start < node.parent.start) {
-              break;
-            }
-            comments.leading.push(currentToken);
-            currentToken = this.getTokenBefore(currentToken, { includeComments: true });
-          }
-          comments.leading.reverse();
-          currentToken = this.getTokenAfter(node, { includeComments: true });
-          while (currentToken && isCommentToken(currentToken)) {
-            if (node.parent && node.parent.type !== "Program" && currentToken.end > node.parent.end) {
-              break;
-            }
-            comments.trailing.push(currentToken);
-            currentToken = this.getTokenAfter(currentToken, { includeComments: true });
-          }
-        }
-        this._commentCache.set(node, comments);
-        return comments;
-      }
-      /**
-       * Retrieves the JSDoc comment for a given node.
-       * @param {ASTNode} node The AST node to get the comment for.
-       * @returns {Token|null} The Block comment token containing the JSDoc comment
-       *      for the given node or null if not found.
-       * @public
-       * @deprecated
-       */
-      getJSDocComment(node) {
-        const findJSDocComment = (astNode) => {
-          const tokenBefore = this.getTokenBefore(astNode, { includeComments: true });
-          if (tokenBefore && isCommentToken(tokenBefore) && tokenBefore.type === "Block" && tokenBefore.value.charAt(0) === "*" && astNode.loc.start.line - tokenBefore.loc.end.line <= 1) {
-            return tokenBefore;
-          }
-          return null;
-        };
-        let parent = node.parent;
-        switch (node.type) {
-          case "ClassDeclaration":
-          case "FunctionDeclaration":
-            return findJSDocComment(looksLikeExport(parent) ? parent : node);
-          case "ClassExpression":
-            return findJSDocComment(parent.parent);
-          case "ArrowFunctionExpression":
-          case "FunctionExpression":
-            if (parent.type !== "CallExpression" && parent.type !== "NewExpression") {
-              while (!this.getCommentsBefore(parent).length && !/Function/u.test(parent.type) && parent.type !== "MethodDefinition" && parent.type !== "Property") {
-                parent = parent.parent;
-                if (!parent) {
-                  break;
-                }
-              }
-              if (parent && parent.type !== "FunctionDeclaration" && parent.type !== "Program") {
-                return findJSDocComment(parent);
-              }
-            }
-            return findJSDocComment(node);
-          default:
-            return null;
-        }
-      }
-      /**
-       * Gets the deepest node containing a range index.
-       * @param {int} index Range index of the desired node.
-       * @returns {ASTNode} The node if found or null if not found.
-       * @public
-       */
-      getNodeByRangeIndex(index) {
-        let result = null;
-        Traverser.traverse(this.ast, {
-          visitorKeys: this.visitorKeys,
-          enter(node) {
-            if (node.range[0] <= index && index < node.range[1]) {
-              result = node;
-            } else {
-              this.skip();
-            }
-          },
-          leave(node) {
-            if (node === result) {
-              this.break();
-            }
-          }
-        });
-        return result;
-      }
-      /**
-       * Determines if two nodes or tokens have at least one whitespace character
-       * between them. Order does not matter. Returns false if the given nodes or
-       * tokens overlap.
-       * @param {ASTNode|Token} first The first node or token to check between.
-       * @param {ASTNode|Token} second The second node or token to check between.
-       * @returns {boolean} True if there is a whitespace character between
-       * any of the tokens found between the two given nodes or tokens.
-       * @public
-       */
-      isSpaceBetween(first, second) {
-        return isSpaceBetween(this, first, second, false);
-      }
-      /**
-       * Determines if two nodes or tokens have at least one whitespace character
-       * between them. Order does not matter. Returns false if the given nodes or
-       * tokens overlap.
-       * For backward compatibility, this method returns true if there are
-       * `JSXText` tokens that contain whitespaces between the two.
-       * @param {ASTNode|Token} first The first node or token to check between.
-       * @param {ASTNode|Token} second The second node or token to check between.
-       * @returns {boolean} True if there is a whitespace character between
-       * any of the tokens found between the two given nodes or tokens.
-       * @deprecated in favor of isSpaceBetween().
-       * @public
-       */
-      isSpaceBetweenTokens(first, second) {
-        return isSpaceBetween(this, first, second, true);
-      }
-      /**
-       * Converts a source text index into a (line, column) pair.
-       * @param {number} index The index of a character in a file
-       * @throws {TypeError} If non-numeric index or index out of range.
-       * @returns {Object} A {line, column} location object with a 0-indexed column
-       * @public
-       */
-      getLocFromIndex(index) {
-        if (typeof index !== "number") {
-          throw new TypeError("Expected `index` to be a number.");
-        }
-        if (index < 0 || index > this.text.length) {
-          throw new RangeError(`Index out of range (requested index ${index}, but source text has length ${this.text.length}).`);
-        }
-        if (index === this.text.length) {
-          return { line: this.lines.length, column: this.lines[this.lines.length - 1].length };
-        }
-        const lineNumber = index >= this.lineStartIndices[this.lineStartIndices.length - 1] ? this.lineStartIndices.length : this.lineStartIndices.findIndex((el) => index < el);
-        return { line: lineNumber, column: index - this.lineStartIndices[lineNumber - 1] };
-      }
-      /**
-       * Converts a (line, column) pair into a range index.
-       * @param {Object} loc A line/column location
-       * @param {number} loc.line The line number of the location (1-indexed)
-       * @param {number} loc.column The column number of the location (0-indexed)
-       * @throws {TypeError|RangeError} If `loc` is not an object with a numeric
-       *   `line` and `column`, if the `line` is less than or equal to zero or
-       *   the line or column is out of the expected range.
-       * @returns {number} The range index of the location in the file.
-       * @public
-       */
-      getIndexFromLoc(loc) {
-        if (typeof loc !== "object" || typeof loc.line !== "number" || typeof loc.column !== "number") {
-          throw new TypeError("Expected `loc` to be an object with numeric `line` and `column` properties.");
-        }
-        if (loc.line <= 0) {
-          throw new RangeError(`Line number out of range (line ${loc.line} requested). Line numbers should be 1-based.`);
-        }
-        if (loc.line > this.lineStartIndices.length) {
-          throw new RangeError(`Line number out of range (line ${loc.line} requested, but only ${this.lineStartIndices.length} lines present).`);
-        }
-        const lineStartIndex = this.lineStartIndices[loc.line - 1];
-        const lineEndIndex = loc.line === this.lineStartIndices.length ? this.text.length : this.lineStartIndices[loc.line];
-        const positionIndex = lineStartIndex + loc.column;
-        if (loc.line === this.lineStartIndices.length && positionIndex > lineEndIndex || loc.line < this.lineStartIndices.length && positionIndex >= lineEndIndex) {
-          throw new RangeError(`Column number out of range (column ${loc.column} requested, but the length of line ${loc.line} is ${lineEndIndex - lineStartIndex}).`);
-        }
-        return positionIndex;
-      }
-      /**
-       * Gets the scope for the given node
-       * @param {ASTNode} currentNode The node to get the scope of
-       * @returns {eslint-scope.Scope} The scope information for this node
-       * @throws {TypeError} If the `currentNode` argument is missing.
-       */
-      getScope(currentNode) {
-        if (!currentNode) {
-          throw new TypeError("Missing required argument: node.");
-        }
-        const cache = this[caches].get("scopes");
-        const cachedScope = cache.get(currentNode);
-        if (cachedScope) {
-          return cachedScope;
-        }
-        const inner = currentNode.type !== "Program";
-        for (let node = currentNode; node; node = node.parent) {
-          const scope = this.scopeManager.acquire(node, inner);
-          if (scope) {
-            if (scope.type === "function-expression-name") {
-              cache.set(currentNode, scope.childScopes[0]);
-              return scope.childScopes[0];
-            }
-            cache.set(currentNode, scope);
-            return scope;
-          }
-        }
-        cache.set(currentNode, this.scopeManager.scopes[0]);
-        return this.scopeManager.scopes[0];
-      }
-      /**
-       * Get the variables that `node` defines.
-       * This is a convenience method that passes through
-       * to the same method on the `scopeManager`.
-       * @param {ASTNode} node The node for which the variables are obtained.
-       * @returns {Array<Variable>} An array of variable nodes representing
-       *      the variables that `node` defines.
-       */
-      getDeclaredVariables(node) {
-        return this.scopeManager.getDeclaredVariables(node);
-      }
-      /* eslint-disable class-methods-use-this -- node is owned by SourceCode */
-      /**
-       * Gets all the ancestors of a given node
-       * @param {ASTNode} node The node
-       * @returns {Array<ASTNode>} All the ancestor nodes in the AST, not including the provided node, starting
-       * from the root node at index 0 and going inwards to the parent node.
-       * @throws {TypeError} When `node` is missing.
-       */
-      getAncestors(node) {
-        if (!node) {
-          throw new TypeError("Missing required argument: node.");
-        }
-        const ancestorsStartingAtParent = [];
-        for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
-          ancestorsStartingAtParent.push(ancestor);
-        }
-        return ancestorsStartingAtParent.reverse();
-      }
-      /* eslint-enable class-methods-use-this -- node is owned by SourceCode */
-      /**
-       * Marks a variable as used in the current scope
-       * @param {string} name The name of the variable to mark as used.
-       * @param {ASTNode} [refNode] The closest node to the variable reference.
-       * @returns {boolean} True if the variable was found and marked as used, false if not.
-       */
-      markVariableAsUsed(name, refNode = this.ast) {
-        const currentScope = this.getScope(refNode);
-        let initialScope = currentScope;
-        if (currentScope.type === "global" && currentScope.childScopes.length > 0 && // top-level scopes refer to a `Program` node
-        currentScope.childScopes[0].block === this.ast) {
-          initialScope = currentScope.childScopes[0];
-        }
-        for (let scope = initialScope; scope; scope = scope.upper) {
-          const variable = scope.variables.find((scopeVar) => scopeVar.name === name);
-          if (variable) {
-            variable.eslintUsed = true;
-            return true;
-          }
-        }
-        return false;
-      }
+    var commonjs = {
+      exports: true,
+      global: false,
+      module: false,
+      require: false
     };
-    module.exports = SourceCode;
-  }
-});
-
-// ../../node_modules/eslint/lib/source-code/index.js
-var require_source_code2 = __commonJS({
-  "../../node_modules/eslint/lib/source-code/index.js"(exports, module) {
-    "use strict";
+    var es3 = {
+      Array: false,
+      Boolean: false,
+      constructor: false,
+      Date: false,
+      decodeURI: false,
+      decodeURIComponent: false,
+      encodeURI: false,
+      encodeURIComponent: false,
+      Error: false,
+      escape: false,
+      eval: false,
+      EvalError: false,
+      Function: false,
+      hasOwnProperty: false,
+      Infinity: false,
+      isFinite: false,
+      isNaN: false,
+      isPrototypeOf: false,
+      Math: false,
+      NaN: false,
+      Number: false,
+      Object: false,
+      parseFloat: false,
+      parseInt: false,
+      propertyIsEnumerable: false,
+      RangeError: false,
+      ReferenceError: false,
+      RegExp: false,
+      String: false,
+      SyntaxError: false,
+      toLocaleString: false,
+      toString: false,
+      TypeError: false,
+      undefined: false,
+      unescape: false,
+      URIError: false,
+      valueOf: false
+    };
+    var es5 = {
+      ...es3,
+      JSON: false
+    };
+    var es2015 = {
+      ...es5,
+      ArrayBuffer: false,
+      DataView: false,
+      Float32Array: false,
+      Float64Array: false,
+      Int16Array: false,
+      Int32Array: false,
+      Int8Array: false,
+      Map: false,
+      Promise: false,
+      Proxy: false,
+      Reflect: false,
+      Set: false,
+      Symbol: false,
+      Uint16Array: false,
+      Uint32Array: false,
+      Uint8Array: false,
+      Uint8ClampedArray: false,
+      WeakMap: false,
+      WeakSet: false
+    };
+    var es2016 = {
+      ...es2015
+    };
+    var es2017 = {
+      ...es2016,
+      Atomics: false,
+      SharedArrayBuffer: false
+    };
+    var es2018 = {
+      ...es2017
+    };
+    var es2019 = {
+      ...es2018
+    };
+    var es2020 = {
+      ...es2019,
+      BigInt: false,
+      BigInt64Array: false,
+      BigUint64Array: false,
+      globalThis: false
+    };
+    var es2021 = {
+      ...es2020,
+      AggregateError: false,
+      FinalizationRegistry: false,
+      WeakRef: false
+    };
+    var es2022 = {
+      ...es2021
+    };
+    var es2023 = {
+      ...es2022
+    };
+    var es2024 = {
+      ...es2023
+    };
     module.exports = {
-      SourceCode: require_source_code()
-    };
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/debug-helpers.js
-var require_debug_helpers = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/debug-helpers.js"(exports, module) {
-    "use strict";
-    var debug = require_browser()("eslint:code-path");
-    function getId(segment) {
-      return segment.id + (segment.reachable ? "" : "!");
-    }
-    function nodeToString(node, label) {
-      const suffix = label ? `:${label}` : "";
-      switch (node.type) {
-        case "Identifier":
-          return `${node.type}${suffix} (${node.name})`;
-        case "Literal":
-          return `${node.type}${suffix} (${node.value})`;
-        default:
-          return `${node.type}${suffix}`;
-      }
-    }
-    module.exports = {
-      /**
-       * A flag that debug dumping is enabled or not.
-       * @type {boolean}
-       */
-      enabled: debug.enabled,
-      /**
-       * Dumps given objects.
-       * @param {...any} args objects to dump.
-       * @returns {void}
-       */
-      dump: debug,
-      /**
-       * Dumps the current analyzing state.
-       * @param {ASTNode} node A node to dump.
-       * @param {CodePathState} state A state to dump.
-       * @param {boolean} leaving A flag whether or not it's leaving
-       * @returns {void}
-       */
-      dumpState: !debug.enabled ? debug : (
-        /* c8 ignore next */
-        function(node, state, leaving) {
-          for (let i = 0; i < state.currentSegments.length; ++i) {
-            const segInternal = state.currentSegments[i].internal;
-            if (leaving) {
-              const last = segInternal.nodes.length - 1;
-              if (last >= 0 && segInternal.nodes[last] === nodeToString(node, "enter")) {
-                segInternal.nodes[last] = nodeToString(node, void 0);
-              } else {
-                segInternal.nodes.push(nodeToString(node, "exit"));
-              }
-            } else {
-              segInternal.nodes.push(nodeToString(node, "enter"));
-            }
-          }
-          debug([
-            `${state.currentSegments.map(getId).join(",")})`,
-            `${node.type}${leaving ? ":exit" : ""}`
-          ].join(" "));
-        }
-      ),
-      /**
-       * Dumps a DOT code of a given code path.
-       * The DOT code can be visualized with Graphvis.
-       * @param {CodePath} codePath A code path to dump.
-       * @returns {void}
-       * @see http://www.graphviz.org
-       * @see http://www.webgraphviz.com
-       */
-      dumpDot: !debug.enabled ? debug : (
-        /* c8 ignore next */
-        function(codePath) {
-          let text = '\ndigraph {\nnode[shape=box,style="rounded,filled",fillcolor=white];\ninitial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];\n';
-          if (codePath.returnedSegments.length > 0) {
-            text += 'final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];\n';
-          }
-          if (codePath.thrownSegments.length > 0) {
-            text += 'thrown[label="\u2718",shape=circle,width=0.3,height=0.3,fixedsize=true];\n';
-          }
-          const traceMap = /* @__PURE__ */ Object.create(null);
-          const arrows = this.makeDotArrows(codePath, traceMap);
-          for (const id in traceMap) {
-            const segment = traceMap[id];
-            text += `${id}[`;
-            if (segment.reachable) {
-              text += 'label="';
-            } else {
-              text += 'style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\\n';
-            }
-            if (segment.internal.nodes.length > 0) {
-              text += segment.internal.nodes.join("\\n");
-            } else {
-              text += "????";
-            }
-            text += '"];\n';
-          }
-          text += `${arrows}
-`;
-          text += "}";
-          debug("DOT", text);
-        }
-      ),
-      /**
-       * Makes a DOT code of a given code path.
-       * The DOT code can be visualized with Graphvis.
-       * @param {CodePath} codePath A code path to make DOT.
-       * @param {Object} traceMap Optional. A map to check whether or not segments had been done.
-       * @returns {string} A DOT code of the code path.
-       */
-      makeDotArrows(codePath, traceMap) {
-        const stack = [[codePath.initialSegment, 0]];
-        const done = traceMap || /* @__PURE__ */ Object.create(null);
-        let lastId = codePath.initialSegment.id;
-        let text = `initial->${codePath.initialSegment.id}`;
-        while (stack.length > 0) {
-          const item = stack.pop();
-          const segment = item[0];
-          const index = item[1];
-          if (done[segment.id] && index === 0) {
-            continue;
-          }
-          done[segment.id] = segment;
-          const nextSegment = segment.allNextSegments[index];
-          if (!nextSegment) {
-            continue;
-          }
-          if (lastId === segment.id) {
-            text += `->${nextSegment.id}`;
-          } else {
-            text += `;
-${segment.id}->${nextSegment.id}`;
-          }
-          lastId = nextSegment.id;
-          stack.unshift([segment, 1 + index]);
-          stack.push([nextSegment, 0]);
-        }
-        codePath.returnedSegments.forEach((finalSegment) => {
-          if (lastId === finalSegment.id) {
-            text += "->final";
-          } else {
-            text += `;
-${finalSegment.id}->final`;
-          }
-          lastId = null;
-        });
-        codePath.thrownSegments.forEach((finalSegment) => {
-          if (lastId === finalSegment.id) {
-            text += "->thrown";
-          } else {
-            text += `;
-${finalSegment.id}->thrown`;
-          }
-          lastId = null;
-        });
-        return `${text};`;
-      }
-    };
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path-segment.js
-var require_code_path_segment = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path-segment.js"(exports, module) {
-    "use strict";
-    var debug = require_debug_helpers();
-    function isReachable(segment) {
-      return segment.reachable;
-    }
-    var CodePathSegment = class _CodePathSegment {
-      /**
-       * @param {string} id An identifier.
-       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
-       *   This array includes unreachable segments.
-       * @param {boolean} reachable A flag which shows this is reachable.
-       */
-      constructor(id, allPrevSegments, reachable) {
-        this.id = id;
-        this.nextSegments = [];
-        this.prevSegments = allPrevSegments.filter(isReachable);
-        this.allNextSegments = [];
-        this.allPrevSegments = allPrevSegments;
-        this.reachable = reachable;
-        Object.defineProperty(this, "internal", {
-          value: {
-            used: false,
-            loopedPrevSegments: []
-          }
-        });
-        if (debug.enabled) {
-          this.internal.nodes = [];
-        }
-      }
-      /**
-       * Checks a given previous segment is coming from the end of a loop.
-       * @param {CodePathSegment} segment A previous segment to check.
-       * @returns {boolean} `true` if the segment is coming from the end of a loop.
-       */
-      isLoopedPrevSegment(segment) {
-        return this.internal.loopedPrevSegments.includes(segment);
-      }
-      /**
-       * Creates the root segment.
-       * @param {string} id An identifier.
-       * @returns {CodePathSegment} The created segment.
-       */
-      static newRoot(id) {
-        return new _CodePathSegment(id, [], true);
-      }
-      /**
-       * Creates a segment that follows given segments.
-       * @param {string} id An identifier.
-       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
-       * @returns {CodePathSegment} The created segment.
-       */
-      static newNext(id, allPrevSegments) {
-        return new _CodePathSegment(
-          id,
-          _CodePathSegment.flattenUnusedSegments(allPrevSegments),
-          allPrevSegments.some(isReachable)
-        );
-      }
-      /**
-       * Creates an unreachable segment that follows given segments.
-       * @param {string} id An identifier.
-       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
-       * @returns {CodePathSegment} The created segment.
-       */
-      static newUnreachable(id, allPrevSegments) {
-        const segment = new _CodePathSegment(id, _CodePathSegment.flattenUnusedSegments(allPrevSegments), false);
-        _CodePathSegment.markUsed(segment);
-        return segment;
-      }
-      /**
-       * Creates a segment that follows given segments.
-       * This factory method does not connect with `allPrevSegments`.
-       * But this inherits `reachable` flag.
-       * @param {string} id An identifier.
-       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
-       * @returns {CodePathSegment} The created segment.
-       */
-      static newDisconnected(id, allPrevSegments) {
-        return new _CodePathSegment(id, [], allPrevSegments.some(isReachable));
-      }
-      /**
-       * Makes a given segment being used.
-       *
-       * And this function registers the segment into the previous segments as a next.
-       * @param {CodePathSegment} segment A segment to mark.
-       * @returns {void}
-       */
-      static markUsed(segment) {
-        if (segment.internal.used) {
-          return;
-        }
-        segment.internal.used = true;
-        let i;
-        if (segment.reachable) {
-          for (i = 0; i < segment.allPrevSegments.length; ++i) {
-            const prevSegment = segment.allPrevSegments[i];
-            prevSegment.allNextSegments.push(segment);
-            prevSegment.nextSegments.push(segment);
-          }
-        } else {
-          for (i = 0; i < segment.allPrevSegments.length; ++i) {
-            segment.allPrevSegments[i].allNextSegments.push(segment);
-          }
-        }
-      }
-      /**
-       * Marks a previous segment as looped.
-       * @param {CodePathSegment} segment A segment.
-       * @param {CodePathSegment} prevSegment A previous segment to mark.
-       * @returns {void}
-       */
-      static markPrevSegmentAsLooped(segment, prevSegment) {
-        segment.internal.loopedPrevSegments.push(prevSegment);
-      }
-      /**
-       * Replaces unused segments with the previous segments of each unused segment.
-       * @param {CodePathSegment[]} segments An array of segments to replace.
-       * @returns {CodePathSegment[]} The replaced array.
-       */
-      static flattenUnusedSegments(segments) {
-        const done = /* @__PURE__ */ Object.create(null);
-        const retv = [];
-        for (let i = 0; i < segments.length; ++i) {
-          const segment = segments[i];
-          if (done[segment.id]) {
-            continue;
-          }
-          if (!segment.internal.used) {
-            for (let j = 0; j < segment.allPrevSegments.length; ++j) {
-              const prevSegment = segment.allPrevSegments[j];
-              if (!done[prevSegment.id]) {
-                done[prevSegment.id] = true;
-                retv.push(prevSegment);
-              }
-            }
-          } else {
-            done[segment.id] = true;
-            retv.push(segment);
-          }
-        }
-        return retv;
-      }
-    };
-    module.exports = CodePathSegment;
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/fork-context.js
-var require_fork_context = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/fork-context.js"(exports, module) {
-    "use strict";
-    var assert = require_assert();
-    var CodePathSegment = require_code_path_segment();
-    function isReachable(segment) {
-      return segment.reachable;
-    }
-    function makeSegments(context, begin, end, create) {
-      const list = context.segmentsList;
-      const normalizedBegin = begin >= 0 ? begin : list.length + begin;
-      const normalizedEnd = end >= 0 ? end : list.length + end;
-      const segments = [];
-      for (let i = 0; i < context.count; ++i) {
-        const allPrevSegments = [];
-        for (let j = normalizedBegin; j <= normalizedEnd; ++j) {
-          allPrevSegments.push(list[j][i]);
-        }
-        segments.push(create(context.idGenerator.next(), allPrevSegments));
-      }
-      return segments;
-    }
-    function mergeExtraSegments(context, segments) {
-      let currentSegments = segments;
-      while (currentSegments.length > context.count) {
-        const merged = [];
-        for (let i = 0, length = currentSegments.length / 2 | 0; i < length; ++i) {
-          merged.push(CodePathSegment.newNext(
-            context.idGenerator.next(),
-            [currentSegments[i], currentSegments[i + length]]
-          ));
-        }
-        currentSegments = merged;
-      }
-      return currentSegments;
-    }
-    var ForkContext = class _ForkContext {
-      /**
-       * @param {IdGenerator} idGenerator An identifier generator for segments.
-       * @param {ForkContext|null} upper An upper fork context.
-       * @param {number} count A number of parallel segments.
-       */
-      constructor(idGenerator, upper, count) {
-        this.idGenerator = idGenerator;
-        this.upper = upper;
-        this.count = count;
-        this.segmentsList = [];
-      }
-      /**
-       * The head segments.
-       * @type {CodePathSegment[]}
-       */
-      get head() {
-        const list = this.segmentsList;
-        return list.length === 0 ? [] : list[list.length - 1];
-      }
-      /**
-       * A flag which shows empty.
-       * @type {boolean}
-       */
-      get empty() {
-        return this.segmentsList.length === 0;
-      }
-      /**
-       * A flag which shows reachable.
-       * @type {boolean}
-       */
-      get reachable() {
-        const segments = this.head;
-        return segments.length > 0 && segments.some(isReachable);
-      }
-      /**
-       * Creates new segments from this context.
-       * @param {number} begin The first index of previous segments.
-       * @param {number} end The last index of previous segments.
-       * @returns {CodePathSegment[]} New segments.
-       */
-      makeNext(begin, end) {
-        return makeSegments(this, begin, end, CodePathSegment.newNext);
-      }
-      /**
-       * Creates new segments from this context.
-       * The new segments is always unreachable.
-       * @param {number} begin The first index of previous segments.
-       * @param {number} end The last index of previous segments.
-       * @returns {CodePathSegment[]} New segments.
-       */
-      makeUnreachable(begin, end) {
-        return makeSegments(this, begin, end, CodePathSegment.newUnreachable);
-      }
-      /**
-       * Creates new segments from this context.
-       * The new segments don't have connections for previous segments.
-       * But these inherit the reachable flag from this context.
-       * @param {number} begin The first index of previous segments.
-       * @param {number} end The last index of previous segments.
-       * @returns {CodePathSegment[]} New segments.
-       */
-      makeDisconnected(begin, end) {
-        return makeSegments(this, begin, end, CodePathSegment.newDisconnected);
-      }
-      /**
-       * Adds segments into this context.
-       * The added segments become the head.
-       * @param {CodePathSegment[]} segments Segments to add.
-       * @returns {void}
-       */
-      add(segments) {
-        assert(segments.length >= this.count, `${segments.length} >= ${this.count}`);
-        this.segmentsList.push(mergeExtraSegments(this, segments));
-      }
-      /**
-       * Replaces the head segments with given segments.
-       * The current head segments are removed.
-       * @param {CodePathSegment[]} segments Segments to add.
-       * @returns {void}
-       */
-      replaceHead(segments) {
-        assert(segments.length >= this.count, `${segments.length} >= ${this.count}`);
-        this.segmentsList.splice(-1, 1, mergeExtraSegments(this, segments));
-      }
-      /**
-       * Adds all segments of a given fork context into this context.
-       * @param {ForkContext} context A fork context to add.
-       * @returns {void}
-       */
-      addAll(context) {
-        assert(context.count === this.count);
-        const source = context.segmentsList;
-        for (let i = 0; i < source.length; ++i) {
-          this.segmentsList.push(source[i]);
-        }
-      }
-      /**
-       * Clears all segments in this context.
-       * @returns {void}
-       */
-      clear() {
-        this.segmentsList = [];
-      }
-      /**
-       * Creates the root fork context.
-       * @param {IdGenerator} idGenerator An identifier generator for segments.
-       * @returns {ForkContext} New fork context.
-       */
-      static newRoot(idGenerator) {
-        const context = new _ForkContext(idGenerator, null, 1);
-        context.add([CodePathSegment.newRoot(idGenerator.next())]);
-        return context;
-      }
-      /**
-       * Creates an empty fork context preceded by a given context.
-       * @param {ForkContext} parentContext The parent fork context.
-       * @param {boolean} forkLeavingPath A flag which shows inside of `finally` block.
-       * @returns {ForkContext} New fork context.
-       */
-      static newEmpty(parentContext, forkLeavingPath) {
-        return new _ForkContext(
-          parentContext.idGenerator,
-          parentContext,
-          (forkLeavingPath ? 2 : 1) * parentContext.count
-        );
-      }
-    };
-    module.exports = ForkContext;
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path-state.js
-var require_code_path_state = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path-state.js"(exports, module) {
-    "use strict";
-    var CodePathSegment = require_code_path_segment();
-    var ForkContext = require_fork_context();
-    function addToReturnedOrThrown(dest, others, all, segments) {
-      for (let i = 0; i < segments.length; ++i) {
-        const segment = segments[i];
-        dest.push(segment);
-        if (!others.includes(segment)) {
-          all.push(segment);
-        }
-      }
-    }
-    function getContinueContext(state, label) {
-      if (!label) {
-        return state.loopContext;
-      }
-      let context = state.loopContext;
-      while (context) {
-        if (context.label === label) {
-          return context;
-        }
-        context = context.upper;
-      }
-      return null;
-    }
-    function getBreakContext(state, label) {
-      let context = state.breakContext;
-      while (context) {
-        if (label ? context.label === label : context.breakable) {
-          return context;
-        }
-        context = context.upper;
-      }
-      return null;
-    }
-    function getReturnContext(state) {
-      let context = state.tryContext;
-      while (context) {
-        if (context.hasFinalizer && context.position !== "finally") {
-          return context;
-        }
-        context = context.upper;
-      }
-      return state;
-    }
-    function getThrowContext(state) {
-      let context = state.tryContext;
-      while (context) {
-        if (context.position === "try" || context.hasFinalizer && context.position === "catch") {
-          return context;
-        }
-        context = context.upper;
-      }
-      return state;
-    }
-    function remove(xs, x) {
-      xs.splice(xs.indexOf(x), 1);
-    }
-    function removeConnection(prevSegments, nextSegments) {
-      for (let i = 0; i < prevSegments.length; ++i) {
-        const prevSegment = prevSegments[i];
-        const nextSegment = nextSegments[i];
-        remove(prevSegment.nextSegments, nextSegment);
-        remove(prevSegment.allNextSegments, nextSegment);
-        remove(nextSegment.prevSegments, prevSegment);
-        remove(nextSegment.allPrevSegments, prevSegment);
-      }
-    }
-    function makeLooped(state, unflattenedFromSegments, unflattenedToSegments) {
-      const fromSegments = CodePathSegment.flattenUnusedSegments(unflattenedFromSegments);
-      const toSegments = CodePathSegment.flattenUnusedSegments(unflattenedToSegments);
-      const end = Math.min(fromSegments.length, toSegments.length);
-      for (let i = 0; i < end; ++i) {
-        const fromSegment = fromSegments[i];
-        const toSegment = toSegments[i];
-        if (toSegment.reachable) {
-          fromSegment.nextSegments.push(toSegment);
-        }
-        if (fromSegment.reachable) {
-          toSegment.prevSegments.push(fromSegment);
-        }
-        fromSegment.allNextSegments.push(toSegment);
-        toSegment.allPrevSegments.push(fromSegment);
-        if (toSegment.allPrevSegments.length >= 2) {
-          CodePathSegment.markPrevSegmentAsLooped(toSegment, fromSegment);
-        }
-        state.notifyLooped(fromSegment, toSegment);
-      }
-    }
-    function finalizeTestSegmentsOfFor(context, choiceContext, head) {
-      if (!choiceContext.processed) {
-        choiceContext.trueForkContext.add(head);
-        choiceContext.falseForkContext.add(head);
-        choiceContext.qqForkContext.add(head);
-      }
-      if (context.test !== true) {
-        context.brokenForkContext.addAll(choiceContext.falseForkContext);
-      }
-      context.endOfTestSegments = choiceContext.trueForkContext.makeNext(0, -1);
-    }
-    var CodePathState = class {
-      /**
-       * @param {IdGenerator} idGenerator An id generator to generate id for code
-       *   path segments.
-       * @param {Function} onLooped A callback function to notify looping.
-       */
-      constructor(idGenerator, onLooped) {
-        this.idGenerator = idGenerator;
-        this.notifyLooped = onLooped;
-        this.forkContext = ForkContext.newRoot(idGenerator);
-        this.choiceContext = null;
-        this.switchContext = null;
-        this.tryContext = null;
-        this.loopContext = null;
-        this.breakContext = null;
-        this.chainContext = null;
-        this.currentSegments = [];
-        this.initialSegment = this.forkContext.head[0];
-        const final = this.finalSegments = [];
-        const returned = this.returnedForkContext = [];
-        const thrown = this.thrownForkContext = [];
-        returned.add = addToReturnedOrThrown.bind(null, returned, thrown, final);
-        thrown.add = addToReturnedOrThrown.bind(null, thrown, returned, final);
-      }
-      /**
-       * The head segments.
-       * @type {CodePathSegment[]}
-       */
-      get headSegments() {
-        return this.forkContext.head;
-      }
-      /**
-       * The parent forking context.
-       * This is used for the root of new forks.
-       * @type {ForkContext}
-       */
-      get parentForkContext() {
-        const current = this.forkContext;
-        return current && current.upper;
-      }
-      /**
-       * Creates and stacks new forking context.
-       * @param {boolean} forkLeavingPath A flag which shows being in a
-       *   "finally" block.
-       * @returns {ForkContext} The created context.
-       */
-      pushForkContext(forkLeavingPath) {
-        this.forkContext = ForkContext.newEmpty(
-          this.forkContext,
-          forkLeavingPath
-        );
-        return this.forkContext;
-      }
-      /**
-       * Pops and merges the last forking context.
-       * @returns {ForkContext} The last context.
-       */
-      popForkContext() {
-        const lastContext = this.forkContext;
-        this.forkContext = lastContext.upper;
-        this.forkContext.replaceHead(lastContext.makeNext(0, -1));
-        return lastContext;
-      }
-      /**
-       * Creates a new path.
-       * @returns {void}
-       */
-      forkPath() {
-        this.forkContext.add(this.parentForkContext.makeNext(-1, -1));
-      }
-      /**
-       * Creates a bypass path.
-       * This is used for such as IfStatement which does not have "else" chunk.
-       * @returns {void}
-       */
-      forkBypassPath() {
-        this.forkContext.add(this.parentForkContext.head);
-      }
-      //--------------------------------------------------------------------------
-      // ConditionalExpression, LogicalExpression, IfStatement
-      //--------------------------------------------------------------------------
-      /**
-       * Creates a context for ConditionalExpression, LogicalExpression, AssignmentExpression (logical assignments only),
-       * IfStatement, WhileStatement, DoWhileStatement, or ForStatement.
-       *
-       * LogicalExpressions have cases that it goes different paths between the
-       * `true` case and the `false` case.
-       *
-       * For Example:
-       *
-       *     if (a || b) {
-       *         foo();
-       *     } else {
-       *         bar();
-       *     }
-       *
-       * In this case, `b` is evaluated always in the code path of the `else`
-       * block, but it's not so in the code path of the `if` block.
-       * So there are 3 paths.
-       *
-       *     a -> foo();
-       *     a -> b -> foo();
-       *     a -> b -> bar();
-       * @param {string} kind A kind string.
-       *   If the new context is LogicalExpression's or AssignmentExpression's, this is `"&&"` or `"||"` or `"??"`.
-       *   If it's IfStatement's or ConditionalExpression's, this is `"test"`.
-       *   Otherwise, this is `"loop"`.
-       * @param {boolean} isForkingAsResult A flag that shows that goes different
-       *   paths between `true` and `false`.
-       * @returns {void}
-       */
-      pushChoiceContext(kind, isForkingAsResult) {
-        this.choiceContext = {
-          upper: this.choiceContext,
-          kind,
-          isForkingAsResult,
-          trueForkContext: ForkContext.newEmpty(this.forkContext),
-          falseForkContext: ForkContext.newEmpty(this.forkContext),
-          qqForkContext: ForkContext.newEmpty(this.forkContext),
-          processed: false
-        };
-      }
-      /**
-       * Pops the last choice context and finalizes it.
-       * @throws {Error} (Unreachable.)
-       * @returns {ChoiceContext} The popped context.
-       */
-      popChoiceContext() {
-        const context = this.choiceContext;
-        this.choiceContext = context.upper;
-        const forkContext = this.forkContext;
-        const headSegments = forkContext.head;
-        switch (context.kind) {
-          case "&&":
-          case "||":
-          case "??":
-            if (!context.processed) {
-              context.trueForkContext.add(headSegments);
-              context.falseForkContext.add(headSegments);
-              context.qqForkContext.add(headSegments);
-            }
-            if (context.isForkingAsResult) {
-              const parentContext = this.choiceContext;
-              parentContext.trueForkContext.addAll(context.trueForkContext);
-              parentContext.falseForkContext.addAll(context.falseForkContext);
-              parentContext.qqForkContext.addAll(context.qqForkContext);
-              parentContext.processed = true;
-              return context;
-            }
-            break;
-          case "test":
-            if (!context.processed) {
-              context.trueForkContext.clear();
-              context.trueForkContext.add(headSegments);
-            } else {
-              context.falseForkContext.clear();
-              context.falseForkContext.add(headSegments);
-            }
-            break;
-          case "loop":
-            return context;
-          default:
-            throw new Error("unreachable");
-        }
-        const prevForkContext = context.trueForkContext;
-        prevForkContext.addAll(context.falseForkContext);
-        forkContext.replaceHead(prevForkContext.makeNext(0, -1));
-        return context;
-      }
-      /**
-       * Makes a code path segment of the right-hand operand of a logical
-       * expression.
-       * @throws {Error} (Unreachable.)
-       * @returns {void}
-       */
-      makeLogicalRight() {
-        const context = this.choiceContext;
-        const forkContext = this.forkContext;
-        if (context.processed) {
-          let prevForkContext;
-          switch (context.kind) {
-            case "&&":
-              prevForkContext = context.trueForkContext;
-              break;
-            case "||":
-              prevForkContext = context.falseForkContext;
-              break;
-            case "??":
-              prevForkContext = context.qqForkContext;
-              break;
-            default:
-              throw new Error("unreachable");
-          }
-          forkContext.replaceHead(prevForkContext.makeNext(0, -1));
-          prevForkContext.clear();
-          context.processed = false;
-        } else {
-          switch (context.kind) {
-            case "&&":
-              context.falseForkContext.add(forkContext.head);
-              break;
-            case "||":
-              context.trueForkContext.add(forkContext.head);
-              break;
-            case "??":
-              context.trueForkContext.add(forkContext.head);
-              context.falseForkContext.add(forkContext.head);
-              break;
-            default:
-              throw new Error("unreachable");
-          }
-          forkContext.replaceHead(forkContext.makeNext(-1, -1));
-        }
-      }
-      /**
-       * Makes a code path segment of the `if` block.
-       * @returns {void}
-       */
-      makeIfConsequent() {
-        const context = this.choiceContext;
-        const forkContext = this.forkContext;
-        if (!context.processed) {
-          context.trueForkContext.add(forkContext.head);
-          context.falseForkContext.add(forkContext.head);
-          context.qqForkContext.add(forkContext.head);
-        }
-        context.processed = false;
-        forkContext.replaceHead(
-          context.trueForkContext.makeNext(0, -1)
-        );
-      }
-      /**
-       * Makes a code path segment of the `else` block.
-       * @returns {void}
-       */
-      makeIfAlternate() {
-        const context = this.choiceContext;
-        const forkContext = this.forkContext;
-        context.trueForkContext.clear();
-        context.trueForkContext.add(forkContext.head);
-        context.processed = true;
-        forkContext.replaceHead(
-          context.falseForkContext.makeNext(0, -1)
-        );
-      }
-      //--------------------------------------------------------------------------
-      // ChainExpression
-      //--------------------------------------------------------------------------
-      /**
-       * Push a new `ChainExpression` context to the stack.
-       * This method is called on entering to each `ChainExpression` node.
-       * This context is used to count forking in the optional chain then merge them on the exiting from the `ChainExpression` node.
-       * @returns {void}
-       */
-      pushChainContext() {
-        this.chainContext = {
-          upper: this.chainContext,
-          countChoiceContexts: 0
-        };
-      }
-      /**
-       * Pop a `ChainExpression` context from the stack.
-       * This method is called on exiting from each `ChainExpression` node.
-       * This merges all forks of the last optional chaining.
-       * @returns {void}
-       */
-      popChainContext() {
-        const context = this.chainContext;
-        this.chainContext = context.upper;
-        for (let i = context.countChoiceContexts; i > 0; --i) {
-          this.popChoiceContext();
-        }
-      }
-      /**
-       * Create a choice context for optional access.
-       * This method is called on entering to each `(Call|Member)Expression[optional=true]` node.
-       * This creates a choice context as similar to `LogicalExpression[operator="??"]` node.
-       * @returns {void}
-       */
-      makeOptionalNode() {
-        if (this.chainContext) {
-          this.chainContext.countChoiceContexts += 1;
-          this.pushChoiceContext("??", false);
-        }
-      }
-      /**
-       * Create a fork.
-       * This method is called on entering to the `arguments|property` property of each `(Call|Member)Expression` node.
-       * @returns {void}
-       */
-      makeOptionalRight() {
-        if (this.chainContext) {
-          this.makeLogicalRight();
-        }
-      }
-      //--------------------------------------------------------------------------
-      // SwitchStatement
-      //--------------------------------------------------------------------------
-      /**
-       * Creates a context object of SwitchStatement and stacks it.
-       * @param {boolean} hasCase `true` if the switch statement has one or more
-       *   case parts.
-       * @param {string|null} label The label text.
-       * @returns {void}
-       */
-      pushSwitchContext(hasCase, label) {
-        this.switchContext = {
-          upper: this.switchContext,
-          hasCase,
-          defaultSegments: null,
-          defaultBodySegments: null,
-          foundDefault: false,
-          lastIsDefault: false,
-          countForks: 0
-        };
-        this.pushBreakContext(true, label);
-      }
-      /**
-       * Pops the last context of SwitchStatement and finalizes it.
-       *
-       * - Disposes all forking stack for `case` and `default`.
-       * - Creates the next code path segment from `context.brokenForkContext`.
-       * - If the last `SwitchCase` node is not a `default` part, creates a path
-       *   to the `default` body.
-       * @returns {void}
-       */
-      popSwitchContext() {
-        const context = this.switchContext;
-        this.switchContext = context.upper;
-        const forkContext = this.forkContext;
-        const brokenForkContext = this.popBreakContext().brokenForkContext;
-        if (context.countForks === 0) {
-          if (!brokenForkContext.empty) {
-            brokenForkContext.add(forkContext.makeNext(-1, -1));
-            forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
-          }
-          return;
-        }
-        const lastSegments = forkContext.head;
-        this.forkBypassPath();
-        const lastCaseSegments = forkContext.head;
-        brokenForkContext.add(lastSegments);
-        if (!context.lastIsDefault) {
-          if (context.defaultBodySegments) {
-            removeConnection(context.defaultSegments, context.defaultBodySegments);
-            makeLooped(this, lastCaseSegments, context.defaultBodySegments);
-          } else {
-            brokenForkContext.add(lastCaseSegments);
-          }
-        }
-        for (let i = 0; i < context.countForks; ++i) {
-          this.forkContext = this.forkContext.upper;
-        }
-        this.forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
-      }
-      /**
-       * Makes a code path segment for a `SwitchCase` node.
-       * @param {boolean} isEmpty `true` if the body is empty.
-       * @param {boolean} isDefault `true` if the body is the default case.
-       * @returns {void}
-       */
-      makeSwitchCaseBody(isEmpty, isDefault) {
-        const context = this.switchContext;
-        if (!context.hasCase) {
-          return;
-        }
-        const parentForkContext = this.forkContext;
-        const forkContext = this.pushForkContext();
-        forkContext.add(parentForkContext.makeNext(0, -1));
-        if (isDefault) {
-          context.defaultSegments = parentForkContext.head;
-          if (isEmpty) {
-            context.foundDefault = true;
-          } else {
-            context.defaultBodySegments = forkContext.head;
-          }
-        } else {
-          if (!isEmpty && context.foundDefault) {
-            context.foundDefault = false;
-            context.defaultBodySegments = forkContext.head;
-          }
-        }
-        context.lastIsDefault = isDefault;
-        context.countForks += 1;
-      }
-      //--------------------------------------------------------------------------
-      // TryStatement
-      //--------------------------------------------------------------------------
-      /**
-       * Creates a context object of TryStatement and stacks it.
-       * @param {boolean} hasFinalizer `true` if the try statement has a
-       *   `finally` block.
-       * @returns {void}
-       */
-      pushTryContext(hasFinalizer) {
-        this.tryContext = {
-          upper: this.tryContext,
-          position: "try",
-          hasFinalizer,
-          returnedForkContext: hasFinalizer ? ForkContext.newEmpty(this.forkContext) : null,
-          thrownForkContext: ForkContext.newEmpty(this.forkContext),
-          lastOfTryIsReachable: false,
-          lastOfCatchIsReachable: false
-        };
-      }
-      /**
-       * Pops the last context of TryStatement and finalizes it.
-       * @returns {void}
-       */
-      popTryContext() {
-        const context = this.tryContext;
-        this.tryContext = context.upper;
-        if (context.position === "catch") {
-          this.popForkContext();
-          return;
-        }
-        const returned = context.returnedForkContext;
-        const thrown = context.thrownForkContext;
-        if (returned.empty && thrown.empty) {
-          return;
-        }
-        const headSegments = this.forkContext.head;
-        this.forkContext = this.forkContext.upper;
-        const normalSegments = headSegments.slice(0, headSegments.length / 2 | 0);
-        const leavingSegments = headSegments.slice(headSegments.length / 2 | 0);
-        if (!returned.empty) {
-          getReturnContext(this).returnedForkContext.add(leavingSegments);
-        }
-        if (!thrown.empty) {
-          getThrowContext(this).thrownForkContext.add(leavingSegments);
-        }
-        this.forkContext.replaceHead(normalSegments);
-        if (!context.lastOfTryIsReachable && !context.lastOfCatchIsReachable) {
-          this.forkContext.makeUnreachable();
-        }
-      }
-      /**
-       * Makes a code path segment for a `catch` block.
-       * @returns {void}
-       */
-      makeCatchBlock() {
-        const context = this.tryContext;
-        const forkContext = this.forkContext;
-        const thrown = context.thrownForkContext;
-        context.position = "catch";
-        context.thrownForkContext = ForkContext.newEmpty(forkContext);
-        context.lastOfTryIsReachable = forkContext.reachable;
-        thrown.add(forkContext.head);
-        const thrownSegments = thrown.makeNext(0, -1);
-        this.pushForkContext();
-        this.forkBypassPath();
-        this.forkContext.add(thrownSegments);
-      }
-      /**
-       * Makes a code path segment for a `finally` block.
-       *
-       * In the `finally` block, parallel paths are created. The parallel paths
-       * are used as leaving-paths. The leaving-paths are paths from `return`
-       * statements and `throw` statements in a `try` block or a `catch` block.
-       * @returns {void}
-       */
-      makeFinallyBlock() {
-        const context = this.tryContext;
-        let forkContext = this.forkContext;
-        const returned = context.returnedForkContext;
-        const thrown = context.thrownForkContext;
-        const headOfLeavingSegments = forkContext.head;
-        if (context.position === "catch") {
-          this.popForkContext();
-          forkContext = this.forkContext;
-          context.lastOfCatchIsReachable = forkContext.reachable;
-        } else {
-          context.lastOfTryIsReachable = forkContext.reachable;
-        }
-        context.position = "finally";
-        if (returned.empty && thrown.empty) {
-          return;
-        }
-        const segments = forkContext.makeNext(-1, -1);
-        for (let i = 0; i < forkContext.count; ++i) {
-          const prevSegsOfLeavingSegment = [headOfLeavingSegments[i]];
-          for (let j = 0; j < returned.segmentsList.length; ++j) {
-            prevSegsOfLeavingSegment.push(returned.segmentsList[j][i]);
-          }
-          for (let j = 0; j < thrown.segmentsList.length; ++j) {
-            prevSegsOfLeavingSegment.push(thrown.segmentsList[j][i]);
-          }
-          segments.push(
-            CodePathSegment.newNext(
-              this.idGenerator.next(),
-              prevSegsOfLeavingSegment
-            )
-          );
-        }
-        this.pushForkContext(true);
-        this.forkContext.add(segments);
-      }
-      /**
-       * Makes a code path segment from the first throwable node to the `catch`
-       * block or the `finally` block.
-       * @returns {void}
-       */
-      makeFirstThrowablePathInTryBlock() {
-        const forkContext = this.forkContext;
-        if (!forkContext.reachable) {
-          return;
-        }
-        const context = getThrowContext(this);
-        if (context === this || context.position !== "try" || !context.thrownForkContext.empty) {
-          return;
-        }
-        context.thrownForkContext.add(forkContext.head);
-        forkContext.replaceHead(forkContext.makeNext(-1, -1));
-      }
-      //--------------------------------------------------------------------------
-      // Loop Statements
-      //--------------------------------------------------------------------------
-      /**
-       * Creates a context object of a loop statement and stacks it.
-       * @param {string} type The type of the node which was triggered. One of
-       *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
-       *   and `ForStatement`.
-       * @param {string|null} label A label of the node which was triggered.
-       * @throws {Error} (Unreachable - unknown type.)
-       * @returns {void}
-       */
-      pushLoopContext(type, label) {
-        const forkContext = this.forkContext;
-        const breakContext = this.pushBreakContext(true, label);
-        switch (type) {
-          case "WhileStatement":
-            this.pushChoiceContext("loop", false);
-            this.loopContext = {
-              upper: this.loopContext,
-              type,
-              label,
-              test: void 0,
-              continueDestSegments: null,
-              brokenForkContext: breakContext.brokenForkContext
-            };
-            break;
-          case "DoWhileStatement":
-            this.pushChoiceContext("loop", false);
-            this.loopContext = {
-              upper: this.loopContext,
-              type,
-              label,
-              test: void 0,
-              entrySegments: null,
-              continueForkContext: ForkContext.newEmpty(forkContext),
-              brokenForkContext: breakContext.brokenForkContext
-            };
-            break;
-          case "ForStatement":
-            this.pushChoiceContext("loop", false);
-            this.loopContext = {
-              upper: this.loopContext,
-              type,
-              label,
-              test: void 0,
-              endOfInitSegments: null,
-              testSegments: null,
-              endOfTestSegments: null,
-              updateSegments: null,
-              endOfUpdateSegments: null,
-              continueDestSegments: null,
-              brokenForkContext: breakContext.brokenForkContext
-            };
-            break;
-          case "ForInStatement":
-          case "ForOfStatement":
-            this.loopContext = {
-              upper: this.loopContext,
-              type,
-              label,
-              prevSegments: null,
-              leftSegments: null,
-              endOfLeftSegments: null,
-              continueDestSegments: null,
-              brokenForkContext: breakContext.brokenForkContext
-            };
-            break;
-          default:
-            throw new Error(`unknown type: "${type}"`);
-        }
-      }
-      /**
-       * Pops the last context of a loop statement and finalizes it.
-       * @throws {Error} (Unreachable - unknown type.)
-       * @returns {void}
-       */
-      popLoopContext() {
-        const context = this.loopContext;
-        this.loopContext = context.upper;
-        const forkContext = this.forkContext;
-        const brokenForkContext = this.popBreakContext().brokenForkContext;
-        switch (context.type) {
-          case "WhileStatement":
-          case "ForStatement":
-            this.popChoiceContext();
-            makeLooped(
-              this,
-              forkContext.head,
-              context.continueDestSegments
-            );
-            break;
-          case "DoWhileStatement": {
-            const choiceContext = this.popChoiceContext();
-            if (!choiceContext.processed) {
-              choiceContext.trueForkContext.add(forkContext.head);
-              choiceContext.falseForkContext.add(forkContext.head);
-            }
-            if (context.test !== true) {
-              brokenForkContext.addAll(choiceContext.falseForkContext);
-            }
-            const segmentsList = choiceContext.trueForkContext.segmentsList;
-            for (let i = 0; i < segmentsList.length; ++i) {
-              makeLooped(
-                this,
-                segmentsList[i],
-                context.entrySegments
-              );
-            }
-            break;
-          }
-          case "ForInStatement":
-          case "ForOfStatement":
-            brokenForkContext.add(forkContext.head);
-            makeLooped(
-              this,
-              forkContext.head,
-              context.leftSegments
-            );
-            break;
-          default:
-            throw new Error("unreachable");
-        }
-        if (brokenForkContext.empty) {
-          forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
-        } else {
-          forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
-        }
-      }
-      /**
-       * Makes a code path segment for the test part of a WhileStatement.
-       * @param {boolean|undefined} test The test value (only when constant).
-       * @returns {void}
-       */
-      makeWhileTest(test) {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        const testSegments = forkContext.makeNext(0, -1);
-        context.test = test;
-        context.continueDestSegments = testSegments;
-        forkContext.replaceHead(testSegments);
-      }
-      /**
-       * Makes a code path segment for the body part of a WhileStatement.
-       * @returns {void}
-       */
-      makeWhileBody() {
-        const context = this.loopContext;
-        const choiceContext = this.choiceContext;
-        const forkContext = this.forkContext;
-        if (!choiceContext.processed) {
-          choiceContext.trueForkContext.add(forkContext.head);
-          choiceContext.falseForkContext.add(forkContext.head);
-        }
-        if (context.test !== true) {
-          context.brokenForkContext.addAll(choiceContext.falseForkContext);
-        }
-        forkContext.replaceHead(choiceContext.trueForkContext.makeNext(0, -1));
-      }
-      /**
-       * Makes a code path segment for the body part of a DoWhileStatement.
-       * @returns {void}
-       */
-      makeDoWhileBody() {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        const bodySegments = forkContext.makeNext(-1, -1);
-        context.entrySegments = bodySegments;
-        forkContext.replaceHead(bodySegments);
-      }
-      /**
-       * Makes a code path segment for the test part of a DoWhileStatement.
-       * @param {boolean|undefined} test The test value (only when constant).
-       * @returns {void}
-       */
-      makeDoWhileTest(test) {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        context.test = test;
-        if (!context.continueForkContext.empty) {
-          context.continueForkContext.add(forkContext.head);
-          const testSegments = context.continueForkContext.makeNext(0, -1);
-          forkContext.replaceHead(testSegments);
-        }
-      }
-      /**
-       * Makes a code path segment for the test part of a ForStatement.
-       * @param {boolean|undefined} test The test value (only when constant).
-       * @returns {void}
-       */
-      makeForTest(test) {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        const endOfInitSegments = forkContext.head;
-        const testSegments = forkContext.makeNext(-1, -1);
-        context.test = test;
-        context.endOfInitSegments = endOfInitSegments;
-        context.continueDestSegments = context.testSegments = testSegments;
-        forkContext.replaceHead(testSegments);
-      }
-      /**
-       * Makes a code path segment for the update part of a ForStatement.
-       * @returns {void}
-       */
-      makeForUpdate() {
-        const context = this.loopContext;
-        const choiceContext = this.choiceContext;
-        const forkContext = this.forkContext;
-        if (context.testSegments) {
-          finalizeTestSegmentsOfFor(
-            context,
-            choiceContext,
-            forkContext.head
-          );
-        } else {
-          context.endOfInitSegments = forkContext.head;
-        }
-        const updateSegments = forkContext.makeDisconnected(-1, -1);
-        context.continueDestSegments = context.updateSegments = updateSegments;
-        forkContext.replaceHead(updateSegments);
-      }
-      /**
-       * Makes a code path segment for the body part of a ForStatement.
-       * @returns {void}
-       */
-      makeForBody() {
-        const context = this.loopContext;
-        const choiceContext = this.choiceContext;
-        const forkContext = this.forkContext;
-        if (context.updateSegments) {
-          context.endOfUpdateSegments = forkContext.head;
-          if (context.testSegments) {
-            makeLooped(
-              this,
-              context.endOfUpdateSegments,
-              context.testSegments
-            );
-          }
-        } else if (context.testSegments) {
-          finalizeTestSegmentsOfFor(
-            context,
-            choiceContext,
-            forkContext.head
-          );
-        } else {
-          context.endOfInitSegments = forkContext.head;
-        }
-        let bodySegments = context.endOfTestSegments;
-        if (!bodySegments) {
-          const prevForkContext = ForkContext.newEmpty(forkContext);
-          prevForkContext.add(context.endOfInitSegments);
-          if (context.endOfUpdateSegments) {
-            prevForkContext.add(context.endOfUpdateSegments);
-          }
-          bodySegments = prevForkContext.makeNext(0, -1);
-        }
-        context.continueDestSegments = context.continueDestSegments || bodySegments;
-        forkContext.replaceHead(bodySegments);
-      }
-      /**
-       * Makes a code path segment for the left part of a ForInStatement and a
-       * ForOfStatement.
-       * @returns {void}
-       */
-      makeForInOfLeft() {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        const leftSegments = forkContext.makeDisconnected(-1, -1);
-        context.prevSegments = forkContext.head;
-        context.leftSegments = context.continueDestSegments = leftSegments;
-        forkContext.replaceHead(leftSegments);
-      }
-      /**
-       * Makes a code path segment for the right part of a ForInStatement and a
-       * ForOfStatement.
-       * @returns {void}
-       */
-      makeForInOfRight() {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        const temp = ForkContext.newEmpty(forkContext);
-        temp.add(context.prevSegments);
-        const rightSegments = temp.makeNext(-1, -1);
-        context.endOfLeftSegments = forkContext.head;
-        forkContext.replaceHead(rightSegments);
-      }
-      /**
-       * Makes a code path segment for the body part of a ForInStatement and a
-       * ForOfStatement.
-       * @returns {void}
-       */
-      makeForInOfBody() {
-        const context = this.loopContext;
-        const forkContext = this.forkContext;
-        const temp = ForkContext.newEmpty(forkContext);
-        temp.add(context.endOfLeftSegments);
-        const bodySegments = temp.makeNext(-1, -1);
-        makeLooped(this, forkContext.head, context.leftSegments);
-        context.brokenForkContext.add(forkContext.head);
-        forkContext.replaceHead(bodySegments);
-      }
-      //--------------------------------------------------------------------------
-      // Control Statements
-      //--------------------------------------------------------------------------
-      /**
-       * Creates new context for BreakStatement.
-       * @param {boolean} breakable The flag to indicate it can break by
-       *      an unlabeled BreakStatement.
-       * @param {string|null} label The label of this context.
-       * @returns {Object} The new context.
-       */
-      pushBreakContext(breakable, label) {
-        this.breakContext = {
-          upper: this.breakContext,
-          breakable,
-          label,
-          brokenForkContext: ForkContext.newEmpty(this.forkContext)
-        };
-        return this.breakContext;
-      }
-      /**
-       * Removes the top item of the break context stack.
-       * @returns {Object} The removed context.
-       */
-      popBreakContext() {
-        const context = this.breakContext;
-        const forkContext = this.forkContext;
-        this.breakContext = context.upper;
-        if (!context.breakable) {
-          const brokenForkContext = context.brokenForkContext;
-          if (!brokenForkContext.empty) {
-            brokenForkContext.add(forkContext.head);
-            forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
-          }
-        }
-        return context;
-      }
-      /**
-       * Makes a path for a `break` statement.
-       *
-       * It registers the head segment to a context of `break`.
-       * It makes new unreachable segment, then it set the head with the segment.
-       * @param {string} label A label of the break statement.
-       * @returns {void}
-       */
-      makeBreak(label) {
-        const forkContext = this.forkContext;
-        if (!forkContext.reachable) {
-          return;
-        }
-        const context = getBreakContext(this, label);
-        if (context) {
-          context.brokenForkContext.add(forkContext.head);
-        }
-        forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
-      }
-      /**
-       * Makes a path for a `continue` statement.
-       *
-       * It makes a looping path.
-       * It makes new unreachable segment, then it set the head with the segment.
-       * @param {string} label A label of the continue statement.
-       * @returns {void}
-       */
-      makeContinue(label) {
-        const forkContext = this.forkContext;
-        if (!forkContext.reachable) {
-          return;
-        }
-        const context = getContinueContext(this, label);
-        if (context) {
-          if (context.continueDestSegments) {
-            makeLooped(this, forkContext.head, context.continueDestSegments);
-            if (context.type === "ForInStatement" || context.type === "ForOfStatement") {
-              context.brokenForkContext.add(forkContext.head);
-            }
-          } else {
-            context.continueForkContext.add(forkContext.head);
-          }
-        }
-        forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
-      }
-      /**
-       * Makes a path for a `return` statement.
-       *
-       * It registers the head segment to a context of `return`.
-       * It makes new unreachable segment, then it set the head with the segment.
-       * @returns {void}
-       */
-      makeReturn() {
-        const forkContext = this.forkContext;
-        if (forkContext.reachable) {
-          getReturnContext(this).returnedForkContext.add(forkContext.head);
-          forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
-        }
-      }
-      /**
-       * Makes a path for a `throw` statement.
-       *
-       * It registers the head segment to a context of `throw`.
-       * It makes new unreachable segment, then it set the head with the segment.
-       * @returns {void}
-       */
-      makeThrow() {
-        const forkContext = this.forkContext;
-        if (forkContext.reachable) {
-          getThrowContext(this).thrownForkContext.add(forkContext.head);
-          forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
-        }
-      }
-      /**
-       * Makes the final path.
-       * @returns {void}
-       */
-      makeFinal() {
-        const segments = this.currentSegments;
-        if (segments.length > 0 && segments[0].reachable) {
-          this.returnedForkContext.add(segments);
-        }
-      }
-    };
-    module.exports = CodePathState;
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/id-generator.js
-var require_id_generator = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/id-generator.js"(exports, module) {
-    "use strict";
-    var IdGenerator = class {
-      /**
-       * @param {string} prefix Optional. A prefix of generated ids.
-       */
-      constructor(prefix) {
-        this.prefix = String(prefix);
-        this.n = 0;
-      }
-      /**
-       * Generates id.
-       * @returns {string} A generated id.
-       */
-      next() {
-        this.n = 1 + this.n | 0;
-        if (this.n < 0) {
-          this.n = 1;
-        }
-        return this.prefix + this.n;
-      }
-    };
-    module.exports = IdGenerator;
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path.js
-var require_code_path = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path.js"(exports, module) {
-    "use strict";
-    var CodePathState = require_code_path_state();
-    var IdGenerator = require_id_generator();
-    var CodePath = class {
-      /**
-       * Creates a new instance.
-       * @param {Object} options Options for the function (see below).
-       * @param {string} options.id An identifier.
-       * @param {string} options.origin The type of code path origin.
-       * @param {CodePath|null} options.upper The code path of the upper function scope.
-       * @param {Function} options.onLooped A callback function to notify looping.
-       */
-      constructor({ id, origin, upper, onLooped }) {
-        this.id = id;
-        this.origin = origin;
-        this.upper = upper;
-        this.childCodePaths = [];
-        Object.defineProperty(
-          this,
-          "internal",
-          { value: new CodePathState(new IdGenerator(`${id}_`), onLooped) }
-        );
-        if (upper) {
-          upper.childCodePaths.push(this);
-        }
-      }
-      /**
-       * Gets the state of a given code path.
-       * @param {CodePath} codePath A code path to get.
-       * @returns {CodePathState} The state of the code path.
-       */
-      static getState(codePath) {
-        return codePath.internal;
-      }
-      /**
-       * The initial code path segment.
-       * @type {CodePathSegment}
-       */
-      get initialSegment() {
-        return this.internal.initialSegment;
-      }
-      /**
-       * Final code path segments.
-       * This array is a mix of `returnedSegments` and `thrownSegments`.
-       * @type {CodePathSegment[]}
-       */
-      get finalSegments() {
-        return this.internal.finalSegments;
-      }
-      /**
-       * Final code path segments which is with `return` statements.
-       * This array contains the last path segment if it's reachable.
-       * Since the reachable last path returns `undefined`.
-       * @type {CodePathSegment[]}
-       */
-      get returnedSegments() {
-        return this.internal.returnedForkContext;
-      }
-      /**
-       * Final code path segments which is with `throw` statements.
-       * @type {CodePathSegment[]}
-       */
-      get thrownSegments() {
-        return this.internal.thrownForkContext;
-      }
-      /**
-       * Current code path segments.
-       * @type {CodePathSegment[]}
-       */
-      get currentSegments() {
-        return this.internal.currentSegments;
-      }
-      /**
-       * Traverses all segments in this code path.
-       *
-       *     codePath.traverseSegments(function(segment, controller) {
-       *         // do something.
-       *     });
-       *
-       * This method enumerates segments in order from the head.
-       *
-       * The `controller` object has two methods.
-       *
-       * - `controller.skip()` - Skip the following segments in this branch.
-       * - `controller.break()` - Skip all following segments.
-       * @param {Object} [options] Omittable.
-       * @param {CodePathSegment} [options.first] The first segment to traverse.
-       * @param {CodePathSegment} [options.last] The last segment to traverse.
-       * @param {Function} callback A callback function.
-       * @returns {void}
-       */
-      traverseSegments(options, callback) {
-        let resolvedOptions;
-        let resolvedCallback;
-        if (typeof options === "function") {
-          resolvedCallback = options;
-          resolvedOptions = {};
-        } else {
-          resolvedOptions = options || {};
-          resolvedCallback = callback;
-        }
-        const startSegment = resolvedOptions.first || this.internal.initialSegment;
-        const lastSegment = resolvedOptions.last;
-        let item = null;
-        let index = 0;
-        let end = 0;
-        let segment = null;
-        const visited = /* @__PURE__ */ Object.create(null);
-        const stack = [[startSegment, 0]];
-        let skippedSegment = null;
-        let broken = false;
-        const controller = {
-          skip() {
-            if (stack.length <= 1) {
-              broken = true;
-            } else {
-              skippedSegment = stack[stack.length - 2][0];
-            }
-          },
-          break() {
-            broken = true;
-          }
-        };
-        function isVisited(prevSegment) {
-          return visited[prevSegment.id] || segment.isLoopedPrevSegment(prevSegment);
-        }
-        while (stack.length > 0) {
-          item = stack[stack.length - 1];
-          segment = item[0];
-          index = item[1];
-          if (index === 0) {
-            if (visited[segment.id]) {
-              stack.pop();
-              continue;
-            }
-            if (segment !== startSegment && segment.prevSegments.length > 0 && !segment.prevSegments.every(isVisited)) {
-              stack.pop();
-              continue;
-            }
-            if (skippedSegment && segment.prevSegments.includes(skippedSegment)) {
-              skippedSegment = null;
-            }
-            visited[segment.id] = true;
-            if (!skippedSegment) {
-              resolvedCallback.call(this, segment, controller);
-              if (segment === lastSegment) {
-                controller.skip();
-              }
-              if (broken) {
-                break;
-              }
-            }
-          }
-          end = segment.nextSegments.length - 1;
-          if (index < end) {
-            item[1] += 1;
-            stack.push([segment.nextSegments[index], 0]);
-          } else if (index === end) {
-            item[0] = segment.nextSegments[index];
-            item[1] = 0;
-          } else {
-            stack.pop();
-          }
-        }
-      }
-    };
-    module.exports = CodePath;
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js
-var require_code_path_analyzer = __commonJS({
-  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js"(exports, module) {
-    "use strict";
-    var assert = require_assert();
-    var { breakableTypePattern } = require_ast_utils();
-    var CodePath = require_code_path();
-    var CodePathSegment = require_code_path_segment();
-    var IdGenerator = require_id_generator();
-    var debug = require_debug_helpers();
-    function isCaseNode(node) {
-      return Boolean(node.test);
-    }
-    function isPropertyDefinitionValue(node) {
-      const parent = node.parent;
-      return parent && parent.type === "PropertyDefinition" && parent.value === node;
-    }
-    function isHandledLogicalOperator(operator) {
-      return operator === "&&" || operator === "||" || operator === "??";
-    }
-    function isLogicalAssignmentOperator(operator) {
-      return operator === "&&=" || operator === "||=" || operator === "??=";
-    }
-    function getLabel(node) {
-      if (node.parent.type === "LabeledStatement") {
-        return node.parent.label.name;
-      }
-      return null;
-    }
-    function isForkingByTrueOrFalse(node) {
-      const parent = node.parent;
-      switch (parent.type) {
-        case "ConditionalExpression":
-        case "IfStatement":
-        case "WhileStatement":
-        case "DoWhileStatement":
-        case "ForStatement":
-          return parent.test === node;
-        case "LogicalExpression":
-          return isHandledLogicalOperator(parent.operator);
-        case "AssignmentExpression":
-          return isLogicalAssignmentOperator(parent.operator);
-        default:
-          return false;
-      }
-    }
-    function getBooleanValueIfSimpleConstant(node) {
-      if (node.type === "Literal") {
-        return Boolean(node.value);
-      }
-      return void 0;
-    }
-    function isIdentifierReference(node) {
-      const parent = node.parent;
-      switch (parent.type) {
-        case "LabeledStatement":
-        case "BreakStatement":
-        case "ContinueStatement":
-        case "ArrayPattern":
-        case "RestElement":
-        case "ImportSpecifier":
-        case "ImportDefaultSpecifier":
-        case "ImportNamespaceSpecifier":
-        case "CatchClause":
-          return false;
-        case "FunctionDeclaration":
-        case "FunctionExpression":
-        case "ArrowFunctionExpression":
-        case "ClassDeclaration":
-        case "ClassExpression":
-        case "VariableDeclarator":
-          return parent.id !== node;
-        case "Property":
-        case "PropertyDefinition":
-        case "MethodDefinition":
-          return parent.key !== node || parent.computed || parent.shorthand;
-        case "AssignmentPattern":
-          return parent.key !== node;
-        default:
-          return true;
-      }
-    }
-    function forwardCurrentToHead(analyzer, node) {
-      const codePath = analyzer.codePath;
-      const state = CodePath.getState(codePath);
-      const currentSegments = state.currentSegments;
-      const headSegments = state.headSegments;
-      const end = Math.max(currentSegments.length, headSegments.length);
-      let i, currentSegment, headSegment;
-      for (i = 0; i < end; ++i) {
-        currentSegment = currentSegments[i];
-        headSegment = headSegments[i];
-        if (currentSegment !== headSegment && currentSegment) {
-          debug.dump(`onCodePathSegmentEnd ${currentSegment.id}`);
-          if (currentSegment.reachable) {
-            analyzer.emitter.emit(
-              "onCodePathSegmentEnd",
-              currentSegment,
-              node
-            );
-          }
-        }
-      }
-      state.currentSegments = headSegments;
-      for (i = 0; i < end; ++i) {
-        currentSegment = currentSegments[i];
-        headSegment = headSegments[i];
-        if (currentSegment !== headSegment && headSegment) {
-          debug.dump(`onCodePathSegmentStart ${headSegment.id}`);
-          CodePathSegment.markUsed(headSegment);
-          if (headSegment.reachable) {
-            analyzer.emitter.emit(
-              "onCodePathSegmentStart",
-              headSegment,
-              node
-            );
-          }
-        }
-      }
-    }
-    function leaveFromCurrentSegment(analyzer, node) {
-      const state = CodePath.getState(analyzer.codePath);
-      const currentSegments = state.currentSegments;
-      for (let i = 0; i < currentSegments.length; ++i) {
-        const currentSegment = currentSegments[i];
-        debug.dump(`onCodePathSegmentEnd ${currentSegment.id}`);
-        if (currentSegment.reachable) {
-          analyzer.emitter.emit(
-            "onCodePathSegmentEnd",
-            currentSegment,
-            node
-          );
-        }
-      }
-      state.currentSegments = [];
-    }
-    function preprocess(analyzer, node) {
-      const codePath = analyzer.codePath;
-      const state = CodePath.getState(codePath);
-      const parent = node.parent;
-      switch (parent.type) {
-        case "CallExpression":
-          if (parent.optional === true && parent.arguments.length >= 1 && parent.arguments[0] === node) {
-            state.makeOptionalRight();
-          }
-          break;
-        case "MemberExpression":
-          if (parent.optional === true && parent.property === node) {
-            state.makeOptionalRight();
-          }
-          break;
-        case "LogicalExpression":
-          if (parent.right === node && isHandledLogicalOperator(parent.operator)) {
-            state.makeLogicalRight();
-          }
-          break;
-        case "AssignmentExpression":
-          if (parent.right === node && isLogicalAssignmentOperator(parent.operator)) {
-            state.makeLogicalRight();
-          }
-          break;
-        case "ConditionalExpression":
-        case "IfStatement":
-          if (parent.consequent === node) {
-            state.makeIfConsequent();
-          } else if (parent.alternate === node) {
-            state.makeIfAlternate();
-          }
-          break;
-        case "SwitchCase":
-          if (parent.consequent[0] === node) {
-            state.makeSwitchCaseBody(false, !parent.test);
-          }
-          break;
-        case "TryStatement":
-          if (parent.handler === node) {
-            state.makeCatchBlock();
-          } else if (parent.finalizer === node) {
-            state.makeFinallyBlock();
-          }
-          break;
-        case "WhileStatement":
-          if (parent.test === node) {
-            state.makeWhileTest(getBooleanValueIfSimpleConstant(node));
-          } else {
-            assert(parent.body === node);
-            state.makeWhileBody();
-          }
-          break;
-        case "DoWhileStatement":
-          if (parent.body === node) {
-            state.makeDoWhileBody();
-          } else {
-            assert(parent.test === node);
-            state.makeDoWhileTest(getBooleanValueIfSimpleConstant(node));
-          }
-          break;
-        case "ForStatement":
-          if (parent.test === node) {
-            state.makeForTest(getBooleanValueIfSimpleConstant(node));
-          } else if (parent.update === node) {
-            state.makeForUpdate();
-          } else if (parent.body === node) {
-            state.makeForBody();
-          }
-          break;
-        case "ForInStatement":
-        case "ForOfStatement":
-          if (parent.left === node) {
-            state.makeForInOfLeft();
-          } else if (parent.right === node) {
-            state.makeForInOfRight();
-          } else {
-            assert(parent.body === node);
-            state.makeForInOfBody();
-          }
-          break;
-        case "AssignmentPattern":
-          if (parent.right === node) {
-            state.pushForkContext();
-            state.forkBypassPath();
-            state.forkPath();
-          }
-          break;
-        default:
-          break;
-      }
-    }
-    function processCodePathToEnter(analyzer, node) {
-      let codePath = analyzer.codePath;
-      let state = codePath && CodePath.getState(codePath);
-      const parent = node.parent;
-      function startCodePath(origin) {
-        if (codePath) {
-          forwardCurrentToHead(analyzer, node);
-          debug.dumpState(node, state, false);
-        }
-        codePath = analyzer.codePath = new CodePath({
-          id: analyzer.idGenerator.next(),
-          origin,
-          upper: codePath,
-          onLooped: analyzer.onLooped
-        });
-        state = CodePath.getState(codePath);
-        debug.dump(`onCodePathStart ${codePath.id}`);
-        analyzer.emitter.emit("onCodePathStart", codePath, node);
-      }
-      if (isPropertyDefinitionValue(node)) {
-        startCodePath("class-field-initializer");
-      }
-      switch (node.type) {
-        case "Program":
-          startCodePath("program");
-          break;
-        case "FunctionDeclaration":
-        case "FunctionExpression":
-        case "ArrowFunctionExpression":
-          startCodePath("function");
-          break;
-        case "StaticBlock":
-          startCodePath("class-static-block");
-          break;
-        case "ChainExpression":
-          state.pushChainContext();
-          break;
-        case "CallExpression":
-          if (node.optional === true) {
-            state.makeOptionalNode();
-          }
-          break;
-        case "MemberExpression":
-          if (node.optional === true) {
-            state.makeOptionalNode();
-          }
-          break;
-        case "LogicalExpression":
-          if (isHandledLogicalOperator(node.operator)) {
-            state.pushChoiceContext(
-              node.operator,
-              isForkingByTrueOrFalse(node)
-            );
-          }
-          break;
-        case "AssignmentExpression":
-          if (isLogicalAssignmentOperator(node.operator)) {
-            state.pushChoiceContext(
-              node.operator.slice(0, -1),
-              // removes `=` from the end
-              isForkingByTrueOrFalse(node)
-            );
-          }
-          break;
-        case "ConditionalExpression":
-        case "IfStatement":
-          state.pushChoiceContext("test", false);
-          break;
-        case "SwitchStatement":
-          state.pushSwitchContext(
-            node.cases.some(isCaseNode),
-            getLabel(node)
-          );
-          break;
-        case "TryStatement":
-          state.pushTryContext(Boolean(node.finalizer));
-          break;
-        case "SwitchCase":
-          if (parent.discriminant !== node && parent.cases[0] !== node) {
-            state.forkPath();
-          }
-          break;
-        case "WhileStatement":
-        case "DoWhileStatement":
-        case "ForStatement":
-        case "ForInStatement":
-        case "ForOfStatement":
-          state.pushLoopContext(node.type, getLabel(node));
-          break;
-        case "LabeledStatement":
-          if (!breakableTypePattern.test(node.body.type)) {
-            state.pushBreakContext(false, node.label.name);
-          }
-          break;
-        default:
-          break;
-      }
-      forwardCurrentToHead(analyzer, node);
-      debug.dumpState(node, state, false);
-    }
-    function processCodePathToExit(analyzer, node) {
-      const codePath = analyzer.codePath;
-      const state = CodePath.getState(codePath);
-      let dontForward = false;
-      switch (node.type) {
-        case "ChainExpression":
-          state.popChainContext();
-          break;
-        case "IfStatement":
-        case "ConditionalExpression":
-          state.popChoiceContext();
-          break;
-        case "LogicalExpression":
-          if (isHandledLogicalOperator(node.operator)) {
-            state.popChoiceContext();
-          }
-          break;
-        case "AssignmentExpression":
-          if (isLogicalAssignmentOperator(node.operator)) {
-            state.popChoiceContext();
-          }
-          break;
-        case "SwitchStatement":
-          state.popSwitchContext();
-          break;
-        case "SwitchCase":
-          if (node.consequent.length === 0) {
-            state.makeSwitchCaseBody(true, !node.test);
-          }
-          if (state.forkContext.reachable) {
-            dontForward = true;
-          }
-          break;
-        case "TryStatement":
-          state.popTryContext();
-          break;
-        case "BreakStatement":
-          forwardCurrentToHead(analyzer, node);
-          state.makeBreak(node.label && node.label.name);
-          dontForward = true;
-          break;
-        case "ContinueStatement":
-          forwardCurrentToHead(analyzer, node);
-          state.makeContinue(node.label && node.label.name);
-          dontForward = true;
-          break;
-        case "ReturnStatement":
-          forwardCurrentToHead(analyzer, node);
-          state.makeReturn();
-          dontForward = true;
-          break;
-        case "ThrowStatement":
-          forwardCurrentToHead(analyzer, node);
-          state.makeThrow();
-          dontForward = true;
-          break;
-        case "Identifier":
-          if (isIdentifierReference(node)) {
-            state.makeFirstThrowablePathInTryBlock();
-            dontForward = true;
-          }
-          break;
-        case "CallExpression":
-        case "ImportExpression":
-        case "MemberExpression":
-        case "NewExpression":
-        case "YieldExpression":
-          state.makeFirstThrowablePathInTryBlock();
-          break;
-        case "WhileStatement":
-        case "DoWhileStatement":
-        case "ForStatement":
-        case "ForInStatement":
-        case "ForOfStatement":
-          state.popLoopContext();
-          break;
-        case "AssignmentPattern":
-          state.popForkContext();
-          break;
-        case "LabeledStatement":
-          if (!breakableTypePattern.test(node.body.type)) {
-            state.popBreakContext();
-          }
-          break;
-        default:
-          break;
-      }
-      if (!dontForward) {
-        forwardCurrentToHead(analyzer, node);
-      }
-      debug.dumpState(node, state, true);
-    }
-    function postprocess(analyzer, node) {
-      function endCodePath() {
-        let codePath = analyzer.codePath;
-        CodePath.getState(codePath).makeFinal();
-        leaveFromCurrentSegment(analyzer, node);
-        debug.dump(`onCodePathEnd ${codePath.id}`);
-        analyzer.emitter.emit("onCodePathEnd", codePath, node);
-        debug.dumpDot(codePath);
-        codePath = analyzer.codePath = analyzer.codePath.upper;
-        if (codePath) {
-          debug.dumpState(node, CodePath.getState(codePath), true);
-        }
-      }
-      switch (node.type) {
-        case "Program":
-        case "FunctionDeclaration":
-        case "FunctionExpression":
-        case "ArrowFunctionExpression":
-        case "StaticBlock": {
-          endCodePath();
-          break;
-        }
-        case "CallExpression":
-          if (node.optional === true && node.arguments.length === 0) {
-            CodePath.getState(analyzer.codePath).makeOptionalRight();
-          }
-          break;
-        default:
-          break;
-      }
-      if (isPropertyDefinitionValue(node)) {
-        endCodePath();
-      }
-    }
-    var CodePathAnalyzer = class {
-      /**
-       * @param {EventGenerator} eventGenerator An event generator to wrap.
-       */
-      constructor(eventGenerator) {
-        this.original = eventGenerator;
-        this.emitter = eventGenerator.emitter;
-        this.codePath = null;
-        this.idGenerator = new IdGenerator("s");
-        this.currentNode = null;
-        this.onLooped = this.onLooped.bind(this);
-      }
-      /**
-       * Does the process to enter a given AST node.
-       * This updates state of analysis and calls `enterNode` of the wrapped.
-       * @param {ASTNode} node A node which is entering.
-       * @returns {void}
-       */
-      enterNode(node) {
-        this.currentNode = node;
-        if (node.parent) {
-          preprocess(this, node);
-        }
-        processCodePathToEnter(this, node);
-        this.original.enterNode(node);
-        this.currentNode = null;
-      }
-      /**
-       * Does the process to leave a given AST node.
-       * This updates state of analysis and calls `leaveNode` of the wrapped.
-       * @param {ASTNode} node A node which is leaving.
-       * @returns {void}
-       */
-      leaveNode(node) {
-        this.currentNode = node;
-        processCodePathToExit(this, node);
-        this.original.leaveNode(node);
-        postprocess(this, node);
-        this.currentNode = null;
-      }
-      /**
-       * This is called on a code path looped.
-       * Then this raises a looped event.
-       * @param {CodePathSegment} fromSegment A segment of prev.
-       * @param {CodePathSegment} toSegment A segment of next.
-       * @returns {void}
-       */
-      onLooped(fromSegment, toSegment) {
-        if (fromSegment.reachable && toSegment.reachable) {
-          debug.dump(`onCodePathSegmentLoop ${fromSegment.id} -> ${toSegment.id}`);
-          this.emitter.emit(
-            "onCodePathSegmentLoop",
-            fromSegment,
-            toSegment,
-            this.currentNode
-          );
-        }
-      }
-    };
-    module.exports = CodePathAnalyzer;
-  }
-});
-
-// ../../node_modules/escape-string-regexp/index.js
-var require_escape_string_regexp = __commonJS({
-  "../../node_modules/escape-string-regexp/index.js"(exports, module) {
-    "use strict";
-    module.exports = (string) => {
-      if (typeof string !== "string") {
-        throw new TypeError("Expected a string");
-      }
-      return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
-    };
-  }
-});
-
-// ../../node_modules/eslint/lib/linter/apply-disable-directives.js
-var require_apply_disable_directives = __commonJS({
-  "../../node_modules/eslint/lib/linter/apply-disable-directives.js"(exports, module) {
-    "use strict";
-    var escapeRegExp = require_escape_string_regexp();
-    function compareLocations(itemA, itemB) {
-      return itemA.line - itemB.line || itemA.column - itemB.column;
-    }
-    function groupByParentComment(directives) {
-      const groups = /* @__PURE__ */ new Map();
-      for (const directive of directives) {
-        const { unprocessedDirective: { parentComment } } = directive;
-        if (groups.has(parentComment)) {
-          groups.get(parentComment).push(directive);
-        } else {
-          groups.set(parentComment, [directive]);
-        }
-      }
-      return [...groups.values()];
-    }
-    function createIndividualDirectivesRemoval(directives, commentToken) {
-      const commentValueStart = commentToken.range[0] + "//".length;
-      const listStartOffset = /^\s*\S+\s+/u.exec(commentToken.value)[0].length;
-      const listText = commentToken.value.slice(listStartOffset).split(/\s-{2,}\s/u)[0].trimEnd();
-      return directives.map((directive) => {
-        const { ruleId } = directive;
-        const regex = new RegExp(String.raw`(?:^|\s*,\s*)${escapeRegExp(ruleId)}(?:\s*,\s*|$)`, "u");
-        const match = regex.exec(listText);
-        const matchedText = match[0];
-        const matchStartOffset = listStartOffset + match.index;
-        const matchEndOffset = matchStartOffset + matchedText.length;
-        const firstIndexOfComma = matchedText.indexOf(",");
-        const lastIndexOfComma = matchedText.lastIndexOf(",");
-        let removalStartOffset, removalEndOffset;
-        if (firstIndexOfComma !== lastIndexOfComma) {
-          removalStartOffset = matchStartOffset + firstIndexOfComma;
-          removalEndOffset = matchStartOffset + lastIndexOfComma;
-        } else {
-          removalStartOffset = matchStartOffset;
-          removalEndOffset = matchEndOffset;
-        }
-        return {
-          description: `'${ruleId}'`,
-          fix: {
-            range: [
-              commentValueStart + removalStartOffset,
-              commentValueStart + removalEndOffset
-            ],
-            text: ""
-          },
-          unprocessedDirective: directive.unprocessedDirective
-        };
-      });
-    }
-    function createCommentRemoval(directives, commentToken) {
-      const { range } = commentToken;
-      const ruleIds = directives.filter((directive) => directive.ruleId).map((directive) => `'${directive.ruleId}'`);
-      return {
-        description: ruleIds.length <= 2 ? ruleIds.join(" or ") : `${ruleIds.slice(0, ruleIds.length - 1).join(", ")}, or ${ruleIds[ruleIds.length - 1]}`,
-        fix: {
-          range,
-          text: " "
-        },
-        unprocessedDirective: directives[0].unprocessedDirective
-      };
-    }
-    function processUnusedDisableDirectives(allDirectives) {
-      const directiveGroups = groupByParentComment(allDirectives);
-      return directiveGroups.flatMap(
-        (directives) => {
-          const { parentComment } = directives[0].unprocessedDirective;
-          const remainingRuleIds = new Set(parentComment.ruleIds);
-          for (const directive of directives) {
-            remainingRuleIds.delete(directive.ruleId);
-          }
-          return remainingRuleIds.size ? createIndividualDirectivesRemoval(directives, parentComment.commentToken) : [createCommentRemoval(directives, parentComment.commentToken)];
-        }
-      );
-    }
-    function applyDirectives(options) {
-      const problems = [];
-      const usedDisableDirectives = /* @__PURE__ */ new Set();
-      for (const problem of options.problems) {
-        let disableDirectivesForProblem = [];
-        let nextDirectiveIndex = 0;
-        while (nextDirectiveIndex < options.directives.length && compareLocations(options.directives[nextDirectiveIndex], problem) <= 0) {
-          const directive = options.directives[nextDirectiveIndex++];
-          if (directive.ruleId === null || directive.ruleId === problem.ruleId) {
-            switch (directive.type) {
-              case "disable":
-                disableDirectivesForProblem.push(directive);
-                break;
-              case "enable":
-                disableDirectivesForProblem = [];
-                break;
-            }
-          }
-        }
-        if (disableDirectivesForProblem.length > 0) {
-          const suppressions = disableDirectivesForProblem.map((directive) => ({
-            kind: "directive",
-            justification: directive.unprocessedDirective.justification
-          }));
-          if (problem.suppressions) {
-            problem.suppressions = problem.suppressions.concat(suppressions);
-          } else {
-            problem.suppressions = suppressions;
-            usedDisableDirectives.add(disableDirectivesForProblem[disableDirectivesForProblem.length - 1]);
-          }
-        }
-        problems.push(problem);
-      }
-      const unusedDisableDirectivesToReport = options.directives.filter((directive) => directive.type === "disable" && !usedDisableDirectives.has(directive));
-      const processed = processUnusedDisableDirectives(unusedDisableDirectivesToReport);
-      const unusedDisableDirectives = processed.map(({ description, fix, unprocessedDirective }) => {
-        const { parentComment, type, line, column } = unprocessedDirective;
-        return {
-          ruleId: null,
-          message: description ? `Unused eslint-disable directive (no problems were reported from ${description}).` : "Unused eslint-disable directive (no problems were reported).",
-          line: type === "disable-next-line" ? parentComment.commentToken.loc.start.line : line,
-          column: type === "disable-next-line" ? parentComment.commentToken.loc.start.column + 1 : column,
-          severity: options.reportUnusedDisableDirectives === "warn" ? 1 : 2,
-          nodeType: null,
-          ...options.disableFixes ? {} : { fix }
-        };
-      });
-      return { problems, unusedDisableDirectives };
-    }
-    module.exports = ({ directives, disableFixes, problems, reportUnusedDisableDirectives = "off" }) => {
-      const blockDirectives = directives.filter((directive) => directive.type === "disable" || directive.type === "enable").map((directive) => Object.assign({}, directive, { unprocessedDirective: directive })).sort(compareLocations);
-      const lineDirectives = directives.flatMap((directive) => {
-        switch (directive.type) {
-          case "disable":
-          case "enable":
-            return [];
-          case "disable-line":
-            return [
-              { type: "disable", line: directive.line, column: 1, ruleId: directive.ruleId, unprocessedDirective: directive },
-              { type: "enable", line: directive.line + 1, column: 0, ruleId: directive.ruleId, unprocessedDirective: directive }
-            ];
-          case "disable-next-line":
-            return [
-              { type: "disable", line: directive.line + 1, column: 1, ruleId: directive.ruleId, unprocessedDirective: directive },
-              { type: "enable", line: directive.line + 2, column: 0, ruleId: directive.ruleId, unprocessedDirective: directive }
-            ];
-          default:
-            throw new TypeError(`Unrecognized directive type '${directive.type}'`);
-        }
-      }).sort(compareLocations);
-      const blockDirectivesResult = applyDirectives({
-        problems,
-        directives: blockDirectives,
-        disableFixes,
-        reportUnusedDisableDirectives
-      });
-      const lineDirectivesResult = applyDirectives({
-        problems: blockDirectivesResult.problems,
-        directives: lineDirectives,
-        disableFixes,
-        reportUnusedDisableDirectives
-      });
-      return reportUnusedDisableDirectives !== "off" ? lineDirectivesResult.problems.concat(blockDirectivesResult.unusedDisableDirectives).concat(lineDirectivesResult.unusedDisableDirectives).sort(compareLocations) : lineDirectivesResult.problems;
+      commonjs,
+      es3,
+      es5,
+      es2015,
+      es2016,
+      es2017,
+      es2018,
+      es2019,
+      es2020,
+      es2021,
+      es2022,
+      es2023,
+      es2024
     };
   }
 });
@@ -32428,6 +30694,9 @@ var require_config_comment_parser = __commonJS({
         ConfigOps
       }
     } = require_eslintrc_universal();
+    var {
+      directivesPattern
+    } = require_directives();
     var debug = require_browser()("eslint:config-comment-parser");
     module.exports = class ConfigCommentParser {
       /**
@@ -32503,13 +30772,3317 @@ var require_config_comment_parser = __commonJS({
         debug("Parsing list config");
         const items = {};
         string.split(",").forEach((name) => {
-          const trimmedName = name.trim();
+          const trimmedName = name.trim().replace(/^(?<quote>['"]?)(?<ruleId>.*)\k<quote>$/us, "$<ruleId>");
           if (trimmedName) {
             items[trimmedName] = true;
           }
         });
         return items;
       }
+      /**
+       * Extract the directive and the justification from a given directive comment and trim them.
+       * @param {string} value The comment text to extract.
+       * @returns {{directivePart: string, justificationPart: string}} The extracted directive and justification.
+       */
+      extractDirectiveComment(value) {
+        const match = /\s-{2,}\s/u.exec(value);
+        if (!match) {
+          return { directivePart: value.trim(), justificationPart: "" };
+        }
+        const directive = value.slice(0, match.index).trim();
+        const justification = value.slice(match.index + match[0].length).trim();
+        return { directivePart: directive, justificationPart: justification };
+      }
+      /**
+       * Parses a directive comment into directive text and value.
+       * @param {Comment} comment The comment node with the directive to be parsed.
+       * @returns {{directiveText: string, directiveValue: string}} The directive text and value.
+       */
+      parseDirective(comment) {
+        const { directivePart } = this.extractDirectiveComment(comment.value);
+        const match = directivesPattern.exec(directivePart);
+        const directiveText = match[1];
+        const directiveValue = directivePart.slice(match.index + directiveText.length);
+        return { directiveText, directiveValue };
+      }
+    };
+  }
+});
+
+// ../../node_modules/eslint/lib/source-code/source-code.js
+var require_source_code = __commonJS({
+  "../../node_modules/eslint/lib/source-code/source-code.js"(exports, module) {
+    "use strict";
+    var { isCommentToken } = require_eslint_utils();
+    var TokenStore = require_token_store();
+    var astUtils = require_ast_utils();
+    var Traverser = require_traverser();
+    var globals = require_globals3();
+    var {
+      directivesPattern
+    } = require_directives();
+    var ConfigCommentParser = require_config_comment_parser();
+    var eslintScope = require_eslint_scope();
+    var commentParser = new ConfigCommentParser();
+    function validate(ast) {
+      if (!ast.tokens) {
+        throw new Error("AST is missing the tokens array.");
+      }
+      if (!ast.comments) {
+        throw new Error("AST is missing the comments array.");
+      }
+      if (!ast.loc) {
+        throw new Error("AST is missing location information.");
+      }
+      if (!ast.range) {
+        throw new Error("AST is missing range information");
+      }
+    }
+    function getGlobalsForEcmaVersion(ecmaVersion) {
+      switch (ecmaVersion) {
+        case 3:
+          return globals.es3;
+        case 5:
+          return globals.es5;
+        default:
+          if (ecmaVersion < 2015) {
+            return globals[`es${ecmaVersion + 2009}`];
+          }
+          return globals[`es${ecmaVersion}`];
+      }
+    }
+    function looksLikeExport(astNode) {
+      return astNode.type === "ExportDefaultDeclaration" || astNode.type === "ExportNamedDeclaration" || astNode.type === "ExportAllDeclaration" || astNode.type === "ExportSpecifier";
+    }
+    function sortedMerge(tokens, comments) {
+      const result = [];
+      let tokenIndex = 0;
+      let commentIndex = 0;
+      while (tokenIndex < tokens.length || commentIndex < comments.length) {
+        if (commentIndex >= comments.length || tokenIndex < tokens.length && tokens[tokenIndex].range[0] < comments[commentIndex].range[0]) {
+          result.push(tokens[tokenIndex++]);
+        } else {
+          result.push(comments[commentIndex++]);
+        }
+      }
+      return result;
+    }
+    function normalizeConfigGlobal(configuredValue) {
+      switch (configuredValue) {
+        case "off":
+          return "off";
+        case true:
+        case "true":
+        case "writeable":
+        case "writable":
+          return "writable";
+        case null:
+        case false:
+        case "false":
+        case "readable":
+        case "readonly":
+          return "readonly";
+        default:
+          throw new Error(`'${configuredValue}' is not a valid configuration for a global (use 'readonly', 'writable', or 'off')`);
+      }
+    }
+    function nodesOrTokensOverlap(first, second) {
+      return first.range[0] <= second.range[0] && first.range[1] >= second.range[0] || second.range[0] <= first.range[0] && second.range[1] >= first.range[0];
+    }
+    function isSpaceBetween(sourceCode, first, second, checkInsideOfJSXText) {
+      if (nodesOrTokensOverlap(first, second)) {
+        return false;
+      }
+      const [startingNodeOrToken, endingNodeOrToken] = first.range[1] <= second.range[0] ? [first, second] : [second, first];
+      const firstToken = sourceCode.getLastToken(startingNodeOrToken) || startingNodeOrToken;
+      const finalToken = sourceCode.getFirstToken(endingNodeOrToken) || endingNodeOrToken;
+      let currentToken = firstToken;
+      while (currentToken !== finalToken) {
+        const nextToken = sourceCode.getTokenAfter(currentToken, { includeComments: true });
+        if (currentToken.range[1] !== nextToken.range[0] || /*
+         * For backward compatibility, check spaces in JSXText.
+         * https://github.com/eslint/eslint/issues/12614
+         */
+        checkInsideOfJSXText && nextToken !== finalToken && nextToken.type === "JSXText" && /\s/u.test(nextToken.value)) {
+          return true;
+        }
+        currentToken = nextToken;
+      }
+      return false;
+    }
+    function addDeclaredGlobals(globalScope, configGlobals = {}, inlineGlobals = {}) {
+      for (const id of /* @__PURE__ */ new Set([...Object.keys(configGlobals), ...Object.keys(inlineGlobals)])) {
+        const configValue = configGlobals[id] === void 0 ? void 0 : normalizeConfigGlobal(configGlobals[id]);
+        const commentValue = inlineGlobals[id] && inlineGlobals[id].value;
+        const value = commentValue || configValue;
+        const sourceComments = inlineGlobals[id] && inlineGlobals[id].comments;
+        if (value === "off") {
+          continue;
+        }
+        let variable = globalScope.set.get(id);
+        if (!variable) {
+          variable = new eslintScope.Variable(id, globalScope);
+          globalScope.variables.push(variable);
+          globalScope.set.set(id, variable);
+        }
+        variable.eslintImplicitGlobalSetting = configValue;
+        variable.eslintExplicitGlobal = sourceComments !== void 0;
+        variable.eslintExplicitGlobalComments = sourceComments;
+        variable.writeable = value === "writable";
+      }
+      globalScope.through = globalScope.through.filter((reference) => {
+        const name = reference.identifier.name;
+        const variable = globalScope.set.get(name);
+        if (variable) {
+          reference.resolved = variable;
+          variable.references.push(reference);
+          return false;
+        }
+        return true;
+      });
+    }
+    function markExportedVariables(globalScope, variables) {
+      Object.keys(variables).forEach((name) => {
+        const variable = globalScope.set.get(name);
+        if (variable) {
+          variable.eslintUsed = true;
+          variable.eslintExported = true;
+        }
+      });
+    }
+    var caches = Symbol("caches");
+    var SourceCode = class extends TokenStore {
+      /**
+       * @param {string|Object} textOrConfig The source code text or config object.
+       * @param {string} textOrConfig.text The source code text.
+       * @param {ASTNode} textOrConfig.ast The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
+       * @param {Object|null} textOrConfig.parserServices The parser services.
+       * @param {ScopeManager|null} textOrConfig.scopeManager The scope of this source code.
+       * @param {Object|null} textOrConfig.visitorKeys The visitor keys to traverse AST.
+       * @param {ASTNode} [astIfNoConfig] The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
+       */
+      constructor(textOrConfig, astIfNoConfig) {
+        let text, ast, parserServices, scopeManager, visitorKeys;
+        if (typeof textOrConfig === "string") {
+          text = textOrConfig;
+          ast = astIfNoConfig;
+        } else if (typeof textOrConfig === "object" && textOrConfig !== null) {
+          text = textOrConfig.text;
+          ast = textOrConfig.ast;
+          parserServices = textOrConfig.parserServices;
+          scopeManager = textOrConfig.scopeManager;
+          visitorKeys = textOrConfig.visitorKeys;
+        }
+        validate(ast);
+        super(ast.tokens, ast.comments);
+        this[caches] = /* @__PURE__ */ new Map([
+          ["scopes", /* @__PURE__ */ new WeakMap()],
+          ["vars", /* @__PURE__ */ new Map()],
+          ["configNodes", void 0]
+        ]);
+        this.hasBOM = text.charCodeAt(0) === 65279;
+        this.text = this.hasBOM ? text.slice(1) : text;
+        this.ast = ast;
+        this.parserServices = parserServices || {};
+        this.scopeManager = scopeManager || null;
+        this.visitorKeys = visitorKeys || Traverser.DEFAULT_VISITOR_KEYS;
+        const shebangMatched = this.text.match(astUtils.shebangPattern);
+        const hasShebang = shebangMatched && ast.comments.length && ast.comments[0].value === shebangMatched[1];
+        if (hasShebang) {
+          ast.comments[0].type = "Shebang";
+        }
+        this.tokensAndComments = sortedMerge(ast.tokens, ast.comments);
+        this.lines = [];
+        this.lineStartIndices = [0];
+        const lineEndingPattern = astUtils.createGlobalLinebreakMatcher();
+        let match;
+        while (match = lineEndingPattern.exec(this.text)) {
+          this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1], match.index));
+          this.lineStartIndices.push(match.index + match[0].length);
+        }
+        this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1]));
+        this._commentCache = /* @__PURE__ */ new WeakMap();
+        Object.freeze(this);
+        Object.freeze(this.lines);
+      }
+      /**
+       * Split the source code into multiple lines based on the line delimiters.
+       * @param {string} text Source code as a string.
+       * @returns {string[]} Array of source code lines.
+       * @public
+       */
+      static splitLines(text) {
+        return text.split(astUtils.createGlobalLinebreakMatcher());
+      }
+      /**
+       * Gets the source code for the given node.
+       * @param {ASTNode} [node] The AST node to get the text for.
+       * @param {int} [beforeCount] The number of characters before the node to retrieve.
+       * @param {int} [afterCount] The number of characters after the node to retrieve.
+       * @returns {string} The text representing the AST node.
+       * @public
+       */
+      getText(node, beforeCount, afterCount) {
+        if (node) {
+          return this.text.slice(
+            Math.max(node.range[0] - (beforeCount || 0), 0),
+            node.range[1] + (afterCount || 0)
+          );
+        }
+        return this.text;
+      }
+      /**
+       * Gets the entire source text split into an array of lines.
+       * @returns {Array} The source text as an array of lines.
+       * @public
+       */
+      getLines() {
+        return this.lines;
+      }
+      /**
+       * Retrieves an array containing all comments in the source code.
+       * @returns {ASTNode[]} An array of comment nodes.
+       * @public
+       */
+      getAllComments() {
+        return this.ast.comments;
+      }
+      /**
+       * Gets all comments for the given node.
+       * @param {ASTNode} node The AST node to get the comments for.
+       * @returns {Object} An object containing a leading and trailing array
+       *      of comments indexed by their position.
+       * @public
+       * @deprecated replaced by getCommentsBefore(), getCommentsAfter(), and getCommentsInside().
+       */
+      getComments(node) {
+        if (this._commentCache.has(node)) {
+          return this._commentCache.get(node);
+        }
+        const comments = {
+          leading: [],
+          trailing: []
+        };
+        if (node.type === "Program") {
+          if (node.body.length === 0) {
+            comments.leading = node.comments;
+          }
+        } else {
+          if ((node.type === "BlockStatement" || node.type === "ClassBody") && node.body.length === 0 || node.type === "ObjectExpression" && node.properties.length === 0 || node.type === "ArrayExpression" && node.elements.length === 0 || node.type === "SwitchStatement" && node.cases.length === 0) {
+            comments.trailing = this.getTokens(node, {
+              includeComments: true,
+              filter: isCommentToken
+            });
+          }
+          let currentToken = this.getTokenBefore(node, { includeComments: true });
+          while (currentToken && isCommentToken(currentToken)) {
+            if (node.parent && node.parent.type !== "Program" && currentToken.start < node.parent.start) {
+              break;
+            }
+            comments.leading.push(currentToken);
+            currentToken = this.getTokenBefore(currentToken, { includeComments: true });
+          }
+          comments.leading.reverse();
+          currentToken = this.getTokenAfter(node, { includeComments: true });
+          while (currentToken && isCommentToken(currentToken)) {
+            if (node.parent && node.parent.type !== "Program" && currentToken.end > node.parent.end) {
+              break;
+            }
+            comments.trailing.push(currentToken);
+            currentToken = this.getTokenAfter(currentToken, { includeComments: true });
+          }
+        }
+        this._commentCache.set(node, comments);
+        return comments;
+      }
+      /**
+       * Retrieves the JSDoc comment for a given node.
+       * @param {ASTNode} node The AST node to get the comment for.
+       * @returns {Token|null} The Block comment token containing the JSDoc comment
+       *      for the given node or null if not found.
+       * @public
+       * @deprecated
+       */
+      getJSDocComment(node) {
+        const findJSDocComment = (astNode) => {
+          const tokenBefore = this.getTokenBefore(astNode, { includeComments: true });
+          if (tokenBefore && isCommentToken(tokenBefore) && tokenBefore.type === "Block" && tokenBefore.value.charAt(0) === "*" && astNode.loc.start.line - tokenBefore.loc.end.line <= 1) {
+            return tokenBefore;
+          }
+          return null;
+        };
+        let parent = node.parent;
+        switch (node.type) {
+          case "ClassDeclaration":
+          case "FunctionDeclaration":
+            return findJSDocComment(looksLikeExport(parent) ? parent : node);
+          case "ClassExpression":
+            return findJSDocComment(parent.parent);
+          case "ArrowFunctionExpression":
+          case "FunctionExpression":
+            if (parent.type !== "CallExpression" && parent.type !== "NewExpression") {
+              while (!this.getCommentsBefore(parent).length && !/Function/u.test(parent.type) && parent.type !== "MethodDefinition" && parent.type !== "Property") {
+                parent = parent.parent;
+                if (!parent) {
+                  break;
+                }
+              }
+              if (parent && parent.type !== "FunctionDeclaration" && parent.type !== "Program") {
+                return findJSDocComment(parent);
+              }
+            }
+            return findJSDocComment(node);
+          default:
+            return null;
+        }
+      }
+      /**
+       * Gets the deepest node containing a range index.
+       * @param {int} index Range index of the desired node.
+       * @returns {ASTNode} The node if found or null if not found.
+       * @public
+       */
+      getNodeByRangeIndex(index) {
+        let result = null;
+        Traverser.traverse(this.ast, {
+          visitorKeys: this.visitorKeys,
+          enter(node) {
+            if (node.range[0] <= index && index < node.range[1]) {
+              result = node;
+            } else {
+              this.skip();
+            }
+          },
+          leave(node) {
+            if (node === result) {
+              this.break();
+            }
+          }
+        });
+        return result;
+      }
+      /**
+       * Determines if two nodes or tokens have at least one whitespace character
+       * between them. Order does not matter. Returns false if the given nodes or
+       * tokens overlap.
+       * @param {ASTNode|Token} first The first node or token to check between.
+       * @param {ASTNode|Token} second The second node or token to check between.
+       * @returns {boolean} True if there is a whitespace character between
+       * any of the tokens found between the two given nodes or tokens.
+       * @public
+       */
+      isSpaceBetween(first, second) {
+        return isSpaceBetween(this, first, second, false);
+      }
+      /**
+       * Determines if two nodes or tokens have at least one whitespace character
+       * between them. Order does not matter. Returns false if the given nodes or
+       * tokens overlap.
+       * For backward compatibility, this method returns true if there are
+       * `JSXText` tokens that contain whitespaces between the two.
+       * @param {ASTNode|Token} first The first node or token to check between.
+       * @param {ASTNode|Token} second The second node or token to check between.
+       * @returns {boolean} True if there is a whitespace character between
+       * any of the tokens found between the two given nodes or tokens.
+       * @deprecated in favor of isSpaceBetween().
+       * @public
+       */
+      isSpaceBetweenTokens(first, second) {
+        return isSpaceBetween(this, first, second, true);
+      }
+      /**
+       * Converts a source text index into a (line, column) pair.
+       * @param {number} index The index of a character in a file
+       * @throws {TypeError} If non-numeric index or index out of range.
+       * @returns {Object} A {line, column} location object with a 0-indexed column
+       * @public
+       */
+      getLocFromIndex(index) {
+        if (typeof index !== "number") {
+          throw new TypeError("Expected `index` to be a number.");
+        }
+        if (index < 0 || index > this.text.length) {
+          throw new RangeError(`Index out of range (requested index ${index}, but source text has length ${this.text.length}).`);
+        }
+        if (index === this.text.length) {
+          return { line: this.lines.length, column: this.lines[this.lines.length - 1].length };
+        }
+        const lineNumber = index >= this.lineStartIndices[this.lineStartIndices.length - 1] ? this.lineStartIndices.length : this.lineStartIndices.findIndex((el) => index < el);
+        return { line: lineNumber, column: index - this.lineStartIndices[lineNumber - 1] };
+      }
+      /**
+       * Converts a (line, column) pair into a range index.
+       * @param {Object} loc A line/column location
+       * @param {number} loc.line The line number of the location (1-indexed)
+       * @param {number} loc.column The column number of the location (0-indexed)
+       * @throws {TypeError|RangeError} If `loc` is not an object with a numeric
+       *   `line` and `column`, if the `line` is less than or equal to zero or
+       *   the line or column is out of the expected range.
+       * @returns {number} The range index of the location in the file.
+       * @public
+       */
+      getIndexFromLoc(loc) {
+        if (typeof loc !== "object" || typeof loc.line !== "number" || typeof loc.column !== "number") {
+          throw new TypeError("Expected `loc` to be an object with numeric `line` and `column` properties.");
+        }
+        if (loc.line <= 0) {
+          throw new RangeError(`Line number out of range (line ${loc.line} requested). Line numbers should be 1-based.`);
+        }
+        if (loc.line > this.lineStartIndices.length) {
+          throw new RangeError(`Line number out of range (line ${loc.line} requested, but only ${this.lineStartIndices.length} lines present).`);
+        }
+        const lineStartIndex = this.lineStartIndices[loc.line - 1];
+        const lineEndIndex = loc.line === this.lineStartIndices.length ? this.text.length : this.lineStartIndices[loc.line];
+        const positionIndex = lineStartIndex + loc.column;
+        if (loc.line === this.lineStartIndices.length && positionIndex > lineEndIndex || loc.line < this.lineStartIndices.length && positionIndex >= lineEndIndex) {
+          throw new RangeError(`Column number out of range (column ${loc.column} requested, but the length of line ${loc.line} is ${lineEndIndex - lineStartIndex}).`);
+        }
+        return positionIndex;
+      }
+      /**
+       * Gets the scope for the given node
+       * @param {ASTNode} currentNode The node to get the scope of
+       * @returns {eslint-scope.Scope} The scope information for this node
+       * @throws {TypeError} If the `currentNode` argument is missing.
+       */
+      getScope(currentNode) {
+        if (!currentNode) {
+          throw new TypeError("Missing required argument: node.");
+        }
+        const cache = this[caches].get("scopes");
+        const cachedScope = cache.get(currentNode);
+        if (cachedScope) {
+          return cachedScope;
+        }
+        const inner = currentNode.type !== "Program";
+        for (let node = currentNode; node; node = node.parent) {
+          const scope = this.scopeManager.acquire(node, inner);
+          if (scope) {
+            if (scope.type === "function-expression-name") {
+              cache.set(currentNode, scope.childScopes[0]);
+              return scope.childScopes[0];
+            }
+            cache.set(currentNode, scope);
+            return scope;
+          }
+        }
+        cache.set(currentNode, this.scopeManager.scopes[0]);
+        return this.scopeManager.scopes[0];
+      }
+      /**
+       * Get the variables that `node` defines.
+       * This is a convenience method that passes through
+       * to the same method on the `scopeManager`.
+       * @param {ASTNode} node The node for which the variables are obtained.
+       * @returns {Array<Variable>} An array of variable nodes representing
+       *      the variables that `node` defines.
+       */
+      getDeclaredVariables(node) {
+        return this.scopeManager.getDeclaredVariables(node);
+      }
+      /* eslint-disable class-methods-use-this -- node is owned by SourceCode */
+      /**
+       * Gets all the ancestors of a given node
+       * @param {ASTNode} node The node
+       * @returns {Array<ASTNode>} All the ancestor nodes in the AST, not including the provided node, starting
+       * from the root node at index 0 and going inwards to the parent node.
+       * @throws {TypeError} When `node` is missing.
+       */
+      getAncestors(node) {
+        if (!node) {
+          throw new TypeError("Missing required argument: node.");
+        }
+        const ancestorsStartingAtParent = [];
+        for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+          ancestorsStartingAtParent.push(ancestor);
+        }
+        return ancestorsStartingAtParent.reverse();
+      }
+      /* eslint-enable class-methods-use-this -- node is owned by SourceCode */
+      /**
+       * Marks a variable as used in the current scope
+       * @param {string} name The name of the variable to mark as used.
+       * @param {ASTNode} [refNode] The closest node to the variable reference.
+       * @returns {boolean} True if the variable was found and marked as used, false if not.
+       */
+      markVariableAsUsed(name, refNode = this.ast) {
+        const currentScope = this.getScope(refNode);
+        let initialScope = currentScope;
+        if (currentScope.type === "global" && currentScope.childScopes.length > 0 && // top-level scopes refer to a `Program` node
+        currentScope.childScopes[0].block === this.ast) {
+          initialScope = currentScope.childScopes[0];
+        }
+        for (let scope = initialScope; scope; scope = scope.upper) {
+          const variable = scope.variables.find((scopeVar) => scopeVar.name === name);
+          if (variable) {
+            variable.eslintUsed = true;
+            return true;
+          }
+        }
+        return false;
+      }
+      /**
+       * Returns an array of all inline configuration nodes found in the
+       * source code.
+       * @returns {Array<Token>} An array of all inline configuration nodes.
+       */
+      getInlineConfigNodes() {
+        let configNodes = this[caches].get("configNodes");
+        if (configNodes) {
+          return configNodes;
+        }
+        configNodes = this.ast.comments.filter((comment) => {
+          if (comment.type === "Shebang") {
+            return false;
+          }
+          const { directivePart } = commentParser.extractDirectiveComment(comment.value);
+          const directiveMatch = directivesPattern.exec(directivePart);
+          if (!directiveMatch) {
+            return false;
+          }
+          return comment.type !== "Line" || !!/^eslint-disable-(next-)?line$/u.test(directiveMatch[1]);
+        });
+        this[caches].set("configNodes", configNodes);
+        return configNodes;
+      }
+      /**
+       * Applies language options sent in from the core.
+       * @param {Object} languageOptions The language options for this run.
+       * @returns {void}
+       */
+      applyLanguageOptions(languageOptions) {
+        const configGlobals = Object.assign(
+          /* @__PURE__ */ Object.create(null),
+          // https://github.com/eslint/eslint/issues/18363
+          getGlobalsForEcmaVersion(languageOptions.ecmaVersion),
+          languageOptions.sourceType === "commonjs" ? globals.commonjs : void 0,
+          languageOptions.globals
+        );
+        const varsCache = this[caches].get("vars");
+        varsCache.set("configGlobals", configGlobals);
+      }
+      /**
+       * Applies configuration found inside of the source code. This method is only
+       * called when ESLint is running with inline configuration allowed.
+       * @returns {{problems:Array<Problem>,configs:{config:FlatConfigArray,node:ASTNode}}} Information
+       *      that ESLint needs to further process the inline configuration.
+       */
+      applyInlineConfig() {
+        const problems = [];
+        const configs = [];
+        const exportedVariables = {};
+        const inlineGlobals = /* @__PURE__ */ Object.create(null);
+        this.getInlineConfigNodes().forEach((comment) => {
+          const { directiveText, directiveValue } = commentParser.parseDirective(comment);
+          switch (directiveText) {
+            case "exported":
+              Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
+              break;
+            case "globals":
+            case "global":
+              for (const [id, { value }] of Object.entries(commentParser.parseStringConfig(directiveValue, comment))) {
+                let normalizedValue;
+                try {
+                  normalizedValue = normalizeConfigGlobal(value);
+                } catch (err) {
+                  problems.push({
+                    ruleId: null,
+                    loc: comment.loc,
+                    message: err.message
+                  });
+                  continue;
+                }
+                if (inlineGlobals[id]) {
+                  inlineGlobals[id].comments.push(comment);
+                  inlineGlobals[id].value = normalizedValue;
+                } else {
+                  inlineGlobals[id] = {
+                    comments: [comment],
+                    value: normalizedValue
+                  };
+                }
+              }
+              break;
+            case "eslint": {
+              const parseResult = commentParser.parseJsonConfig(directiveValue, comment.loc);
+              if (parseResult.success) {
+                configs.push({
+                  config: {
+                    rules: parseResult.config
+                  },
+                  node: comment
+                });
+              } else {
+                problems.push(parseResult.error);
+              }
+              break;
+            }
+          }
+        });
+        const varsCache = this[caches].get("vars");
+        varsCache.set("inlineGlobals", inlineGlobals);
+        varsCache.set("exportedVariables", exportedVariables);
+        return {
+          configs,
+          problems
+        };
+      }
+      /**
+       * Called by ESLint core to indicate that it has finished providing
+       * information. We now add in all the missing variables and ensure that
+       * state-changing methods cannot be called by rules.
+       * @returns {void}
+       */
+      finalize() {
+        const varsCache = this[caches].get("vars");
+        const globalScope = this.scopeManager.scopes[0];
+        const configGlobals = varsCache.get("configGlobals");
+        const inlineGlobals = varsCache.get("inlineGlobals");
+        const exportedVariables = varsCache.get("exportedVariables");
+        addDeclaredGlobals(globalScope, configGlobals, inlineGlobals);
+        if (exportedVariables) {
+          markExportedVariables(globalScope, exportedVariables);
+        }
+      }
+    };
+    module.exports = SourceCode;
+  }
+});
+
+// ../../node_modules/eslint/lib/source-code/index.js
+var require_source_code2 = __commonJS({
+  "../../node_modules/eslint/lib/source-code/index.js"(exports, module) {
+    "use strict";
+    module.exports = {
+      SourceCode: require_source_code()
+    };
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/debug-helpers.js
+var require_debug_helpers = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/debug-helpers.js"(exports, module) {
+    "use strict";
+    var debug = require_browser()("eslint:code-path");
+    function getId(segment) {
+      return segment.id + (segment.reachable ? "" : "!");
+    }
+    function nodeToString(node, label) {
+      const suffix = label ? `:${label}` : "";
+      switch (node.type) {
+        case "Identifier":
+          return `${node.type}${suffix} (${node.name})`;
+        case "Literal":
+          return `${node.type}${suffix} (${node.value})`;
+        default:
+          return `${node.type}${suffix}`;
+      }
+    }
+    module.exports = {
+      /**
+       * A flag that debug dumping is enabled or not.
+       * @type {boolean}
+       */
+      enabled: debug.enabled,
+      /**
+       * Dumps given objects.
+       * @param {...any} args objects to dump.
+       * @returns {void}
+       */
+      dump: debug,
+      /**
+       * Dumps the current analyzing state.
+       * @param {ASTNode} node A node to dump.
+       * @param {CodePathState} state A state to dump.
+       * @param {boolean} leaving A flag whether or not it's leaving
+       * @returns {void}
+       */
+      dumpState: !debug.enabled ? debug : (
+        /* c8 ignore next */
+        function(node, state, leaving) {
+          for (let i = 0; i < state.currentSegments.length; ++i) {
+            const segInternal = state.currentSegments[i].internal;
+            if (leaving) {
+              const last = segInternal.nodes.length - 1;
+              if (last >= 0 && segInternal.nodes[last] === nodeToString(node, "enter")) {
+                segInternal.nodes[last] = nodeToString(node, void 0);
+              } else {
+                segInternal.nodes.push(nodeToString(node, "exit"));
+              }
+            } else {
+              segInternal.nodes.push(nodeToString(node, "enter"));
+            }
+          }
+          debug([
+            `${state.currentSegments.map(getId).join(",")})`,
+            `${node.type}${leaving ? ":exit" : ""}`
+          ].join(" "));
+        }
+      ),
+      /**
+       * Dumps a DOT code of a given code path.
+       * The DOT code can be visualized with Graphvis.
+       * @param {CodePath} codePath A code path to dump.
+       * @returns {void}
+       * @see http://www.graphviz.org
+       * @see http://www.webgraphviz.com
+       */
+      dumpDot: !debug.enabled ? debug : (
+        /* c8 ignore next */
+        function(codePath) {
+          let text = '\ndigraph {\nnode[shape=box,style="rounded,filled",fillcolor=white];\ninitial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];\n';
+          if (codePath.returnedSegments.length > 0) {
+            text += 'final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];\n';
+          }
+          if (codePath.thrownSegments.length > 0) {
+            text += 'thrown[label="\u2718",shape=circle,width=0.3,height=0.3,fixedsize=true];\n';
+          }
+          const traceMap = /* @__PURE__ */ Object.create(null);
+          const arrows = this.makeDotArrows(codePath, traceMap);
+          for (const id in traceMap) {
+            const segment = traceMap[id];
+            text += `${id}[`;
+            if (segment.reachable) {
+              text += 'label="';
+            } else {
+              text += 'style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\\n';
+            }
+            if (segment.internal.nodes.length > 0) {
+              text += segment.internal.nodes.join("\\n");
+            } else {
+              text += "????";
+            }
+            text += '"];\n';
+          }
+          text += `${arrows}
+`;
+          text += "}";
+          debug("DOT", text);
+        }
+      ),
+      /**
+       * Makes a DOT code of a given code path.
+       * The DOT code can be visualized with Graphvis.
+       * @param {CodePath} codePath A code path to make DOT.
+       * @param {Object} traceMap Optional. A map to check whether or not segments had been done.
+       * @returns {string} A DOT code of the code path.
+       */
+      makeDotArrows(codePath, traceMap) {
+        const stack = [[codePath.initialSegment, 0]];
+        const done = traceMap || /* @__PURE__ */ Object.create(null);
+        let lastId = codePath.initialSegment.id;
+        let text = `initial->${codePath.initialSegment.id}`;
+        while (stack.length > 0) {
+          const item = stack.pop();
+          const segment = item[0];
+          const index = item[1];
+          if (done[segment.id] && index === 0) {
+            continue;
+          }
+          done[segment.id] = segment;
+          const nextSegment = segment.allNextSegments[index];
+          if (!nextSegment) {
+            continue;
+          }
+          if (lastId === segment.id) {
+            text += `->${nextSegment.id}`;
+          } else {
+            text += `;
+${segment.id}->${nextSegment.id}`;
+          }
+          lastId = nextSegment.id;
+          stack.unshift([segment, 1 + index]);
+          stack.push([nextSegment, 0]);
+        }
+        codePath.returnedSegments.forEach((finalSegment) => {
+          if (lastId === finalSegment.id) {
+            text += "->final";
+          } else {
+            text += `;
+${finalSegment.id}->final`;
+          }
+          lastId = null;
+        });
+        codePath.thrownSegments.forEach((finalSegment) => {
+          if (lastId === finalSegment.id) {
+            text += "->thrown";
+          } else {
+            text += `;
+${finalSegment.id}->thrown`;
+          }
+          lastId = null;
+        });
+        return `${text};`;
+      }
+    };
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path-segment.js
+var require_code_path_segment = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path-segment.js"(exports, module) {
+    "use strict";
+    var debug = require_debug_helpers();
+    function isReachable(segment) {
+      return segment.reachable;
+    }
+    var CodePathSegment = class _CodePathSegment {
+      /**
+       * Creates a new instance.
+       * @param {string} id An identifier.
+       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
+       *   This array includes unreachable segments.
+       * @param {boolean} reachable A flag which shows this is reachable.
+       */
+      constructor(id, allPrevSegments, reachable) {
+        this.id = id;
+        this.nextSegments = [];
+        this.prevSegments = allPrevSegments.filter(isReachable);
+        this.allNextSegments = [];
+        this.allPrevSegments = allPrevSegments;
+        this.reachable = reachable;
+        Object.defineProperty(this, "internal", {
+          value: {
+            // determines if the segment has been attached to the code path
+            used: false,
+            // array of previous segments coming from the end of a loop
+            loopedPrevSegments: []
+          }
+        });
+        if (debug.enabled) {
+          this.internal.nodes = [];
+        }
+      }
+      /**
+       * Checks a given previous segment is coming from the end of a loop.
+       * @param {CodePathSegment} segment A previous segment to check.
+       * @returns {boolean} `true` if the segment is coming from the end of a loop.
+       */
+      isLoopedPrevSegment(segment) {
+        return this.internal.loopedPrevSegments.includes(segment);
+      }
+      /**
+       * Creates the root segment.
+       * @param {string} id An identifier.
+       * @returns {CodePathSegment} The created segment.
+       */
+      static newRoot(id) {
+        return new _CodePathSegment(id, [], true);
+      }
+      /**
+       * Creates a new segment and appends it after the given segments.
+       * @param {string} id An identifier.
+       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments
+       *      to append to.
+       * @returns {CodePathSegment} The created segment.
+       */
+      static newNext(id, allPrevSegments) {
+        return new _CodePathSegment(
+          id,
+          _CodePathSegment.flattenUnusedSegments(allPrevSegments),
+          allPrevSegments.some(isReachable)
+        );
+      }
+      /**
+       * Creates an unreachable segment and appends it after the given segments.
+       * @param {string} id An identifier.
+       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
+       * @returns {CodePathSegment} The created segment.
+       */
+      static newUnreachable(id, allPrevSegments) {
+        const segment = new _CodePathSegment(id, _CodePathSegment.flattenUnusedSegments(allPrevSegments), false);
+        _CodePathSegment.markUsed(segment);
+        return segment;
+      }
+      /**
+       * Creates a segment that follows given segments.
+       * This factory method does not connect with `allPrevSegments`.
+       * But this inherits `reachable` flag.
+       * @param {string} id An identifier.
+       * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
+       * @returns {CodePathSegment} The created segment.
+       */
+      static newDisconnected(id, allPrevSegments) {
+        return new _CodePathSegment(id, [], allPrevSegments.some(isReachable));
+      }
+      /**
+       * Marks a given segment as used.
+       *
+       * And this function registers the segment into the previous segments as a next.
+       * @param {CodePathSegment} segment A segment to mark.
+       * @returns {void}
+       */
+      static markUsed(segment) {
+        if (segment.internal.used) {
+          return;
+        }
+        segment.internal.used = true;
+        let i;
+        if (segment.reachable) {
+          for (i = 0; i < segment.allPrevSegments.length; ++i) {
+            const prevSegment = segment.allPrevSegments[i];
+            prevSegment.allNextSegments.push(segment);
+            prevSegment.nextSegments.push(segment);
+          }
+        } else {
+          for (i = 0; i < segment.allPrevSegments.length; ++i) {
+            segment.allPrevSegments[i].allNextSegments.push(segment);
+          }
+        }
+      }
+      /**
+       * Marks a previous segment as looped.
+       * @param {CodePathSegment} segment A segment.
+       * @param {CodePathSegment} prevSegment A previous segment to mark.
+       * @returns {void}
+       */
+      static markPrevSegmentAsLooped(segment, prevSegment) {
+        segment.internal.loopedPrevSegments.push(prevSegment);
+      }
+      /**
+       * Creates a new array based on an array of segments. If any segment in the
+       * array is unused, then it is replaced by all of its previous segments.
+       * All used segments are returned as-is without replacement.
+       * @param {CodePathSegment[]} segments The array of segments to flatten.
+       * @returns {CodePathSegment[]} The flattened array.
+       */
+      static flattenUnusedSegments(segments) {
+        const done = /* @__PURE__ */ new Set();
+        for (let i = 0; i < segments.length; ++i) {
+          const segment = segments[i];
+          if (done.has(segment)) {
+            continue;
+          }
+          if (!segment.internal.used) {
+            for (let j = 0; j < segment.allPrevSegments.length; ++j) {
+              const prevSegment = segment.allPrevSegments[j];
+              if (!done.has(prevSegment)) {
+                done.add(prevSegment);
+              }
+            }
+          } else {
+            done.add(segment);
+          }
+        }
+        return [...done];
+      }
+    };
+    module.exports = CodePathSegment;
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/fork-context.js
+var require_fork_context = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/fork-context.js"(exports, module) {
+    "use strict";
+    var assert = require_assert();
+    var CodePathSegment = require_code_path_segment();
+    function isReachable(segment) {
+      return segment.reachable;
+    }
+    function createSegments(context, startIndex, endIndex, create) {
+      const list = context.segmentsList;
+      const normalizedBegin = startIndex >= 0 ? startIndex : list.length + startIndex;
+      const normalizedEnd = endIndex >= 0 ? endIndex : list.length + endIndex;
+      const segments = [];
+      for (let i = 0; i < context.count; ++i) {
+        const allPrevSegments = [];
+        for (let j = normalizedBegin; j <= normalizedEnd; ++j) {
+          allPrevSegments.push(list[j][i]);
+        }
+        segments.push(create(context.idGenerator.next(), allPrevSegments));
+      }
+      return segments;
+    }
+    function mergeExtraSegments(context, segments) {
+      let currentSegments = segments;
+      while (currentSegments.length > context.count) {
+        const merged = [];
+        for (let i = 0, length = Math.floor(currentSegments.length / 2); i < length; ++i) {
+          merged.push(CodePathSegment.newNext(
+            context.idGenerator.next(),
+            [currentSegments[i], currentSegments[i + length]]
+          ));
+        }
+        currentSegments = merged;
+      }
+      return currentSegments;
+    }
+    var ForkContext = class _ForkContext {
+      /**
+       * Creates a new instance.
+       * @param {IdGenerator} idGenerator An identifier generator for segments.
+       * @param {ForkContext|null} upper The preceding fork context.
+       * @param {number} count The number of parallel segments in each element
+       *      of `segmentsList`.
+       */
+      constructor(idGenerator, upper, count) {
+        this.idGenerator = idGenerator;
+        this.upper = upper;
+        this.count = count;
+        this.segmentsList = [];
+      }
+      /**
+       * The segments that begin this fork context.
+       * @type {Array<CodePathSegment>}
+       */
+      get head() {
+        const list = this.segmentsList;
+        return list.length === 0 ? [] : list[list.length - 1];
+      }
+      /**
+       * Indicates if the context contains no segments.
+       * @type {boolean}
+       */
+      get empty() {
+        return this.segmentsList.length === 0;
+      }
+      /**
+       * Indicates if there are any segments that are reachable.
+       * @type {boolean}
+       */
+      get reachable() {
+        const segments = this.head;
+        return segments.length > 0 && segments.some(isReachable);
+      }
+      /**
+       * Creates new segments in this context and appends them to the end of the
+       * already existing `CodePathSegment`s specified by `startIndex` and
+       * `endIndex`.
+       * @param {number} startIndex The index of the first segment in the context
+       *      that should be specified as previous segments for the newly created segments.
+       * @param {number} endIndex The index of the last segment in the context
+       *      that should be specified as previous segments for the newly created segments.
+       * @returns {Array<CodePathSegment>} An array of the newly created segments.
+       */
+      makeNext(startIndex, endIndex) {
+        return createSegments(this, startIndex, endIndex, CodePathSegment.newNext);
+      }
+      /**
+       * Creates new unreachable segments in this context and appends them to the end of the
+       * already existing `CodePathSegment`s specified by `startIndex` and
+       * `endIndex`.
+       * @param {number} startIndex The index of the first segment in the context
+       *      that should be specified as previous segments for the newly created segments.
+       * @param {number} endIndex The index of the last segment in the context
+       *      that should be specified as previous segments for the newly created segments.
+       * @returns {Array<CodePathSegment>} An array of the newly created segments.
+       */
+      makeUnreachable(startIndex, endIndex) {
+        return createSegments(this, startIndex, endIndex, CodePathSegment.newUnreachable);
+      }
+      /**
+       * Creates new segments in this context and does not append them to the end
+       *  of the already existing `CodePathSegment`s specified by `startIndex` and
+       * `endIndex`. The `startIndex` and `endIndex` are only used to determine if
+       * the new segments should be reachable. If any of the segments in this range
+       * are reachable then the new segments are also reachable; otherwise, the new
+       * segments are unreachable.
+       * @param {number} startIndex The index of the first segment in the context
+       *      that should be considered for reachability.
+       * @param {number} endIndex The index of the last segment in the context
+       *      that should be considered for reachability.
+       * @returns {Array<CodePathSegment>} An array of the newly created segments.
+       */
+      makeDisconnected(startIndex, endIndex) {
+        return createSegments(this, startIndex, endIndex, CodePathSegment.newDisconnected);
+      }
+      /**
+       * Adds segments to the head of this context.
+       * @param {Array<CodePathSegment>} segments The segments to add.
+       * @returns {void}
+       */
+      add(segments) {
+        assert(segments.length >= this.count, `${segments.length} >= ${this.count}`);
+        this.segmentsList.push(mergeExtraSegments(this, segments));
+      }
+      /**
+       * Replaces the head segments with the given segments.
+       * The current head segments are removed.
+       * @param {Array<CodePathSegment>} replacementHeadSegments The new head segments.
+       * @returns {void}
+       */
+      replaceHead(replacementHeadSegments) {
+        assert(
+          replacementHeadSegments.length >= this.count,
+          `${replacementHeadSegments.length} >= ${this.count}`
+        );
+        this.segmentsList.splice(-1, 1, mergeExtraSegments(this, replacementHeadSegments));
+      }
+      /**
+       * Adds all segments of a given fork context into this context.
+       * @param {ForkContext} otherForkContext The fork context to add from.
+       * @returns {void}
+       */
+      addAll(otherForkContext) {
+        assert(otherForkContext.count === this.count);
+        this.segmentsList.push(...otherForkContext.segmentsList);
+      }
+      /**
+       * Clears all segments in this context.
+       * @returns {void}
+       */
+      clear() {
+        this.segmentsList = [];
+      }
+      /**
+       * Creates a new root context, meaning that there are no parent
+       * fork contexts.
+       * @param {IdGenerator} idGenerator An identifier generator for segments.
+       * @returns {ForkContext} New fork context.
+       */
+      static newRoot(idGenerator) {
+        const context = new _ForkContext(idGenerator, null, 1);
+        context.add([CodePathSegment.newRoot(idGenerator.next())]);
+        return context;
+      }
+      /**
+       * Creates an empty fork context preceded by a given context.
+       * @param {ForkContext} parentContext The parent fork context.
+       * @param {boolean} shouldForkLeavingPath Indicates that we are inside of
+       *      a `finally` block and should therefore fork the path that leaves
+       *      `finally`.
+       * @returns {ForkContext} New fork context.
+       */
+      static newEmpty(parentContext, shouldForkLeavingPath) {
+        return new _ForkContext(
+          parentContext.idGenerator,
+          parentContext,
+          (shouldForkLeavingPath ? 2 : 1) * parentContext.count
+        );
+      }
+    };
+    module.exports = ForkContext;
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path-state.js
+var require_code_path_state = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path-state.js"(exports, module) {
+    "use strict";
+    var CodePathSegment = require_code_path_segment();
+    var ForkContext = require_fork_context();
+    var BreakContext = class {
+      /**
+       * Creates a new instance.
+       * @param {BreakContext} upperContext The previous `BreakContext`.
+       * @param {boolean} breakable Indicates if we are inside a statement where
+       *      `break` without a label will exit the statement.
+       * @param {string|null} label The label for the statement.
+       * @param {ForkContext} forkContext The current fork context.
+       */
+      constructor(upperContext, breakable, label, forkContext) {
+        this.upper = upperContext;
+        this.breakable = breakable;
+        this.label = label;
+        this.brokenForkContext = ForkContext.newEmpty(forkContext);
+      }
+    };
+    var ChainContext = class {
+      /**
+       * Creates a new instance.
+       * @param {ChainContext} upperContext The previous `ChainContext`.
+       */
+      constructor(upperContext) {
+        this.upper = upperContext;
+        this.choiceContextCount = 0;
+      }
+    };
+    var ChoiceContext = class {
+      /**
+       * Creates a new instance.
+       * @param {ChoiceContext} upperContext The previous `ChoiceContext`.
+       * @param {string} kind The kind of choice. If it's a logical or assignment expression, this
+       *      is `"&&"` or `"||"` or `"??"`; if it's an `if` statement or
+       *      conditional expression, this is `"test"`; otherwise, this is `"loop"`.
+       * @param {boolean} isForkingAsResult Indicates if the result of the choice
+       *      creates a fork.
+       * @param {ForkContext} forkContext The containing `ForkContext`.
+       */
+      constructor(upperContext, kind, isForkingAsResult, forkContext) {
+        this.upper = upperContext;
+        this.kind = kind;
+        this.isForkingAsResult = isForkingAsResult;
+        this.trueForkContext = ForkContext.newEmpty(forkContext);
+        this.falseForkContext = ForkContext.newEmpty(forkContext);
+        this.nullishForkContext = ForkContext.newEmpty(forkContext);
+        this.processed = false;
+      }
+    };
+    var LoopContextBase = class {
+      /**
+       * Creates a new instance.
+       * @param {LoopContext|null} upperContext The previous `LoopContext`.
+       * @param {string} type The AST node's `type` for the loop.
+       * @param {string|null} label The label for the loop from an enclosing `LabeledStatement`.
+       * @param {BreakContext} breakContext The context for breaking the loop.
+       */
+      constructor(upperContext, type, label, breakContext) {
+        this.upper = upperContext;
+        this.type = type;
+        this.label = label;
+        this.brokenForkContext = breakContext.brokenForkContext;
+      }
+    };
+    var WhileLoopContext = class extends LoopContextBase {
+      /**
+       * Creates a new instance.
+       * @param {LoopContext|null} upperContext The previous `LoopContext`.
+       * @param {string|null} label The label for the loop from an enclosing `LabeledStatement`.
+       * @param {BreakContext} breakContext The context for breaking the loop.
+       */
+      constructor(upperContext, label, breakContext) {
+        super(upperContext, "WhileStatement", label, breakContext);
+        this.test = void 0;
+        this.continueDestSegments = null;
+      }
+    };
+    var DoWhileLoopContext = class extends LoopContextBase {
+      /**
+       * Creates a new instance.
+       * @param {LoopContext|null} upperContext The previous `LoopContext`.
+       * @param {string|null} label The label for the loop from an enclosing `LabeledStatement`.
+       * @param {BreakContext} breakContext The context for breaking the loop.
+       * @param {ForkContext} forkContext The enclosing fork context.
+       */
+      constructor(upperContext, label, breakContext, forkContext) {
+        super(upperContext, "DoWhileStatement", label, breakContext);
+        this.test = void 0;
+        this.entrySegments = null;
+        this.continueForkContext = ForkContext.newEmpty(forkContext);
+      }
+    };
+    var ForLoopContext = class extends LoopContextBase {
+      /**
+       * Creates a new instance.
+       * @param {LoopContext|null} upperContext The previous `LoopContext`.
+       * @param {string|null} label The label for the loop from an enclosing `LabeledStatement`.
+       * @param {BreakContext} breakContext The context for breaking the loop.
+       */
+      constructor(upperContext, label, breakContext) {
+        super(upperContext, "ForStatement", label, breakContext);
+        this.test = void 0;
+        this.endOfInitSegments = null;
+        this.testSegments = null;
+        this.endOfTestSegments = null;
+        this.updateSegments = null;
+        this.endOfUpdateSegments = null;
+        this.continueDestSegments = null;
+      }
+    };
+    var ForInLoopContext = class extends LoopContextBase {
+      /**
+       * Creates a new instance.
+       * @param {LoopContext|null} upperContext The previous `LoopContext`.
+       * @param {string|null} label The label for the loop from an enclosing `LabeledStatement`.
+       * @param {BreakContext} breakContext The context for breaking the loop.
+       */
+      constructor(upperContext, label, breakContext) {
+        super(upperContext, "ForInStatement", label, breakContext);
+        this.prevSegments = null;
+        this.leftSegments = null;
+        this.endOfLeftSegments = null;
+        this.continueDestSegments = null;
+      }
+    };
+    var ForOfLoopContext = class extends LoopContextBase {
+      /**
+       * Creates a new instance.
+       * @param {LoopContext|null} upperContext The previous `LoopContext`.
+       * @param {string|null} label The label for the loop from an enclosing `LabeledStatement`.
+       * @param {BreakContext} breakContext The context for breaking the loop.
+       */
+      constructor(upperContext, label, breakContext) {
+        super(upperContext, "ForOfStatement", label, breakContext);
+        this.prevSegments = null;
+        this.leftSegments = null;
+        this.endOfLeftSegments = null;
+        this.continueDestSegments = null;
+      }
+    };
+    var SwitchContext = class {
+      /**
+       * Creates a new instance.
+       * @param {SwitchContext} upperContext The previous context.
+       * @param {boolean} hasCase Indicates if there is at least one `case` statement.
+       *      `default` doesn't count.
+       */
+      constructor(upperContext, hasCase) {
+        this.upper = upperContext;
+        this.hasCase = hasCase;
+        this.defaultSegments = null;
+        this.defaultBodySegments = null;
+        this.foundEmptyDefault = false;
+        this.lastIsDefault = false;
+        this.forkCount = 0;
+      }
+    };
+    var TryContext = class {
+      /**
+       * Creates a new instance.
+       * @param {TryContext} upperContext The previous context.
+       * @param {boolean} hasFinalizer Indicates if the `try` statement has a
+       *      `finally` block.
+       * @param {ForkContext} forkContext The enclosing fork context.
+       */
+      constructor(upperContext, hasFinalizer, forkContext) {
+        this.upper = upperContext;
+        this.hasFinalizer = hasFinalizer;
+        this.position = "try";
+        this.returnedForkContext = hasFinalizer ? ForkContext.newEmpty(forkContext) : null;
+        this.thrownForkContext = ForkContext.newEmpty(forkContext);
+        this.lastOfTryIsReachable = false;
+        this.lastOfCatchIsReachable = false;
+      }
+    };
+    function addToReturnedOrThrown(dest, others, all, segments) {
+      for (let i = 0; i < segments.length; ++i) {
+        const segment = segments[i];
+        dest.push(segment);
+        if (!others.includes(segment)) {
+          all.push(segment);
+        }
+      }
+    }
+    function getContinueContext(state, label) {
+      if (!label) {
+        return state.loopContext;
+      }
+      let context = state.loopContext;
+      while (context) {
+        if (context.label === label) {
+          return context;
+        }
+        context = context.upper;
+      }
+      return null;
+    }
+    function getBreakContext(state, label) {
+      let context = state.breakContext;
+      while (context) {
+        if (label ? context.label === label : context.breakable) {
+          return context;
+        }
+        context = context.upper;
+      }
+      return null;
+    }
+    function getReturnContext(state) {
+      let context = state.tryContext;
+      while (context) {
+        if (context.hasFinalizer && context.position !== "finally") {
+          return context;
+        }
+        context = context.upper;
+      }
+      return state;
+    }
+    function getThrowContext(state) {
+      let context = state.tryContext;
+      while (context) {
+        if (context.position === "try" || context.hasFinalizer && context.position === "catch") {
+          return context;
+        }
+        context = context.upper;
+      }
+      return state;
+    }
+    function removeFromArray(elements, value) {
+      elements.splice(elements.indexOf(value), 1);
+    }
+    function disconnectSegments(prevSegments, nextSegments) {
+      for (let i = 0; i < prevSegments.length; ++i) {
+        const prevSegment = prevSegments[i];
+        const nextSegment = nextSegments[i];
+        removeFromArray(prevSegment.nextSegments, nextSegment);
+        removeFromArray(prevSegment.allNextSegments, nextSegment);
+        removeFromArray(nextSegment.prevSegments, prevSegment);
+        removeFromArray(nextSegment.allPrevSegments, prevSegment);
+      }
+    }
+    function makeLooped(state, unflattenedFromSegments, unflattenedToSegments) {
+      const fromSegments = CodePathSegment.flattenUnusedSegments(unflattenedFromSegments);
+      const toSegments = CodePathSegment.flattenUnusedSegments(unflattenedToSegments);
+      const end = Math.min(fromSegments.length, toSegments.length);
+      for (let i = 0; i < end; ++i) {
+        const fromSegment = fromSegments[i];
+        const toSegment = toSegments[i];
+        if (toSegment.reachable) {
+          fromSegment.nextSegments.push(toSegment);
+        }
+        if (fromSegment.reachable) {
+          toSegment.prevSegments.push(fromSegment);
+        }
+        fromSegment.allNextSegments.push(toSegment);
+        toSegment.allPrevSegments.push(fromSegment);
+        if (toSegment.allPrevSegments.length >= 2) {
+          CodePathSegment.markPrevSegmentAsLooped(toSegment, fromSegment);
+        }
+        state.notifyLooped(fromSegment, toSegment);
+      }
+    }
+    function finalizeTestSegmentsOfFor(context, choiceContext, head) {
+      if (!choiceContext.processed) {
+        choiceContext.trueForkContext.add(head);
+        choiceContext.falseForkContext.add(head);
+        choiceContext.nullishForkContext.add(head);
+      }
+      if (context.test !== true) {
+        context.brokenForkContext.addAll(choiceContext.falseForkContext);
+      }
+      context.endOfTestSegments = choiceContext.trueForkContext.makeNext(0, -1);
+    }
+    var CodePathState = class {
+      /**
+       * Creates a new instance.
+       * @param {IdGenerator} idGenerator An id generator to generate id for code
+       *   path segments.
+       * @param {Function} onLooped A callback function to notify looping.
+       */
+      constructor(idGenerator, onLooped) {
+        this.idGenerator = idGenerator;
+        this.notifyLooped = onLooped;
+        this.forkContext = ForkContext.newRoot(idGenerator);
+        this.choiceContext = null;
+        this.switchContext = null;
+        this.tryContext = null;
+        this.loopContext = null;
+        this.breakContext = null;
+        this.chainContext = null;
+        this.currentSegments = [];
+        this.initialSegment = this.forkContext.head[0];
+        this.finalSegments = [];
+        this.returnedForkContext = [];
+        this.thrownForkContext = [];
+        const final = this.finalSegments;
+        const returned = this.returnedForkContext;
+        const thrown = this.thrownForkContext;
+        returned.add = addToReturnedOrThrown.bind(null, returned, thrown, final);
+        thrown.add = addToReturnedOrThrown.bind(null, thrown, returned, final);
+      }
+      /**
+       * A passthrough property exposing the current pointer as part of the API.
+       * @type {CodePathSegment[]}
+       */
+      get headSegments() {
+        return this.forkContext.head;
+      }
+      /**
+       * The parent forking context.
+       * This is used for the root of new forks.
+       * @type {ForkContext}
+       */
+      get parentForkContext() {
+        const current = this.forkContext;
+        return current && current.upper;
+      }
+      /**
+       * Creates and stacks new forking context.
+       * @param {boolean} forkLeavingPath A flag which shows being in a
+       *   "finally" block.
+       * @returns {ForkContext} The created context.
+       */
+      pushForkContext(forkLeavingPath) {
+        this.forkContext = ForkContext.newEmpty(
+          this.forkContext,
+          forkLeavingPath
+        );
+        return this.forkContext;
+      }
+      /**
+       * Pops and merges the last forking context.
+       * @returns {ForkContext} The last context.
+       */
+      popForkContext() {
+        const lastContext = this.forkContext;
+        this.forkContext = lastContext.upper;
+        this.forkContext.replaceHead(lastContext.makeNext(0, -1));
+        return lastContext;
+      }
+      /**
+       * Creates a new path.
+       * @returns {void}
+       */
+      forkPath() {
+        this.forkContext.add(this.parentForkContext.makeNext(-1, -1));
+      }
+      /**
+       * Creates a bypass path.
+       * This is used for such as IfStatement which does not have "else" chunk.
+       * @returns {void}
+       */
+      forkBypassPath() {
+        this.forkContext.add(this.parentForkContext.head);
+      }
+      //--------------------------------------------------------------------------
+      // ConditionalExpression, LogicalExpression, IfStatement
+      //--------------------------------------------------------------------------
+      /**
+       * Creates a context for ConditionalExpression, LogicalExpression, AssignmentExpression (logical assignments only),
+       * IfStatement, WhileStatement, DoWhileStatement, or ForStatement.
+       *
+       * LogicalExpressions have cases that it goes different paths between the
+       * `true` case and the `false` case.
+       *
+       * For Example:
+       *
+       *     if (a || b) {
+       *         foo();
+       *     } else {
+       *         bar();
+       *     }
+       *
+       * In this case, `b` is evaluated always in the code path of the `else`
+       * block, but it's not so in the code path of the `if` block.
+       * So there are 3 paths.
+       *
+       *     a -> foo();
+       *     a -> b -> foo();
+       *     a -> b -> bar();
+       * @param {string} kind A kind string.
+       *   If the new context is LogicalExpression's or AssignmentExpression's, this is `"&&"` or `"||"` or `"??"`.
+       *   If it's IfStatement's or ConditionalExpression's, this is `"test"`.
+       *   Otherwise, this is `"loop"`.
+       * @param {boolean} isForkingAsResult Indicates if the result of the choice
+       *      creates a fork.
+       * @returns {void}
+       */
+      pushChoiceContext(kind, isForkingAsResult) {
+        this.choiceContext = new ChoiceContext(this.choiceContext, kind, isForkingAsResult, this.forkContext);
+      }
+      /**
+       * Pops the last choice context and finalizes it.
+       * This is called upon leaving a node that represents a choice.
+       * @throws {Error} (Unreachable.)
+       * @returns {ChoiceContext} The popped context.
+       */
+      popChoiceContext() {
+        const poppedChoiceContext = this.choiceContext;
+        const forkContext = this.forkContext;
+        const head = forkContext.head;
+        this.choiceContext = poppedChoiceContext.upper;
+        switch (poppedChoiceContext.kind) {
+          case "&&":
+          case "||":
+          case "??":
+            if (!poppedChoiceContext.processed) {
+              poppedChoiceContext.trueForkContext.add(head);
+              poppedChoiceContext.falseForkContext.add(head);
+              poppedChoiceContext.nullishForkContext.add(head);
+            }
+            if (poppedChoiceContext.isForkingAsResult) {
+              const parentContext = this.choiceContext;
+              parentContext.trueForkContext.addAll(poppedChoiceContext.trueForkContext);
+              parentContext.falseForkContext.addAll(poppedChoiceContext.falseForkContext);
+              parentContext.nullishForkContext.addAll(poppedChoiceContext.nullishForkContext);
+              parentContext.processed = true;
+              return poppedChoiceContext;
+            }
+            break;
+          case "test":
+            if (!poppedChoiceContext.processed) {
+              poppedChoiceContext.trueForkContext.clear();
+              poppedChoiceContext.trueForkContext.add(head);
+            } else {
+              poppedChoiceContext.falseForkContext.clear();
+              poppedChoiceContext.falseForkContext.add(head);
+            }
+            break;
+          case "loop":
+            return poppedChoiceContext;
+          default:
+            throw new Error("unreachable");
+        }
+        const combinedForkContext = poppedChoiceContext.trueForkContext;
+        combinedForkContext.addAll(poppedChoiceContext.falseForkContext);
+        forkContext.replaceHead(combinedForkContext.makeNext(0, -1));
+        return poppedChoiceContext;
+      }
+      /**
+       * Creates a code path segment to represent right-hand operand of a logical
+       * expression.
+       * This is called in the preprocessing phase when entering a node.
+       * @throws {Error} (Unreachable.)
+       * @returns {void}
+       */
+      makeLogicalRight() {
+        const currentChoiceContext = this.choiceContext;
+        const forkContext = this.forkContext;
+        if (currentChoiceContext.processed) {
+          let prevForkContext;
+          switch (currentChoiceContext.kind) {
+            case "&&":
+              prevForkContext = currentChoiceContext.trueForkContext;
+              break;
+            case "||":
+              prevForkContext = currentChoiceContext.falseForkContext;
+              break;
+            case "??":
+              prevForkContext = currentChoiceContext.nullishForkContext;
+              break;
+            default:
+              throw new Error("unreachable");
+          }
+          forkContext.replaceHead(prevForkContext.makeNext(0, -1));
+          prevForkContext.clear();
+          currentChoiceContext.processed = false;
+        } else {
+          switch (currentChoiceContext.kind) {
+            case "&&":
+              currentChoiceContext.falseForkContext.add(forkContext.head);
+              currentChoiceContext.nullishForkContext.add(forkContext.head);
+              break;
+            case "||":
+              currentChoiceContext.trueForkContext.add(forkContext.head);
+              break;
+            case "??":
+              currentChoiceContext.trueForkContext.add(forkContext.head);
+              currentChoiceContext.falseForkContext.add(forkContext.head);
+              break;
+            default:
+              throw new Error("unreachable");
+          }
+          forkContext.replaceHead(forkContext.makeNext(-1, -1));
+        }
+      }
+      /**
+       * Makes a code path segment of the `if` block.
+       * @returns {void}
+       */
+      makeIfConsequent() {
+        const context = this.choiceContext;
+        const forkContext = this.forkContext;
+        if (!context.processed) {
+          context.trueForkContext.add(forkContext.head);
+          context.falseForkContext.add(forkContext.head);
+          context.nullishForkContext.add(forkContext.head);
+        }
+        context.processed = false;
+        forkContext.replaceHead(
+          context.trueForkContext.makeNext(0, -1)
+        );
+      }
+      /**
+       * Makes a code path segment of the `else` block.
+       * @returns {void}
+       */
+      makeIfAlternate() {
+        const context = this.choiceContext;
+        const forkContext = this.forkContext;
+        context.trueForkContext.clear();
+        context.trueForkContext.add(forkContext.head);
+        context.processed = true;
+        forkContext.replaceHead(
+          context.falseForkContext.makeNext(0, -1)
+        );
+      }
+      //--------------------------------------------------------------------------
+      // ChainExpression
+      //--------------------------------------------------------------------------
+      /**
+       * Pushes a new `ChainExpression` context to the stack. This method is
+       * called when entering a `ChainExpression` node. A chain context is used to
+       * count forking in the optional chain then merge them on the exiting from the
+       * `ChainExpression` node.
+       * @returns {void}
+       */
+      pushChainContext() {
+        this.chainContext = new ChainContext(this.chainContext);
+      }
+      /**
+       * Pop a `ChainExpression` context from the stack. This method is called on
+       * exiting from each `ChainExpression` node. This merges all forks of the
+       * last optional chaining.
+       * @returns {void}
+       */
+      popChainContext() {
+        const context = this.chainContext;
+        this.chainContext = context.upper;
+        for (let i = context.choiceContextCount; i > 0; --i) {
+          this.popChoiceContext();
+        }
+      }
+      /**
+       * Create a choice context for optional access.
+       * This method is called on entering to each `(Call|Member)Expression[optional=true]` node.
+       * This creates a choice context as similar to `LogicalExpression[operator="??"]` node.
+       * @returns {void}
+       */
+      makeOptionalNode() {
+        if (this.chainContext) {
+          this.chainContext.choiceContextCount += 1;
+          this.pushChoiceContext("??", false);
+        }
+      }
+      /**
+       * Create a fork.
+       * This method is called on entering to the `arguments|property` property of each `(Call|Member)Expression` node.
+       * @returns {void}
+       */
+      makeOptionalRight() {
+        if (this.chainContext) {
+          this.makeLogicalRight();
+        }
+      }
+      //--------------------------------------------------------------------------
+      // SwitchStatement
+      //--------------------------------------------------------------------------
+      /**
+       * Creates a context object of SwitchStatement and stacks it.
+       * @param {boolean} hasCase `true` if the switch statement has one or more
+       *   case parts.
+       * @param {string|null} label The label text.
+       * @returns {void}
+       */
+      pushSwitchContext(hasCase, label) {
+        this.switchContext = new SwitchContext(this.switchContext, hasCase);
+        this.pushBreakContext(true, label);
+      }
+      /**
+       * Pops the last context of SwitchStatement and finalizes it.
+       *
+       * - Disposes all forking stack for `case` and `default`.
+       * - Creates the next code path segment from `context.brokenForkContext`.
+       * - If the last `SwitchCase` node is not a `default` part, creates a path
+       *   to the `default` body.
+       * @returns {void}
+       */
+      popSwitchContext() {
+        const context = this.switchContext;
+        this.switchContext = context.upper;
+        const forkContext = this.forkContext;
+        const brokenForkContext = this.popBreakContext().brokenForkContext;
+        if (context.forkCount === 0) {
+          if (!brokenForkContext.empty) {
+            brokenForkContext.add(forkContext.makeNext(-1, -1));
+            forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+          }
+          return;
+        }
+        const lastSegments = forkContext.head;
+        this.forkBypassPath();
+        const lastCaseSegments = forkContext.head;
+        brokenForkContext.add(lastSegments);
+        if (!context.lastIsDefault) {
+          if (context.defaultBodySegments) {
+            disconnectSegments(context.defaultSegments, context.defaultBodySegments);
+            makeLooped(this, lastCaseSegments, context.defaultBodySegments);
+          } else {
+            brokenForkContext.add(lastCaseSegments);
+          }
+        }
+        for (let i = 0; i < context.forkCount; ++i) {
+          this.forkContext = this.forkContext.upper;
+        }
+        this.forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+      }
+      /**
+       * Makes a code path segment for a `SwitchCase` node.
+       * @param {boolean} isCaseBodyEmpty `true` if the body is empty.
+       * @param {boolean} isDefaultCase `true` if the body is the default case.
+       * @returns {void}
+       */
+      makeSwitchCaseBody(isCaseBodyEmpty, isDefaultCase) {
+        const context = this.switchContext;
+        if (!context.hasCase) {
+          return;
+        }
+        const parentForkContext = this.forkContext;
+        const forkContext = this.pushForkContext();
+        forkContext.add(parentForkContext.makeNext(0, -1));
+        if (isDefaultCase) {
+          context.defaultSegments = parentForkContext.head;
+          if (isCaseBodyEmpty) {
+            context.foundEmptyDefault = true;
+          } else {
+            context.defaultBodySegments = forkContext.head;
+          }
+        } else {
+          if (!isCaseBodyEmpty && context.foundEmptyDefault) {
+            context.foundEmptyDefault = false;
+            context.defaultBodySegments = forkContext.head;
+          }
+        }
+        context.lastIsDefault = isDefaultCase;
+        context.forkCount += 1;
+      }
+      //--------------------------------------------------------------------------
+      // TryStatement
+      //--------------------------------------------------------------------------
+      /**
+       * Creates a context object of TryStatement and stacks it.
+       * @param {boolean} hasFinalizer `true` if the try statement has a
+       *   `finally` block.
+       * @returns {void}
+       */
+      pushTryContext(hasFinalizer) {
+        this.tryContext = new TryContext(this.tryContext, hasFinalizer, this.forkContext);
+      }
+      /**
+       * Pops the last context of TryStatement and finalizes it.
+       * @returns {void}
+       */
+      popTryContext() {
+        const context = this.tryContext;
+        this.tryContext = context.upper;
+        if (context.position === "catch") {
+          this.popForkContext();
+          return;
+        }
+        const originalReturnedForkContext = context.returnedForkContext;
+        const originalThrownForkContext = context.thrownForkContext;
+        if (originalReturnedForkContext.empty && originalThrownForkContext.empty) {
+          return;
+        }
+        const headSegments = this.forkContext.head;
+        this.forkContext = this.forkContext.upper;
+        const normalSegments = headSegments.slice(0, headSegments.length / 2 | 0);
+        const leavingSegments = headSegments.slice(headSegments.length / 2 | 0);
+        if (!originalReturnedForkContext.empty) {
+          getReturnContext(this).returnedForkContext.add(leavingSegments);
+        }
+        if (!originalThrownForkContext.empty) {
+          getThrowContext(this).thrownForkContext.add(leavingSegments);
+        }
+        this.forkContext.replaceHead(normalSegments);
+        if (!context.lastOfTryIsReachable && !context.lastOfCatchIsReachable) {
+          this.forkContext.makeUnreachable();
+        }
+      }
+      /**
+       * Makes a code path segment for a `catch` block.
+       * @returns {void}
+       */
+      makeCatchBlock() {
+        const context = this.tryContext;
+        const forkContext = this.forkContext;
+        const originalThrownForkContext = context.thrownForkContext;
+        context.position = "catch";
+        context.thrownForkContext = ForkContext.newEmpty(forkContext);
+        context.lastOfTryIsReachable = forkContext.reachable;
+        originalThrownForkContext.add(forkContext.head);
+        const thrownSegments = originalThrownForkContext.makeNext(0, -1);
+        this.pushForkContext();
+        this.forkBypassPath();
+        this.forkContext.add(thrownSegments);
+      }
+      /**
+       * Makes a code path segment for a `finally` block.
+       *
+       * In the `finally` block, parallel paths are created. The parallel paths
+       * are used as leaving-paths. The leaving-paths are paths from `return`
+       * statements and `throw` statements in a `try` block or a `catch` block.
+       * @returns {void}
+       */
+      makeFinallyBlock() {
+        const context = this.tryContext;
+        let forkContext = this.forkContext;
+        const originalReturnedForkContext = context.returnedForkContext;
+        const originalThrownForContext = context.thrownForkContext;
+        const headOfLeavingSegments = forkContext.head;
+        if (context.position === "catch") {
+          this.popForkContext();
+          forkContext = this.forkContext;
+          context.lastOfCatchIsReachable = forkContext.reachable;
+        } else {
+          context.lastOfTryIsReachable = forkContext.reachable;
+        }
+        context.position = "finally";
+        if (originalReturnedForkContext.empty && originalThrownForContext.empty) {
+          return;
+        }
+        const segments = forkContext.makeNext(-1, -1);
+        for (let i = 0; i < forkContext.count; ++i) {
+          const prevSegsOfLeavingSegment = [headOfLeavingSegments[i]];
+          for (let j = 0; j < originalReturnedForkContext.segmentsList.length; ++j) {
+            prevSegsOfLeavingSegment.push(originalReturnedForkContext.segmentsList[j][i]);
+          }
+          for (let j = 0; j < originalThrownForContext.segmentsList.length; ++j) {
+            prevSegsOfLeavingSegment.push(originalThrownForContext.segmentsList[j][i]);
+          }
+          segments.push(
+            CodePathSegment.newNext(
+              this.idGenerator.next(),
+              prevSegsOfLeavingSegment
+            )
+          );
+        }
+        this.pushForkContext(true);
+        this.forkContext.add(segments);
+      }
+      /**
+       * Makes a code path segment from the first throwable node to the `catch`
+       * block or the `finally` block.
+       * @returns {void}
+       */
+      makeFirstThrowablePathInTryBlock() {
+        const forkContext = this.forkContext;
+        if (!forkContext.reachable) {
+          return;
+        }
+        const context = getThrowContext(this);
+        if (context === this || context.position !== "try" || !context.thrownForkContext.empty) {
+          return;
+        }
+        context.thrownForkContext.add(forkContext.head);
+        forkContext.replaceHead(forkContext.makeNext(-1, -1));
+      }
+      //--------------------------------------------------------------------------
+      // Loop Statements
+      //--------------------------------------------------------------------------
+      /**
+       * Creates a context object of a loop statement and stacks it.
+       * @param {string} type The type of the node which was triggered. One of
+       *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
+       *   and `ForStatement`.
+       * @param {string|null} label A label of the node which was triggered.
+       * @throws {Error} (Unreachable - unknown type.)
+       * @returns {void}
+       */
+      pushLoopContext(type, label) {
+        const forkContext = this.forkContext;
+        const breakContext = this.pushBreakContext(true, label);
+        switch (type) {
+          case "WhileStatement":
+            this.pushChoiceContext("loop", false);
+            this.loopContext = new WhileLoopContext(this.loopContext, label, breakContext);
+            break;
+          case "DoWhileStatement":
+            this.pushChoiceContext("loop", false);
+            this.loopContext = new DoWhileLoopContext(this.loopContext, label, breakContext, forkContext);
+            break;
+          case "ForStatement":
+            this.pushChoiceContext("loop", false);
+            this.loopContext = new ForLoopContext(this.loopContext, label, breakContext);
+            break;
+          case "ForInStatement":
+            this.loopContext = new ForInLoopContext(this.loopContext, label, breakContext);
+            break;
+          case "ForOfStatement":
+            this.loopContext = new ForOfLoopContext(this.loopContext, label, breakContext);
+            break;
+          default:
+            throw new Error(`unknown type: "${type}"`);
+        }
+      }
+      /**
+       * Pops the last context of a loop statement and finalizes it.
+       * @throws {Error} (Unreachable - unknown type.)
+       * @returns {void}
+       */
+      popLoopContext() {
+        const context = this.loopContext;
+        this.loopContext = context.upper;
+        const forkContext = this.forkContext;
+        const brokenForkContext = this.popBreakContext().brokenForkContext;
+        switch (context.type) {
+          case "WhileStatement":
+          case "ForStatement":
+            this.popChoiceContext();
+            makeLooped(
+              this,
+              forkContext.head,
+              context.continueDestSegments
+            );
+            break;
+          case "DoWhileStatement": {
+            const choiceContext = this.popChoiceContext();
+            if (!choiceContext.processed) {
+              choiceContext.trueForkContext.add(forkContext.head);
+              choiceContext.falseForkContext.add(forkContext.head);
+            }
+            if (context.test !== true) {
+              brokenForkContext.addAll(choiceContext.falseForkContext);
+            }
+            const segmentsList = choiceContext.trueForkContext.segmentsList;
+            for (let i = 0; i < segmentsList.length; ++i) {
+              makeLooped(
+                this,
+                segmentsList[i],
+                context.entrySegments
+              );
+            }
+            break;
+          }
+          case "ForInStatement":
+          case "ForOfStatement":
+            brokenForkContext.add(forkContext.head);
+            makeLooped(
+              this,
+              forkContext.head,
+              context.leftSegments
+            );
+            break;
+          default:
+            throw new Error("unreachable");
+        }
+        if (brokenForkContext.empty) {
+          forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+        } else {
+          forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+        }
+      }
+      /**
+       * Makes a code path segment for the test part of a WhileStatement.
+       * @param {boolean|undefined} test The test value (only when constant).
+       * @returns {void}
+       */
+      makeWhileTest(test) {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        const testSegments = forkContext.makeNext(0, -1);
+        context.test = test;
+        context.continueDestSegments = testSegments;
+        forkContext.replaceHead(testSegments);
+      }
+      /**
+       * Makes a code path segment for the body part of a WhileStatement.
+       * @returns {void}
+       */
+      makeWhileBody() {
+        const context = this.loopContext;
+        const choiceContext = this.choiceContext;
+        const forkContext = this.forkContext;
+        if (!choiceContext.processed) {
+          choiceContext.trueForkContext.add(forkContext.head);
+          choiceContext.falseForkContext.add(forkContext.head);
+        }
+        if (context.test !== true) {
+          context.brokenForkContext.addAll(choiceContext.falseForkContext);
+        }
+        forkContext.replaceHead(choiceContext.trueForkContext.makeNext(0, -1));
+      }
+      /**
+       * Makes a code path segment for the body part of a DoWhileStatement.
+       * @returns {void}
+       */
+      makeDoWhileBody() {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        const bodySegments = forkContext.makeNext(-1, -1);
+        context.entrySegments = bodySegments;
+        forkContext.replaceHead(bodySegments);
+      }
+      /**
+       * Makes a code path segment for the test part of a DoWhileStatement.
+       * @param {boolean|undefined} test The test value (only when constant).
+       * @returns {void}
+       */
+      makeDoWhileTest(test) {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        context.test = test;
+        if (!context.continueForkContext.empty) {
+          context.continueForkContext.add(forkContext.head);
+          const testSegments = context.continueForkContext.makeNext(0, -1);
+          forkContext.replaceHead(testSegments);
+        }
+      }
+      /**
+       * Makes a code path segment for the test part of a ForStatement.
+       * @param {boolean|undefined} test The test value (only when constant).
+       * @returns {void}
+       */
+      makeForTest(test) {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        const endOfInitSegments = forkContext.head;
+        const testSegments = forkContext.makeNext(-1, -1);
+        context.test = test;
+        context.endOfInitSegments = endOfInitSegments;
+        context.continueDestSegments = context.testSegments = testSegments;
+        forkContext.replaceHead(testSegments);
+      }
+      /**
+       * Makes a code path segment for the update part of a ForStatement.
+       * @returns {void}
+       */
+      makeForUpdate() {
+        const context = this.loopContext;
+        const choiceContext = this.choiceContext;
+        const forkContext = this.forkContext;
+        if (context.testSegments) {
+          finalizeTestSegmentsOfFor(
+            context,
+            choiceContext,
+            forkContext.head
+          );
+        } else {
+          context.endOfInitSegments = forkContext.head;
+        }
+        const updateSegments = forkContext.makeDisconnected(-1, -1);
+        context.continueDestSegments = context.updateSegments = updateSegments;
+        forkContext.replaceHead(updateSegments);
+      }
+      /**
+       * Makes a code path segment for the body part of a ForStatement.
+       * @returns {void}
+       */
+      makeForBody() {
+        const context = this.loopContext;
+        const choiceContext = this.choiceContext;
+        const forkContext = this.forkContext;
+        if (context.updateSegments) {
+          context.endOfUpdateSegments = forkContext.head;
+          if (context.testSegments) {
+            makeLooped(
+              this,
+              context.endOfUpdateSegments,
+              context.testSegments
+            );
+          }
+        } else if (context.testSegments) {
+          finalizeTestSegmentsOfFor(
+            context,
+            choiceContext,
+            forkContext.head
+          );
+        } else {
+          context.endOfInitSegments = forkContext.head;
+        }
+        let bodySegments = context.endOfTestSegments;
+        if (!bodySegments) {
+          const prevForkContext = ForkContext.newEmpty(forkContext);
+          prevForkContext.add(context.endOfInitSegments);
+          if (context.endOfUpdateSegments) {
+            prevForkContext.add(context.endOfUpdateSegments);
+          }
+          bodySegments = prevForkContext.makeNext(0, -1);
+        }
+        context.continueDestSegments = context.continueDestSegments || bodySegments;
+        forkContext.replaceHead(bodySegments);
+      }
+      /**
+       * Makes a code path segment for the left part of a ForInStatement and a
+       * ForOfStatement.
+       * @returns {void}
+       */
+      makeForInOfLeft() {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        const leftSegments = forkContext.makeDisconnected(-1, -1);
+        context.prevSegments = forkContext.head;
+        context.leftSegments = context.continueDestSegments = leftSegments;
+        forkContext.replaceHead(leftSegments);
+      }
+      /**
+       * Makes a code path segment for the right part of a ForInStatement and a
+       * ForOfStatement.
+       * @returns {void}
+       */
+      makeForInOfRight() {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        const temp = ForkContext.newEmpty(forkContext);
+        temp.add(context.prevSegments);
+        const rightSegments = temp.makeNext(-1, -1);
+        context.endOfLeftSegments = forkContext.head;
+        forkContext.replaceHead(rightSegments);
+      }
+      /**
+       * Makes a code path segment for the body part of a ForInStatement and a
+       * ForOfStatement.
+       * @returns {void}
+       */
+      makeForInOfBody() {
+        const context = this.loopContext;
+        const forkContext = this.forkContext;
+        const temp = ForkContext.newEmpty(forkContext);
+        temp.add(context.endOfLeftSegments);
+        const bodySegments = temp.makeNext(-1, -1);
+        makeLooped(this, forkContext.head, context.leftSegments);
+        context.brokenForkContext.add(forkContext.head);
+        forkContext.replaceHead(bodySegments);
+      }
+      //--------------------------------------------------------------------------
+      // Control Statements
+      //--------------------------------------------------------------------------
+      /**
+       * Creates new context in which a `break` statement can be used. This occurs inside of a loop,
+       * labeled statement, or switch statement.
+       * @param {boolean} breakable Indicates if we are inside a statement where
+       *      `break` without a label will exit the statement.
+       * @param {string|null} label The label associated with the statement.
+       * @returns {BreakContext} The new context.
+       */
+      pushBreakContext(breakable, label) {
+        this.breakContext = new BreakContext(this.breakContext, breakable, label, this.forkContext);
+        return this.breakContext;
+      }
+      /**
+       * Removes the top item of the break context stack.
+       * @returns {Object} The removed context.
+       */
+      popBreakContext() {
+        const context = this.breakContext;
+        const forkContext = this.forkContext;
+        this.breakContext = context.upper;
+        if (!context.breakable) {
+          const brokenForkContext = context.brokenForkContext;
+          if (!brokenForkContext.empty) {
+            brokenForkContext.add(forkContext.head);
+            forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+          }
+        }
+        return context;
+      }
+      /**
+       * Makes a path for a `break` statement.
+       *
+       * It registers the head segment to a context of `break`.
+       * It makes new unreachable segment, then it set the head with the segment.
+       * @param {string|null} label A label of the break statement.
+       * @returns {void}
+       */
+      makeBreak(label) {
+        const forkContext = this.forkContext;
+        if (!forkContext.reachable) {
+          return;
+        }
+        const context = getBreakContext(this, label);
+        if (context) {
+          context.brokenForkContext.add(forkContext.head);
+        }
+        forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+      }
+      /**
+       * Makes a path for a `continue` statement.
+       *
+       * It makes a looping path.
+       * It makes new unreachable segment, then it set the head with the segment.
+       * @param {string|null} label A label of the continue statement.
+       * @returns {void}
+       */
+      makeContinue(label) {
+        const forkContext = this.forkContext;
+        if (!forkContext.reachable) {
+          return;
+        }
+        const context = getContinueContext(this, label);
+        if (context) {
+          if (context.continueDestSegments) {
+            makeLooped(this, forkContext.head, context.continueDestSegments);
+            if (context.type === "ForInStatement" || context.type === "ForOfStatement") {
+              context.brokenForkContext.add(forkContext.head);
+            }
+          } else {
+            context.continueForkContext.add(forkContext.head);
+          }
+        }
+        forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+      }
+      /**
+       * Makes a path for a `return` statement.
+       *
+       * It registers the head segment to a context of `return`.
+       * It makes new unreachable segment, then it set the head with the segment.
+       * @returns {void}
+       */
+      makeReturn() {
+        const forkContext = this.forkContext;
+        if (forkContext.reachable) {
+          getReturnContext(this).returnedForkContext.add(forkContext.head);
+          forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+        }
+      }
+      /**
+       * Makes a path for a `throw` statement.
+       *
+       * It registers the head segment to a context of `throw`.
+       * It makes new unreachable segment, then it set the head with the segment.
+       * @returns {void}
+       */
+      makeThrow() {
+        const forkContext = this.forkContext;
+        if (forkContext.reachable) {
+          getThrowContext(this).thrownForkContext.add(forkContext.head);
+          forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+        }
+      }
+      /**
+       * Makes the final path.
+       * @returns {void}
+       */
+      makeFinal() {
+        const segments = this.currentSegments;
+        if (segments.length > 0 && segments[0].reachable) {
+          this.returnedForkContext.add(segments);
+        }
+      }
+    };
+    module.exports = CodePathState;
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/id-generator.js
+var require_id_generator = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/id-generator.js"(exports, module) {
+    "use strict";
+    var IdGenerator = class {
+      /**
+       * @param {string} prefix Optional. A prefix of generated ids.
+       */
+      constructor(prefix) {
+        this.prefix = String(prefix);
+        this.n = 0;
+      }
+      /**
+       * Generates id.
+       * @returns {string} A generated id.
+       */
+      next() {
+        this.n = 1 + this.n | 0;
+        if (this.n < 0) {
+          this.n = 1;
+        }
+        return this.prefix + this.n;
+      }
+    };
+    module.exports = IdGenerator;
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path.js
+var require_code_path = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path.js"(exports, module) {
+    "use strict";
+    var CodePathState = require_code_path_state();
+    var IdGenerator = require_id_generator();
+    var CodePath = class {
+      /**
+       * Creates a new instance.
+       * @param {Object} options Options for the function (see below).
+       * @param {string} options.id An identifier.
+       * @param {string} options.origin The type of code path origin.
+       * @param {CodePath|null} options.upper The code path of the upper function scope.
+       * @param {Function} options.onLooped A callback function to notify looping.
+       */
+      constructor({ id, origin, upper, onLooped }) {
+        this.id = id;
+        this.origin = origin;
+        this.upper = upper;
+        this.childCodePaths = [];
+        Object.defineProperty(
+          this,
+          "internal",
+          { value: new CodePathState(new IdGenerator(`${id}_`), onLooped) }
+        );
+        if (upper) {
+          upper.childCodePaths.push(this);
+        }
+      }
+      /**
+       * Gets the state of a given code path.
+       * @param {CodePath} codePath A code path to get.
+       * @returns {CodePathState} The state of the code path.
+       */
+      static getState(codePath) {
+        return codePath.internal;
+      }
+      /**
+       * The initial code path segment. This is the segment that is at the head
+       * of the code path.
+       * This is a passthrough to the underlying `CodePathState`.
+       * @type {CodePathSegment}
+       */
+      get initialSegment() {
+        return this.internal.initialSegment;
+      }
+      /**
+       * Final code path segments. These are the terminal (tail) segments in the
+       * code path, which is the combination of `returnedSegments` and `thrownSegments`.
+       * All segments in this array are reachable.
+       * This is a passthrough to the underlying `CodePathState`.
+       * @type {CodePathSegment[]}
+       */
+      get finalSegments() {
+        return this.internal.finalSegments;
+      }
+      /**
+       * Final code path segments that represent normal completion of the code path.
+       * For functions, this means both explicit `return` statements and implicit returns,
+       * such as the last reachable segment in a function that does not have an
+       * explicit `return` as this implicitly returns `undefined`. For scripts,
+       * modules, class field initializers, and class static blocks, this means
+       * all lines of code have been executed.
+       * These segments are also present in `finalSegments`.
+       * This is a passthrough to the underlying `CodePathState`.
+       * @type {CodePathSegment[]}
+       */
+      get returnedSegments() {
+        return this.internal.returnedForkContext;
+      }
+      /**
+       * Final code path segments that represent `throw` statements.
+       * This is a passthrough to the underlying `CodePathState`.
+       * These segments are also present in `finalSegments`.
+       * @type {CodePathSegment[]}
+       */
+      get thrownSegments() {
+        return this.internal.thrownForkContext;
+      }
+      /**
+       * Tracks the traversal of the code path through each segment. This array
+       * starts empty and segments are added or removed as the code path is
+       * traversed. This array always ends up empty at the end of a code path
+       * traversal. The `CodePathState` uses this to track its progress through
+       * the code path.
+       * This is a passthrough to the underlying `CodePathState`.
+       * @type {CodePathSegment[]}
+       * @deprecated
+       */
+      get currentSegments() {
+        return this.internal.currentSegments;
+      }
+      /**
+       * Traverses all segments in this code path.
+       *
+       *     codePath.traverseSegments((segment, controller) => {
+       *         // do something.
+       *     });
+       *
+       * This method enumerates segments in order from the head.
+       *
+       * The `controller` argument has two methods:
+       *
+       * - `skip()` - skips the following segments in this branch
+       * - `break()` - skips all following segments in the traversal
+       *
+       * A note on the parameters: the `options` argument is optional. This means
+       * the first argument might be an options object or the callback function.
+       * @param {Object} [optionsOrCallback] Optional first and last segments to traverse.
+       * @param {CodePathSegment} [optionsOrCallback.first] The first segment to traverse.
+       * @param {CodePathSegment} [optionsOrCallback.last] The last segment to traverse.
+       * @param {Function} callback A callback function.
+       * @returns {void}
+       */
+      traverseSegments(optionsOrCallback, callback) {
+        let resolvedOptions;
+        let resolvedCallback;
+        if (typeof optionsOrCallback === "function") {
+          resolvedCallback = optionsOrCallback;
+          resolvedOptions = {};
+        } else {
+          resolvedOptions = optionsOrCallback || {};
+          resolvedCallback = callback;
+        }
+        const startSegment = resolvedOptions.first || this.internal.initialSegment;
+        const lastSegment = resolvedOptions.last;
+        let record = null;
+        let index = 0;
+        let end = 0;
+        let segment = null;
+        const visited = /* @__PURE__ */ new Set();
+        const stack = [[startSegment, 0]];
+        let skippedSegment = null;
+        let broken = false;
+        const controller = {
+          /**
+           * Skip the following segments in this branch.
+           * @returns {void}
+           */
+          skip() {
+            if (stack.length <= 1) {
+              broken = true;
+            } else {
+              skippedSegment = stack[stack.length - 2][0];
+            }
+          },
+          /**
+           * Stop traversal completely - do not traverse to any
+           * other segments.
+           * @returns {void}
+           */
+          break() {
+            broken = true;
+          }
+        };
+        function isVisited(prevSegment) {
+          return visited.has(prevSegment) || segment.isLoopedPrevSegment(prevSegment);
+        }
+        while (stack.length > 0) {
+          record = stack[stack.length - 1];
+          segment = record[0];
+          index = record[1];
+          if (index === 0) {
+            if (visited.has(segment)) {
+              stack.pop();
+              continue;
+            }
+            if (segment !== startSegment && segment.prevSegments.length > 0 && !segment.prevSegments.every(isVisited)) {
+              stack.pop();
+              continue;
+            }
+            if (skippedSegment && segment.prevSegments.includes(skippedSegment)) {
+              skippedSegment = null;
+            }
+            visited.add(segment);
+            if (!skippedSegment) {
+              resolvedCallback.call(this, segment, controller);
+              if (segment === lastSegment) {
+                controller.skip();
+              }
+              if (broken) {
+                break;
+              }
+            }
+          }
+          end = segment.nextSegments.length - 1;
+          if (index < end) {
+            record[1] += 1;
+            stack.push([segment.nextSegments[index], 0]);
+          } else if (index === end) {
+            record[0] = segment.nextSegments[index];
+            record[1] = 0;
+          } else {
+            stack.pop();
+          }
+        }
+      }
+    };
+    module.exports = CodePath;
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js
+var require_code_path_analyzer = __commonJS({
+  "../../node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js"(exports, module) {
+    "use strict";
+    var assert = require_assert();
+    var { breakableTypePattern } = require_ast_utils();
+    var CodePath = require_code_path();
+    var CodePathSegment = require_code_path_segment();
+    var IdGenerator = require_id_generator();
+    var debug = require_debug_helpers();
+    function isCaseNode(node) {
+      return Boolean(node.test);
+    }
+    function isPropertyDefinitionValue(node) {
+      const parent = node.parent;
+      return parent && parent.type === "PropertyDefinition" && parent.value === node;
+    }
+    function isHandledLogicalOperator(operator) {
+      return operator === "&&" || operator === "||" || operator === "??";
+    }
+    function isLogicalAssignmentOperator(operator) {
+      return operator === "&&=" || operator === "||=" || operator === "??=";
+    }
+    function getLabel(node) {
+      if (node.parent.type === "LabeledStatement") {
+        return node.parent.label.name;
+      }
+      return null;
+    }
+    function isForkingByTrueOrFalse(node) {
+      const parent = node.parent;
+      switch (parent.type) {
+        case "ConditionalExpression":
+        case "IfStatement":
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "ForStatement":
+          return parent.test === node;
+        case "LogicalExpression":
+          return isHandledLogicalOperator(parent.operator);
+        case "AssignmentExpression":
+          return isLogicalAssignmentOperator(parent.operator);
+        default:
+          return false;
+      }
+    }
+    function getBooleanValueIfSimpleConstant(node) {
+      if (node.type === "Literal") {
+        return Boolean(node.value);
+      }
+      return void 0;
+    }
+    function isIdentifierReference(node) {
+      const parent = node.parent;
+      switch (parent.type) {
+        case "LabeledStatement":
+        case "BreakStatement":
+        case "ContinueStatement":
+        case "ArrayPattern":
+        case "RestElement":
+        case "ImportSpecifier":
+        case "ImportDefaultSpecifier":
+        case "ImportNamespaceSpecifier":
+        case "CatchClause":
+          return false;
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+        case "ClassDeclaration":
+        case "ClassExpression":
+        case "VariableDeclarator":
+          return parent.id !== node;
+        case "Property":
+        case "PropertyDefinition":
+        case "MethodDefinition":
+          return parent.key !== node || parent.computed || parent.shorthand;
+        case "AssignmentPattern":
+          return parent.key !== node;
+        default:
+          return true;
+      }
+    }
+    function forwardCurrentToHead(analyzer, node) {
+      const codePath = analyzer.codePath;
+      const state = CodePath.getState(codePath);
+      const currentSegments = state.currentSegments;
+      const headSegments = state.headSegments;
+      const end = Math.max(currentSegments.length, headSegments.length);
+      let i, currentSegment, headSegment;
+      for (i = 0; i < end; ++i) {
+        currentSegment = currentSegments[i];
+        headSegment = headSegments[i];
+        if (currentSegment !== headSegment && currentSegment) {
+          const eventName = currentSegment.reachable ? "onCodePathSegmentEnd" : "onUnreachableCodePathSegmentEnd";
+          debug.dump(`${eventName} ${currentSegment.id}`);
+          analyzer.emitter.emit(
+            eventName,
+            currentSegment,
+            node
+          );
+        }
+      }
+      state.currentSegments = headSegments;
+      for (i = 0; i < end; ++i) {
+        currentSegment = currentSegments[i];
+        headSegment = headSegments[i];
+        if (currentSegment !== headSegment && headSegment) {
+          const eventName = headSegment.reachable ? "onCodePathSegmentStart" : "onUnreachableCodePathSegmentStart";
+          debug.dump(`${eventName} ${headSegment.id}`);
+          CodePathSegment.markUsed(headSegment);
+          analyzer.emitter.emit(
+            eventName,
+            headSegment,
+            node
+          );
+        }
+      }
+    }
+    function leaveFromCurrentSegment(analyzer, node) {
+      const state = CodePath.getState(analyzer.codePath);
+      const currentSegments = state.currentSegments;
+      for (let i = 0; i < currentSegments.length; ++i) {
+        const currentSegment = currentSegments[i];
+        const eventName = currentSegment.reachable ? "onCodePathSegmentEnd" : "onUnreachableCodePathSegmentEnd";
+        debug.dump(`${eventName} ${currentSegment.id}`);
+        analyzer.emitter.emit(
+          eventName,
+          currentSegment,
+          node
+        );
+      }
+      state.currentSegments = [];
+    }
+    function preprocess(analyzer, node) {
+      const codePath = analyzer.codePath;
+      const state = CodePath.getState(codePath);
+      const parent = node.parent;
+      switch (parent.type) {
+        case "CallExpression":
+          if (parent.optional === true && parent.arguments.length >= 1 && parent.arguments[0] === node) {
+            state.makeOptionalRight();
+          }
+          break;
+        case "MemberExpression":
+          if (parent.optional === true && parent.property === node) {
+            state.makeOptionalRight();
+          }
+          break;
+        case "LogicalExpression":
+          if (parent.right === node && isHandledLogicalOperator(parent.operator)) {
+            state.makeLogicalRight();
+          }
+          break;
+        case "AssignmentExpression":
+          if (parent.right === node && isLogicalAssignmentOperator(parent.operator)) {
+            state.makeLogicalRight();
+          }
+          break;
+        case "ConditionalExpression":
+        case "IfStatement":
+          if (parent.consequent === node) {
+            state.makeIfConsequent();
+          } else if (parent.alternate === node) {
+            state.makeIfAlternate();
+          }
+          break;
+        case "SwitchCase":
+          if (parent.consequent[0] === node) {
+            state.makeSwitchCaseBody(false, !parent.test);
+          }
+          break;
+        case "TryStatement":
+          if (parent.handler === node) {
+            state.makeCatchBlock();
+          } else if (parent.finalizer === node) {
+            state.makeFinallyBlock();
+          }
+          break;
+        case "WhileStatement":
+          if (parent.test === node) {
+            state.makeWhileTest(getBooleanValueIfSimpleConstant(node));
+          } else {
+            assert(parent.body === node);
+            state.makeWhileBody();
+          }
+          break;
+        case "DoWhileStatement":
+          if (parent.body === node) {
+            state.makeDoWhileBody();
+          } else {
+            assert(parent.test === node);
+            state.makeDoWhileTest(getBooleanValueIfSimpleConstant(node));
+          }
+          break;
+        case "ForStatement":
+          if (parent.test === node) {
+            state.makeForTest(getBooleanValueIfSimpleConstant(node));
+          } else if (parent.update === node) {
+            state.makeForUpdate();
+          } else if (parent.body === node) {
+            state.makeForBody();
+          }
+          break;
+        case "ForInStatement":
+        case "ForOfStatement":
+          if (parent.left === node) {
+            state.makeForInOfLeft();
+          } else if (parent.right === node) {
+            state.makeForInOfRight();
+          } else {
+            assert(parent.body === node);
+            state.makeForInOfBody();
+          }
+          break;
+        case "AssignmentPattern":
+          if (parent.right === node) {
+            state.pushForkContext();
+            state.forkBypassPath();
+            state.forkPath();
+          }
+          break;
+        default:
+          break;
+      }
+    }
+    function processCodePathToEnter(analyzer, node) {
+      let codePath = analyzer.codePath;
+      let state = codePath && CodePath.getState(codePath);
+      const parent = node.parent;
+      function startCodePath(origin) {
+        if (codePath) {
+          forwardCurrentToHead(analyzer, node);
+          debug.dumpState(node, state, false);
+        }
+        codePath = analyzer.codePath = new CodePath({
+          id: analyzer.idGenerator.next(),
+          origin,
+          upper: codePath,
+          onLooped: analyzer.onLooped
+        });
+        state = CodePath.getState(codePath);
+        debug.dump(`onCodePathStart ${codePath.id}`);
+        analyzer.emitter.emit("onCodePathStart", codePath, node);
+      }
+      if (isPropertyDefinitionValue(node)) {
+        startCodePath("class-field-initializer");
+      }
+      switch (node.type) {
+        case "Program":
+          startCodePath("program");
+          break;
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+          startCodePath("function");
+          break;
+        case "StaticBlock":
+          startCodePath("class-static-block");
+          break;
+        case "ChainExpression":
+          state.pushChainContext();
+          break;
+        case "CallExpression":
+          if (node.optional === true) {
+            state.makeOptionalNode();
+          }
+          break;
+        case "MemberExpression":
+          if (node.optional === true) {
+            state.makeOptionalNode();
+          }
+          break;
+        case "LogicalExpression":
+          if (isHandledLogicalOperator(node.operator)) {
+            state.pushChoiceContext(
+              node.operator,
+              isForkingByTrueOrFalse(node)
+            );
+          }
+          break;
+        case "AssignmentExpression":
+          if (isLogicalAssignmentOperator(node.operator)) {
+            state.pushChoiceContext(
+              node.operator.slice(0, -1),
+              // removes `=` from the end
+              isForkingByTrueOrFalse(node)
+            );
+          }
+          break;
+        case "ConditionalExpression":
+        case "IfStatement":
+          state.pushChoiceContext("test", false);
+          break;
+        case "SwitchStatement":
+          state.pushSwitchContext(
+            node.cases.some(isCaseNode),
+            getLabel(node)
+          );
+          break;
+        case "TryStatement":
+          state.pushTryContext(Boolean(node.finalizer));
+          break;
+        case "SwitchCase":
+          if (parent.discriminant !== node && parent.cases[0] !== node) {
+            state.forkPath();
+          }
+          break;
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "ForStatement":
+        case "ForInStatement":
+        case "ForOfStatement":
+          state.pushLoopContext(node.type, getLabel(node));
+          break;
+        case "LabeledStatement":
+          if (!breakableTypePattern.test(node.body.type)) {
+            state.pushBreakContext(false, node.label.name);
+          }
+          break;
+        default:
+          break;
+      }
+      forwardCurrentToHead(analyzer, node);
+      debug.dumpState(node, state, false);
+    }
+    function processCodePathToExit(analyzer, node) {
+      const codePath = analyzer.codePath;
+      const state = CodePath.getState(codePath);
+      let dontForward = false;
+      switch (node.type) {
+        case "ChainExpression":
+          state.popChainContext();
+          break;
+        case "IfStatement":
+        case "ConditionalExpression":
+          state.popChoiceContext();
+          break;
+        case "LogicalExpression":
+          if (isHandledLogicalOperator(node.operator)) {
+            state.popChoiceContext();
+          }
+          break;
+        case "AssignmentExpression":
+          if (isLogicalAssignmentOperator(node.operator)) {
+            state.popChoiceContext();
+          }
+          break;
+        case "SwitchStatement":
+          state.popSwitchContext();
+          break;
+        case "SwitchCase":
+          if (node.consequent.length === 0) {
+            state.makeSwitchCaseBody(true, !node.test);
+          }
+          if (state.forkContext.reachable) {
+            dontForward = true;
+          }
+          break;
+        case "TryStatement":
+          state.popTryContext();
+          break;
+        case "BreakStatement":
+          forwardCurrentToHead(analyzer, node);
+          state.makeBreak(node.label && node.label.name);
+          dontForward = true;
+          break;
+        case "ContinueStatement":
+          forwardCurrentToHead(analyzer, node);
+          state.makeContinue(node.label && node.label.name);
+          dontForward = true;
+          break;
+        case "ReturnStatement":
+          forwardCurrentToHead(analyzer, node);
+          state.makeReturn();
+          dontForward = true;
+          break;
+        case "ThrowStatement":
+          forwardCurrentToHead(analyzer, node);
+          state.makeThrow();
+          dontForward = true;
+          break;
+        case "Identifier":
+          if (isIdentifierReference(node)) {
+            state.makeFirstThrowablePathInTryBlock();
+            dontForward = true;
+          }
+          break;
+        case "CallExpression":
+        case "ImportExpression":
+        case "MemberExpression":
+        case "NewExpression":
+        case "YieldExpression":
+          state.makeFirstThrowablePathInTryBlock();
+          break;
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "ForStatement":
+        case "ForInStatement":
+        case "ForOfStatement":
+          state.popLoopContext();
+          break;
+        case "AssignmentPattern":
+          state.popForkContext();
+          break;
+        case "LabeledStatement":
+          if (!breakableTypePattern.test(node.body.type)) {
+            state.popBreakContext();
+          }
+          break;
+        default:
+          break;
+      }
+      if (!dontForward) {
+        forwardCurrentToHead(analyzer, node);
+      }
+      debug.dumpState(node, state, true);
+    }
+    function postprocess(analyzer, node) {
+      function endCodePath() {
+        let codePath = analyzer.codePath;
+        CodePath.getState(codePath).makeFinal();
+        leaveFromCurrentSegment(analyzer, node);
+        debug.dump(`onCodePathEnd ${codePath.id}`);
+        analyzer.emitter.emit("onCodePathEnd", codePath, node);
+        debug.dumpDot(codePath);
+        codePath = analyzer.codePath = analyzer.codePath.upper;
+        if (codePath) {
+          debug.dumpState(node, CodePath.getState(codePath), true);
+        }
+      }
+      switch (node.type) {
+        case "Program":
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+        case "StaticBlock": {
+          endCodePath();
+          break;
+        }
+        case "CallExpression":
+          if (node.optional === true && node.arguments.length === 0) {
+            CodePath.getState(analyzer.codePath).makeOptionalRight();
+          }
+          break;
+        default:
+          break;
+      }
+      if (isPropertyDefinitionValue(node)) {
+        endCodePath();
+      }
+    }
+    var CodePathAnalyzer = class {
+      /**
+       * @param {EventGenerator} eventGenerator An event generator to wrap.
+       */
+      constructor(eventGenerator) {
+        this.original = eventGenerator;
+        this.emitter = eventGenerator.emitter;
+        this.codePath = null;
+        this.idGenerator = new IdGenerator("s");
+        this.currentNode = null;
+        this.onLooped = this.onLooped.bind(this);
+      }
+      /**
+       * Does the process to enter a given AST node.
+       * This updates state of analysis and calls `enterNode` of the wrapped.
+       * @param {ASTNode} node A node which is entering.
+       * @returns {void}
+       */
+      enterNode(node) {
+        this.currentNode = node;
+        if (node.parent) {
+          preprocess(this, node);
+        }
+        processCodePathToEnter(this, node);
+        this.original.enterNode(node);
+        this.currentNode = null;
+      }
+      /**
+       * Does the process to leave a given AST node.
+       * This updates state of analysis and calls `leaveNode` of the wrapped.
+       * @param {ASTNode} node A node which is leaving.
+       * @returns {void}
+       */
+      leaveNode(node) {
+        this.currentNode = node;
+        processCodePathToExit(this, node);
+        this.original.leaveNode(node);
+        postprocess(this, node);
+        this.currentNode = null;
+      }
+      /**
+       * This is called on a code path looped.
+       * Then this raises a looped event.
+       * @param {CodePathSegment} fromSegment A segment of prev.
+       * @param {CodePathSegment} toSegment A segment of next.
+       * @returns {void}
+       */
+      onLooped(fromSegment, toSegment) {
+        if (fromSegment.reachable && toSegment.reachable) {
+          debug.dump(`onCodePathSegmentLoop ${fromSegment.id} -> ${toSegment.id}`);
+          this.emitter.emit(
+            "onCodePathSegmentLoop",
+            fromSegment,
+            toSegment,
+            this.currentNode
+          );
+        }
+      }
+    };
+    module.exports = CodePathAnalyzer;
+  }
+});
+
+// ../../node_modules/escape-string-regexp/index.js
+var require_escape_string_regexp = __commonJS({
+  "../../node_modules/escape-string-regexp/index.js"(exports, module) {
+    "use strict";
+    module.exports = (string) => {
+      if (typeof string !== "string") {
+        throw new TypeError("Expected a string");
+      }
+      return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
+    };
+  }
+});
+
+// ../../node_modules/eslint/lib/linter/apply-disable-directives.js
+var require_apply_disable_directives = __commonJS({
+  "../../node_modules/eslint/lib/linter/apply-disable-directives.js"(exports, module) {
+    "use strict";
+    var escapeRegExp = require_escape_string_regexp();
+    function compareLocations(itemA, itemB) {
+      return itemA.line - itemB.line || itemA.column - itemB.column;
+    }
+    function groupByParentComment(directives) {
+      const groups = /* @__PURE__ */ new Map();
+      for (const directive of directives) {
+        const { unprocessedDirective: { parentComment } } = directive;
+        if (groups.has(parentComment)) {
+          groups.get(parentComment).push(directive);
+        } else {
+          groups.set(parentComment, [directive]);
+        }
+      }
+      return [...groups.values()];
+    }
+    function createIndividualDirectivesRemoval(directives, commentToken) {
+      const commentValueStart = commentToken.range[0] + "//".length;
+      const listStartOffset = /^\s*\S+\s+/u.exec(commentToken.value)[0].length;
+      const listText = commentToken.value.slice(listStartOffset).split(/\s-{2,}\s/u)[0].trimEnd();
+      return directives.map((directive) => {
+        const { ruleId } = directive;
+        const regex = new RegExp(String.raw`(?:^|\s*,\s*)(?<quote>['"]?)${escapeRegExp(ruleId)}\k<quote>(?:\s*,\s*|$)`, "u");
+        const match = regex.exec(listText);
+        const matchedText = match[0];
+        const matchStartOffset = listStartOffset + match.index;
+        const matchEndOffset = matchStartOffset + matchedText.length;
+        const firstIndexOfComma = matchedText.indexOf(",");
+        const lastIndexOfComma = matchedText.lastIndexOf(",");
+        let removalStartOffset, removalEndOffset;
+        if (firstIndexOfComma !== lastIndexOfComma) {
+          removalStartOffset = matchStartOffset + firstIndexOfComma;
+          removalEndOffset = matchStartOffset + lastIndexOfComma;
+        } else {
+          removalStartOffset = matchStartOffset;
+          removalEndOffset = matchEndOffset;
+        }
+        return {
+          description: `'${ruleId}'`,
+          fix: {
+            range: [
+              commentValueStart + removalStartOffset,
+              commentValueStart + removalEndOffset
+            ],
+            text: ""
+          },
+          unprocessedDirective: directive.unprocessedDirective
+        };
+      });
+    }
+    function createCommentRemoval(directives, commentToken) {
+      const { range } = commentToken;
+      const ruleIds = directives.filter((directive) => directive.ruleId).map((directive) => `'${directive.ruleId}'`);
+      return {
+        description: ruleIds.length <= 2 ? ruleIds.join(" or ") : `${ruleIds.slice(0, ruleIds.length - 1).join(", ")}, or ${ruleIds[ruleIds.length - 1]}`,
+        fix: {
+          range,
+          text: " "
+        },
+        unprocessedDirective: directives[0].unprocessedDirective
+      };
+    }
+    function processUnusedDirectives(allDirectives) {
+      const directiveGroups = groupByParentComment(allDirectives);
+      return directiveGroups.flatMap(
+        (directives) => {
+          const { parentComment } = directives[0].unprocessedDirective;
+          const remainingRuleIds = new Set(parentComment.ruleIds);
+          for (const directive of directives) {
+            remainingRuleIds.delete(directive.ruleId);
+          }
+          return remainingRuleIds.size ? createIndividualDirectivesRemoval(directives, parentComment.commentToken) : [createCommentRemoval(directives, parentComment.commentToken)];
+        }
+      );
+    }
+    function collectUsedEnableDirectives(directives) {
+      const enabledRules = /* @__PURE__ */ new Map();
+      const usedEnableDirectives = /* @__PURE__ */ new Set();
+      for (let index = directives.length - 1; index >= 0; index--) {
+        const directive = directives[index];
+        if (directive.type === "disable") {
+          if (enabledRules.size === 0) {
+            continue;
+          }
+          if (directive.ruleId === null) {
+            for (const enableDirective of enabledRules.values()) {
+              usedEnableDirectives.add(enableDirective);
+            }
+            enabledRules.clear();
+          } else {
+            const enableDirective = enabledRules.get(directive.ruleId);
+            if (enableDirective) {
+              usedEnableDirectives.add(enableDirective);
+            } else {
+              const enabledDirectiveWithoutRuleId = enabledRules.get(null);
+              if (enabledDirectiveWithoutRuleId) {
+                usedEnableDirectives.add(enabledDirectiveWithoutRuleId);
+              }
+            }
+          }
+        } else if (directive.type === "enable") {
+          if (directive.ruleId === null) {
+            enabledRules.clear();
+            enabledRules.set(null, directive);
+          } else {
+            enabledRules.set(directive.ruleId, directive);
+          }
+        }
+      }
+      return usedEnableDirectives;
+    }
+    function applyDirectives(options) {
+      const problems = [];
+      const usedDisableDirectives = /* @__PURE__ */ new Set();
+      for (const problem of options.problems) {
+        let disableDirectivesForProblem = [];
+        let nextDirectiveIndex = 0;
+        while (nextDirectiveIndex < options.directives.length && compareLocations(options.directives[nextDirectiveIndex], problem) <= 0) {
+          const directive = options.directives[nextDirectiveIndex++];
+          if (directive.ruleId === null || directive.ruleId === problem.ruleId) {
+            switch (directive.type) {
+              case "disable":
+                disableDirectivesForProblem.push(directive);
+                break;
+              case "enable":
+                disableDirectivesForProblem = [];
+                break;
+            }
+          }
+        }
+        if (disableDirectivesForProblem.length > 0) {
+          const suppressions = disableDirectivesForProblem.map((directive) => ({
+            kind: "directive",
+            justification: directive.unprocessedDirective.justification
+          }));
+          if (problem.suppressions) {
+            problem.suppressions = problem.suppressions.concat(suppressions);
+          } else {
+            problem.suppressions = suppressions;
+            usedDisableDirectives.add(disableDirectivesForProblem[disableDirectivesForProblem.length - 1]);
+          }
+        }
+        problems.push(problem);
+      }
+      const unusedDisableDirectivesToReport = options.directives.filter((directive) => directive.type === "disable" && !usedDisableDirectives.has(directive));
+      const unusedEnableDirectivesToReport = new Set(
+        options.directives.filter((directive) => directive.unprocessedDirective.type === "enable")
+      );
+      if (unusedEnableDirectivesToReport.size > 0) {
+        for (const directive of collectUsedEnableDirectives(options.directives)) {
+          unusedEnableDirectivesToReport.delete(directive);
+        }
+      }
+      const processed = processUnusedDirectives(unusedDisableDirectivesToReport).concat(processUnusedDirectives(unusedEnableDirectivesToReport));
+      const unusedDirectives = processed.map(({ description, fix, unprocessedDirective }) => {
+        const { parentComment, type, line, column } = unprocessedDirective;
+        let message;
+        if (type === "enable") {
+          message = description ? `Unused eslint-enable directive (no matching eslint-disable directives were found for ${description}).` : "Unused eslint-enable directive (no matching eslint-disable directives were found).";
+        } else {
+          message = description ? `Unused eslint-disable directive (no problems were reported from ${description}).` : "Unused eslint-disable directive (no problems were reported).";
+        }
+        return {
+          ruleId: null,
+          message,
+          line: type === "disable-next-line" ? parentComment.commentToken.loc.start.line : line,
+          column: type === "disable-next-line" ? parentComment.commentToken.loc.start.column + 1 : column,
+          severity: options.reportUnusedDisableDirectives === "warn" ? 1 : 2,
+          nodeType: null,
+          ...options.disableFixes ? {} : { fix }
+        };
+      });
+      return { problems, unusedDirectives };
+    }
+    module.exports = ({ directives, disableFixes, problems, reportUnusedDisableDirectives = "off" }) => {
+      const blockDirectives = directives.filter((directive) => directive.type === "disable" || directive.type === "enable").map((directive) => Object.assign({}, directive, { unprocessedDirective: directive })).sort(compareLocations);
+      const lineDirectives = directives.flatMap((directive) => {
+        switch (directive.type) {
+          case "disable":
+          case "enable":
+            return [];
+          case "disable-line":
+            return [
+              { type: "disable", line: directive.line, column: 1, ruleId: directive.ruleId, unprocessedDirective: directive },
+              { type: "enable", line: directive.line + 1, column: 0, ruleId: directive.ruleId, unprocessedDirective: directive }
+            ];
+          case "disable-next-line":
+            return [
+              { type: "disable", line: directive.line + 1, column: 1, ruleId: directive.ruleId, unprocessedDirective: directive },
+              { type: "enable", line: directive.line + 2, column: 0, ruleId: directive.ruleId, unprocessedDirective: directive }
+            ];
+          default:
+            throw new TypeError(`Unrecognized directive type '${directive.type}'`);
+        }
+      }).sort(compareLocations);
+      const blockDirectivesResult = applyDirectives({
+        problems,
+        directives: blockDirectives,
+        disableFixes,
+        reportUnusedDisableDirectives
+      });
+      const lineDirectivesResult = applyDirectives({
+        problems: blockDirectivesResult.problems,
+        directives: lineDirectives,
+        disableFixes,
+        reportUnusedDisableDirectives
+      });
+      return reportUnusedDisableDirectives !== "off" ? lineDirectivesResult.problems.concat(blockDirectivesResult.unusedDirectives).concat(lineDirectivesResult.unusedDirectives).sort(compareLocations) : lineDirectivesResult.problems;
     };
   }
 });
@@ -32846,13 +34419,17 @@ var require_esquery_min = __commonJS({
             }(t2) + " found.";
           }, { SyntaxError: e3, parse: function(t2, r2) {
             r2 = void 0 !== r2 ? r2 : {};
-            var n2, o2, a2, i2, s2 = {}, u2 = { start: de }, l2 = de, c2 = ce(" ", false), f2 = /^[^ [\],():#!=><~+.]/, p2 = fe([" ", "[", "]", ",", "(", ")", ":", "#", "!", "=", ">", "<", "~", "+", "."], true, false), h2 = ce(">", false), y2 = ce("~", false), d2 = ce("+", false), m2 = ce(",", false), x2 = ce("!", false), v2 = ce("*", false), g2 = ce("#", false), A2 = ce("[", false), E = ce("]", false), b = /^[><!]/, S = fe([">", "<", "!"], false, false), _ = ce("=", false), C = function(e4) {
+            var n2, o2, a2, i2, s2 = {}, u2 = { start: me }, l2 = me, c2 = fe(" ", false), f2 = /^[^ [\],():#!=><~+.]/, p2 = pe([" ", "[", "]", ",", "(", ")", ":", "#", "!", "=", ">", "<", "~", "+", "."], true, false), h2 = fe(">", false), y2 = fe("~", false), d2 = fe("+", false), m2 = fe(",", false), x2 = function(e4, t3) {
+              return [e4].concat(t3.map(function(e5) {
+                return e5[3];
+              }));
+            }, v2 = fe("!", false), g2 = fe("*", false), A2 = fe("#", false), E = fe("[", false), b = fe("]", false), S = /^[><!]/, _ = pe([">", "<", "!"], false, false), C = fe("=", false), w = function(e4) {
               return (e4 || "") + "=";
-            }, w = /^[><]/, P = fe([">", "<"], false, false), k = ce(".", false), D = function(e4, t3, r3) {
+            }, P = /^[><]/, k = pe([">", "<"], false, false), D = fe(".", false), I = function(e4, t3, r3) {
               return { type: "attribute", name: e4, operator: t3, value: r3 };
-            }, I = ce('"', false), j = /^[^\\"]/, T = fe(["\\", '"'], true, false), F = ce("\\", false), R = { type: "any" }, O = function(e4, t3) {
+            }, j = fe('"', false), T = /^[^\\"]/, F = pe(["\\", '"'], true, false), R = fe("\\", false), O = { type: "any" }, L = function(e4, t3) {
               return e4 + t3;
-            }, L = function(e4) {
+            }, M = function(e4) {
               return { type: "literal", value: (t3 = e4.join(""), t3.replace(/\\(.)/g, function(e5, t4) {
                 switch (t4) {
                   case "b":
@@ -32872,294 +34449,307 @@ var require_esquery_min = __commonJS({
                 }
               })) };
               var t3;
-            }, M = ce("'", false), B = /^[^\\']/, U = fe(["\\", "'"], true, false), K = /^[0-9]/, W = fe([["0", "9"]], false, false), q = ce("type(", false), V = /^[^ )]/, N = fe([" ", ")"], true, false), G = ce(")", false), z = /^[imsu]/, H = fe(["i", "m", "s", "u"], false, false), Y = ce("/", false), $ = /^[^\/]/, J = fe(["/"], true, false), Q = ce(":not(", false), X = ce(":matches(", false), Z = ce(":has(", false), ee = ce(":first-child", false), te = ce(":last-child", false), re = ce(":nth-child(", false), ne = ce(":nth-last-child(", false), oe = ce(":", false), ae = 0, ie = [{ line: 1, column: 1 }], se = 0, ue = [], le = {};
+            }, B = fe("'", false), U = /^[^\\']/, K = pe(["\\", "'"], true, false), N = /^[0-9]/, W = pe([["0", "9"]], false, false), q = fe("type(", false), V = /^[^ )]/, G = pe([" ", ")"], true, false), z = fe(")", false), H = /^[imsu]/, Y = pe(["i", "m", "s", "u"], false, false), $ = fe("/", false), J = /^[^\/]/, Q = pe(["/"], true, false), X = fe(":not(", false), Z = fe(":matches(", false), ee = fe(":has(", false), te = fe(":first-child", false), re = fe(":last-child", false), ne = fe(":nth-child(", false), oe = fe(":nth-last-child(", false), ae = fe(":", false), ie = 0, se = [{ line: 1, column: 1 }], ue = 0, le = [], ce = {};
             if ("startRule" in r2) {
               if (!(r2.startRule in u2))
                 throw new Error(`Can't start parsing from rule "` + r2.startRule + '".');
               l2 = u2[r2.startRule];
             }
-            function ce(e4, t3) {
+            function fe(e4, t3) {
               return { type: "literal", text: e4, ignoreCase: t3 };
             }
-            function fe(e4, t3, r3) {
+            function pe(e4, t3, r3) {
               return { type: "class", parts: e4, inverted: t3, ignoreCase: r3 };
             }
-            function pe(e4) {
-              var r3, n3 = ie[e4];
+            function he(e4) {
+              var r3, n3 = se[e4];
               if (n3)
                 return n3;
-              for (r3 = e4 - 1; !ie[r3]; )
+              for (r3 = e4 - 1; !se[r3]; )
                 r3--;
-              for (n3 = { line: (n3 = ie[r3]).line, column: n3.column }; r3 < e4; )
+              for (n3 = { line: (n3 = se[r3]).line, column: n3.column }; r3 < e4; )
                 10 === t2.charCodeAt(r3) ? (n3.line++, n3.column = 1) : n3.column++, r3++;
-              return ie[e4] = n3, n3;
+              return se[e4] = n3, n3;
             }
-            function he(e4, t3) {
-              var r3 = pe(e4), n3 = pe(t3);
+            function ye(e4, t3) {
+              var r3 = he(e4), n3 = he(t3);
               return { start: { offset: e4, line: r3.line, column: r3.column }, end: { offset: t3, line: n3.line, column: n3.column } };
             }
-            function ye(e4) {
-              ae < se || (ae > se && (se = ae, ue = []), ue.push(e4));
-            }
-            function de() {
-              var e4, t3, r3, n3, o3 = 30 * ae + 0, a3 = le[o3];
-              return a3 ? (ae = a3.nextPos, a3.result) : (e4 = ae, (t3 = me()) !== s2 && (r3 = ge()) !== s2 && me() !== s2 ? e4 = t3 = 1 === (n3 = r3).length ? n3[0] : { type: "matches", selectors: n3 } : (ae = e4, e4 = s2), e4 === s2 && (e4 = ae, (t3 = me()) !== s2 && (t3 = void 0), e4 = t3), le[o3] = { nextPos: ae, result: e4 }, e4);
+            function de(e4) {
+              ie < ue || (ie > ue && (ue = ie, le = []), le.push(e4));
             }
             function me() {
-              var e4, r3, n3 = 30 * ae + 1, o3 = le[n3];
-              if (o3)
-                return ae = o3.nextPos, o3.result;
-              for (e4 = [], 32 === t2.charCodeAt(ae) ? (r3 = " ", ae++) : (r3 = s2, ye(c2)); r3 !== s2; )
-                e4.push(r3), 32 === t2.charCodeAt(ae) ? (r3 = " ", ae++) : (r3 = s2, ye(c2));
-              return le[n3] = { nextPos: ae, result: e4 }, e4;
+              var e4, t3, r3, n3, o3 = 32 * ie + 0, a3 = ce[o3];
+              return a3 ? (ie = a3.nextPos, a3.result) : (e4 = ie, (t3 = xe()) !== s2 && (r3 = Ae()) !== s2 && xe() !== s2 ? e4 = t3 = 1 === (n3 = r3).length ? n3[0] : { type: "matches", selectors: n3 } : (ie = e4, e4 = s2), e4 === s2 && (e4 = ie, (t3 = xe()) !== s2 && (t3 = void 0), e4 = t3), ce[o3] = { nextPos: ie, result: e4 }, e4);
             }
             function xe() {
-              var e4, r3, n3, o3 = 30 * ae + 2, a3 = le[o3];
-              if (a3)
-                return ae = a3.nextPos, a3.result;
-              if (r3 = [], f2.test(t2.charAt(ae)) ? (n3 = t2.charAt(ae), ae++) : (n3 = s2, ye(p2)), n3 !== s2)
-                for (; n3 !== s2; )
-                  r3.push(n3), f2.test(t2.charAt(ae)) ? (n3 = t2.charAt(ae), ae++) : (n3 = s2, ye(p2));
-              else
-                r3 = s2;
-              return r3 !== s2 && (r3 = r3.join("")), e4 = r3, le[o3] = { nextPos: ae, result: e4 }, e4;
+              var e4, r3, n3 = 32 * ie + 1, o3 = ce[n3];
+              if (o3)
+                return ie = o3.nextPos, o3.result;
+              for (e4 = [], 32 === t2.charCodeAt(ie) ? (r3 = " ", ie++) : (r3 = s2, de(c2)); r3 !== s2; )
+                e4.push(r3), 32 === t2.charCodeAt(ie) ? (r3 = " ", ie++) : (r3 = s2, de(c2));
+              return ce[n3] = { nextPos: ie, result: e4 }, e4;
             }
             function ve() {
-              var e4, r3, n3, o3 = 30 * ae + 3, a3 = le[o3];
-              return a3 ? (ae = a3.nextPos, a3.result) : (e4 = ae, (r3 = me()) !== s2 ? (62 === t2.charCodeAt(ae) ? (n3 = ">", ae++) : (n3 = s2, ye(h2)), n3 !== s2 && me() !== s2 ? e4 = r3 = "child" : (ae = e4, e4 = s2)) : (ae = e4, e4 = s2), e4 === s2 && (e4 = ae, (r3 = me()) !== s2 ? (126 === t2.charCodeAt(ae) ? (n3 = "~", ae++) : (n3 = s2, ye(y2)), n3 !== s2 && me() !== s2 ? e4 = r3 = "sibling" : (ae = e4, e4 = s2)) : (ae = e4, e4 = s2), e4 === s2 && (e4 = ae, (r3 = me()) !== s2 ? (43 === t2.charCodeAt(ae) ? (n3 = "+", ae++) : (n3 = s2, ye(d2)), n3 !== s2 && me() !== s2 ? e4 = r3 = "adjacent" : (ae = e4, e4 = s2)) : (ae = e4, e4 = s2), e4 === s2 && (e4 = ae, 32 === t2.charCodeAt(ae) ? (r3 = " ", ae++) : (r3 = s2, ye(c2)), r3 !== s2 && (n3 = me()) !== s2 ? e4 = r3 = "descendant" : (ae = e4, e4 = s2)))), le[o3] = { nextPos: ae, result: e4 }, e4);
+              var e4, r3, n3, o3 = 32 * ie + 2, a3 = ce[o3];
+              if (a3)
+                return ie = a3.nextPos, a3.result;
+              if (r3 = [], f2.test(t2.charAt(ie)) ? (n3 = t2.charAt(ie), ie++) : (n3 = s2, de(p2)), n3 !== s2)
+                for (; n3 !== s2; )
+                  r3.push(n3), f2.test(t2.charAt(ie)) ? (n3 = t2.charAt(ie), ie++) : (n3 = s2, de(p2));
+              else
+                r3 = s2;
+              return r3 !== s2 && (r3 = r3.join("")), e4 = r3, ce[o3] = { nextPos: ie, result: e4 }, e4;
             }
             function ge() {
-              var e4, r3, n3, o3, a3, i3, u3, l3, c3 = 30 * ae + 4, f3 = le[c3];
-              if (f3)
-                return ae = f3.nextPos, f3.result;
-              if (e4 = ae, (r3 = Ae()) !== s2) {
-                for (n3 = [], o3 = ae, (a3 = me()) !== s2 ? (44 === t2.charCodeAt(ae) ? (i3 = ",", ae++) : (i3 = s2, ye(m2)), i3 !== s2 && (u3 = me()) !== s2 && (l3 = Ae()) !== s2 ? o3 = a3 = [a3, i3, u3, l3] : (ae = o3, o3 = s2)) : (ae = o3, o3 = s2); o3 !== s2; )
-                  n3.push(o3), o3 = ae, (a3 = me()) !== s2 ? (44 === t2.charCodeAt(ae) ? (i3 = ",", ae++) : (i3 = s2, ye(m2)), i3 !== s2 && (u3 = me()) !== s2 && (l3 = Ae()) !== s2 ? o3 = a3 = [a3, i3, u3, l3] : (ae = o3, o3 = s2)) : (ae = o3, o3 = s2);
-                n3 !== s2 ? e4 = r3 = [r3].concat(n3.map(function(e5) {
-                  return e5[3];
-                })) : (ae = e4, e4 = s2);
-              } else
-                ae = e4, e4 = s2;
-              return le[c3] = { nextPos: ae, result: e4 }, e4;
+              var e4, r3, n3, o3 = 32 * ie + 3, a3 = ce[o3];
+              return a3 ? (ie = a3.nextPos, a3.result) : (e4 = ie, (r3 = xe()) !== s2 ? (62 === t2.charCodeAt(ie) ? (n3 = ">", ie++) : (n3 = s2, de(h2)), n3 !== s2 && xe() !== s2 ? e4 = r3 = "child" : (ie = e4, e4 = s2)) : (ie = e4, e4 = s2), e4 === s2 && (e4 = ie, (r3 = xe()) !== s2 ? (126 === t2.charCodeAt(ie) ? (n3 = "~", ie++) : (n3 = s2, de(y2)), n3 !== s2 && xe() !== s2 ? e4 = r3 = "sibling" : (ie = e4, e4 = s2)) : (ie = e4, e4 = s2), e4 === s2 && (e4 = ie, (r3 = xe()) !== s2 ? (43 === t2.charCodeAt(ie) ? (n3 = "+", ie++) : (n3 = s2, de(d2)), n3 !== s2 && xe() !== s2 ? e4 = r3 = "adjacent" : (ie = e4, e4 = s2)) : (ie = e4, e4 = s2), e4 === s2 && (e4 = ie, 32 === t2.charCodeAt(ie) ? (r3 = " ", ie++) : (r3 = s2, de(c2)), r3 !== s2 && (n3 = xe()) !== s2 ? e4 = r3 = "descendant" : (ie = e4, e4 = s2)))), ce[o3] = { nextPos: ie, result: e4 }, e4);
             }
             function Ae() {
-              var e4, t3, r3, n3, o3, a3, i3, u3 = 30 * ae + 5, l3 = le[u3];
-              if (l3)
-                return ae = l3.nextPos, l3.result;
-              if (e4 = ae, (t3 = Ee()) !== s2) {
-                for (r3 = [], n3 = ae, (o3 = ve()) !== s2 && (a3 = Ee()) !== s2 ? n3 = o3 = [o3, a3] : (ae = n3, n3 = s2); n3 !== s2; )
-                  r3.push(n3), n3 = ae, (o3 = ve()) !== s2 && (a3 = Ee()) !== s2 ? n3 = o3 = [o3, a3] : (ae = n3, n3 = s2);
-                r3 !== s2 ? (i3 = t3, e4 = t3 = r3.reduce(function(e5, t4) {
-                  return { type: t4[0], left: e5, right: t4[1] };
-                }, i3)) : (ae = e4, e4 = s2);
+              var e4, r3, n3, o3, a3, i3, u3, l3, c3 = 32 * ie + 5, f3 = ce[c3];
+              if (f3)
+                return ie = f3.nextPos, f3.result;
+              if (e4 = ie, (r3 = be()) !== s2) {
+                for (n3 = [], o3 = ie, (a3 = xe()) !== s2 ? (44 === t2.charCodeAt(ie) ? (i3 = ",", ie++) : (i3 = s2, de(m2)), i3 !== s2 && (u3 = xe()) !== s2 && (l3 = be()) !== s2 ? o3 = a3 = [a3, i3, u3, l3] : (ie = o3, o3 = s2)) : (ie = o3, o3 = s2); o3 !== s2; )
+                  n3.push(o3), o3 = ie, (a3 = xe()) !== s2 ? (44 === t2.charCodeAt(ie) ? (i3 = ",", ie++) : (i3 = s2, de(m2)), i3 !== s2 && (u3 = xe()) !== s2 && (l3 = be()) !== s2 ? o3 = a3 = [a3, i3, u3, l3] : (ie = o3, o3 = s2)) : (ie = o3, o3 = s2);
+                n3 !== s2 ? e4 = r3 = x2(r3, n3) : (ie = e4, e4 = s2);
               } else
-                ae = e4, e4 = s2;
-              return le[u3] = { nextPos: ae, result: e4 }, e4;
+                ie = e4, e4 = s2;
+              return ce[c3] = { nextPos: ie, result: e4 }, e4;
             }
             function Ee() {
-              var e4, r3, n3, o3, a3, i3, u3, l3 = 30 * ae + 6, c3 = le[l3];
-              if (c3)
-                return ae = c3.nextPos, c3.result;
-              if (e4 = ae, 33 === t2.charCodeAt(ae) ? (r3 = "!", ae++) : (r3 = s2, ye(x2)), r3 === s2 && (r3 = null), r3 !== s2) {
-                if (n3 = [], (o3 = be()) !== s2)
-                  for (; o3 !== s2; )
-                    n3.push(o3), o3 = be();
-                else
-                  n3 = s2;
-                n3 !== s2 ? (a3 = r3, u3 = 1 === (i3 = n3).length ? i3[0] : { type: "compound", selectors: i3 }, a3 && (u3.subject = true), e4 = r3 = u3) : (ae = e4, e4 = s2);
-              } else
-                ae = e4, e4 = s2;
-              return le[l3] = { nextPos: ae, result: e4 }, e4;
+              var e4, t3, r3, n3, o3, a3 = 32 * ie + 6, i3 = ce[a3];
+              return i3 ? (ie = i3.nextPos, i3.result) : (e4 = ie, (t3 = ge()) === s2 && (t3 = null), t3 !== s2 && (r3 = be()) !== s2 ? (o3 = r3, e4 = t3 = (n3 = t3) ? { type: n3, left: { type: "exactNode" }, right: o3 } : o3) : (ie = e4, e4 = s2), ce[a3] = { nextPos: ie, result: e4 }, e4);
             }
             function be() {
-              var e4, r3 = 30 * ae + 7, n3 = le[r3];
-              return n3 ? (ae = n3.nextPos, n3.result) : ((e4 = function() {
-                var e5, r4, n4 = 30 * ae + 8, o3 = le[n4];
-                return o3 ? (ae = o3.nextPos, o3.result) : (42 === t2.charCodeAt(ae) ? (r4 = "*", ae++) : (r4 = s2, ye(v2)), r4 !== s2 && (r4 = { type: "wildcard", value: r4 }), e5 = r4, le[n4] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3 = 30 * ae + 9, a3 = le[o3];
-                return a3 ? (ae = a3.nextPos, a3.result) : (e5 = ae, 35 === t2.charCodeAt(ae) ? (r4 = "#", ae++) : (r4 = s2, ye(g2)), r4 === s2 && (r4 = null), r4 !== s2 && (n4 = xe()) !== s2 ? e5 = r4 = { type: "identifier", value: n4 } : (ae = e5, e5 = s2), le[o3] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3 = 30 * ae + 10, i3 = le[a3];
-                return i3 ? (ae = i3.nextPos, i3.result) : (e5 = ae, 91 === t2.charCodeAt(ae) ? (r4 = "[", ae++) : (r4 = s2, ye(A2)), r4 !== s2 && me() !== s2 && (n4 = function() {
-                  var e6, r5, n5, o4, a4 = 30 * ae + 14, i4 = le[a4];
-                  return i4 ? (ae = i4.nextPos, i4.result) : (e6 = ae, (r5 = Se()) !== s2 && me() !== s2 && (n5 = function() {
-                    var e7, r6, n6, o5 = 30 * ae + 12, a5 = le[o5];
-                    return a5 ? (ae = a5.nextPos, a5.result) : (e7 = ae, 33 === t2.charCodeAt(ae) ? (r6 = "!", ae++) : (r6 = s2, ye(x2)), r6 === s2 && (r6 = null), r6 !== s2 ? (61 === t2.charCodeAt(ae) ? (n6 = "=", ae++) : (n6 = s2, ye(_)), n6 !== s2 ? (r6 = C(r6), e7 = r6) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2), le[o5] = { nextPos: ae, result: e7 }, e7);
-                  }()) !== s2 && me() !== s2 ? ((o4 = function() {
-                    var e7, r6, n6, o5, a5, i5 = 30 * ae + 18, u3 = le[i5];
-                    if (u3)
-                      return ae = u3.nextPos, u3.result;
-                    if (e7 = ae, "type(" === t2.substr(ae, 5) ? (r6 = "type(", ae += 5) : (r6 = s2, ye(q)), r6 !== s2)
-                      if (me() !== s2) {
-                        if (n6 = [], V.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(N)), o5 !== s2)
-                          for (; o5 !== s2; )
-                            n6.push(o5), V.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(N));
-                        else
-                          n6 = s2;
-                        n6 !== s2 && (o5 = me()) !== s2 ? (41 === t2.charCodeAt(ae) ? (a5 = ")", ae++) : (a5 = s2, ye(G)), a5 !== s2 ? (r6 = { type: "type", value: n6.join("") }, e7 = r6) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2);
-                      } else
-                        ae = e7, e7 = s2;
-                    else
-                      ae = e7, e7 = s2;
-                    return le[i5] = { nextPos: ae, result: e7 }, e7;
-                  }()) === s2 && (o4 = function() {
-                    var e7, r6, n6, o5, a5, i5, u3 = 30 * ae + 20, l3 = le[u3];
-                    if (l3)
-                      return ae = l3.nextPos, l3.result;
-                    if (e7 = ae, 47 === t2.charCodeAt(ae) ? (r6 = "/", ae++) : (r6 = s2, ye(Y)), r6 !== s2) {
-                      if (n6 = [], $.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(J)), o5 !== s2)
-                        for (; o5 !== s2; )
-                          n6.push(o5), $.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(J));
-                      else
-                        n6 = s2;
-                      n6 !== s2 ? (47 === t2.charCodeAt(ae) ? (o5 = "/", ae++) : (o5 = s2, ye(Y)), o5 !== s2 ? ((a5 = function() {
-                        var e8, r7, n7 = 30 * ae + 19, o6 = le[n7];
-                        if (o6)
-                          return ae = o6.nextPos, o6.result;
-                        if (e8 = [], z.test(t2.charAt(ae)) ? (r7 = t2.charAt(ae), ae++) : (r7 = s2, ye(H)), r7 !== s2)
-                          for (; r7 !== s2; )
-                            e8.push(r7), z.test(t2.charAt(ae)) ? (r7 = t2.charAt(ae), ae++) : (r7 = s2, ye(H));
-                        else
-                          e8 = s2;
-                        return le[n7] = { nextPos: ae, result: e8 }, e8;
-                      }()) === s2 && (a5 = null), a5 !== s2 ? (i5 = a5, r6 = { type: "regexp", value: new RegExp(n6.join(""), i5 ? i5.join("") : "") }, e7 = r6) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2);
-                    } else
-                      ae = e7, e7 = s2;
-                    return le[u3] = { nextPos: ae, result: e7 }, e7;
-                  }()), o4 !== s2 ? (r5 = D(r5, n5, o4), e6 = r5) : (ae = e6, e6 = s2)) : (ae = e6, e6 = s2), e6 === s2 && (e6 = ae, (r5 = Se()) !== s2 && me() !== s2 && (n5 = function() {
-                    var e7, r6, n6, o5 = 30 * ae + 11, a5 = le[o5];
-                    return a5 ? (ae = a5.nextPos, a5.result) : (e7 = ae, b.test(t2.charAt(ae)) ? (r6 = t2.charAt(ae), ae++) : (r6 = s2, ye(S)), r6 === s2 && (r6 = null), r6 !== s2 ? (61 === t2.charCodeAt(ae) ? (n6 = "=", ae++) : (n6 = s2, ye(_)), n6 !== s2 ? (r6 = C(r6), e7 = r6) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2), e7 === s2 && (w.test(t2.charAt(ae)) ? (e7 = t2.charAt(ae), ae++) : (e7 = s2, ye(P))), le[o5] = { nextPos: ae, result: e7 }, e7);
-                  }()) !== s2 && me() !== s2 ? ((o4 = function() {
-                    var e7, r6, n6, o5, a5, i5, u3 = 30 * ae + 15, l3 = le[u3];
-                    if (l3)
-                      return ae = l3.nextPos, l3.result;
-                    if (e7 = ae, 34 === t2.charCodeAt(ae) ? (r6 = '"', ae++) : (r6 = s2, ye(I)), r6 !== s2) {
-                      for (n6 = [], j.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(T)), o5 === s2 && (o5 = ae, 92 === t2.charCodeAt(ae) ? (a5 = "\\", ae++) : (a5 = s2, ye(F)), a5 !== s2 ? (t2.length > ae ? (i5 = t2.charAt(ae), ae++) : (i5 = s2, ye(R)), i5 !== s2 ? (a5 = O(a5, i5), o5 = a5) : (ae = o5, o5 = s2)) : (ae = o5, o5 = s2)); o5 !== s2; )
-                        n6.push(o5), j.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(T)), o5 === s2 && (o5 = ae, 92 === t2.charCodeAt(ae) ? (a5 = "\\", ae++) : (a5 = s2, ye(F)), a5 !== s2 ? (t2.length > ae ? (i5 = t2.charAt(ae), ae++) : (i5 = s2, ye(R)), i5 !== s2 ? (a5 = O(a5, i5), o5 = a5) : (ae = o5, o5 = s2)) : (ae = o5, o5 = s2));
-                      n6 !== s2 ? (34 === t2.charCodeAt(ae) ? (o5 = '"', ae++) : (o5 = s2, ye(I)), o5 !== s2 ? (r6 = L(n6), e7 = r6) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2);
-                    } else
-                      ae = e7, e7 = s2;
-                    if (e7 === s2)
-                      if (e7 = ae, 39 === t2.charCodeAt(ae) ? (r6 = "'", ae++) : (r6 = s2, ye(M)), r6 !== s2) {
-                        for (n6 = [], B.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(U)), o5 === s2 && (o5 = ae, 92 === t2.charCodeAt(ae) ? (a5 = "\\", ae++) : (a5 = s2, ye(F)), a5 !== s2 ? (t2.length > ae ? (i5 = t2.charAt(ae), ae++) : (i5 = s2, ye(R)), i5 !== s2 ? (a5 = O(a5, i5), o5 = a5) : (ae = o5, o5 = s2)) : (ae = o5, o5 = s2)); o5 !== s2; )
-                          n6.push(o5), B.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(U)), o5 === s2 && (o5 = ae, 92 === t2.charCodeAt(ae) ? (a5 = "\\", ae++) : (a5 = s2, ye(F)), a5 !== s2 ? (t2.length > ae ? (i5 = t2.charAt(ae), ae++) : (i5 = s2, ye(R)), i5 !== s2 ? (a5 = O(a5, i5), o5 = a5) : (ae = o5, o5 = s2)) : (ae = o5, o5 = s2));
-                        n6 !== s2 ? (39 === t2.charCodeAt(ae) ? (o5 = "'", ae++) : (o5 = s2, ye(M)), o5 !== s2 ? (r6 = L(n6), e7 = r6) : (ae = e7, e7 = s2)) : (ae = e7, e7 = s2);
-                      } else
-                        ae = e7, e7 = s2;
-                    return le[u3] = { nextPos: ae, result: e7 }, e7;
-                  }()) === s2 && (o4 = function() {
-                    var e7, r6, n6, o5, a5, i5, u3, l3 = 30 * ae + 16, c3 = le[l3];
-                    if (c3)
-                      return ae = c3.nextPos, c3.result;
-                    for (e7 = ae, r6 = ae, n6 = [], K.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(W)); o5 !== s2; )
-                      n6.push(o5), K.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(W));
-                    if (n6 !== s2 ? (46 === t2.charCodeAt(ae) ? (o5 = ".", ae++) : (o5 = s2, ye(k)), o5 !== s2 ? r6 = n6 = [n6, o5] : (ae = r6, r6 = s2)) : (ae = r6, r6 = s2), r6 === s2 && (r6 = null), r6 !== s2) {
-                      if (n6 = [], K.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(W)), o5 !== s2)
-                        for (; o5 !== s2; )
-                          n6.push(o5), K.test(t2.charAt(ae)) ? (o5 = t2.charAt(ae), ae++) : (o5 = s2, ye(W));
-                      else
-                        n6 = s2;
-                      n6 !== s2 ? (i5 = n6, u3 = (a5 = r6) ? [].concat.apply([], a5).join("") : "", r6 = { type: "literal", value: parseFloat(u3 + i5.join("")) }, e7 = r6) : (ae = e7, e7 = s2);
-                    } else
-                      ae = e7, e7 = s2;
-                    return le[l3] = { nextPos: ae, result: e7 }, e7;
-                  }()) === s2 && (o4 = function() {
-                    var e7, t3, r6 = 30 * ae + 17, n6 = le[r6];
-                    return n6 ? (ae = n6.nextPos, n6.result) : ((t3 = xe()) !== s2 && (t3 = { type: "literal", value: t3 }), e7 = t3, le[r6] = { nextPos: ae, result: e7 }, e7);
-                  }()), o4 !== s2 ? (r5 = D(r5, n5, o4), e6 = r5) : (ae = e6, e6 = s2)) : (ae = e6, e6 = s2), e6 === s2 && (e6 = ae, (r5 = Se()) !== s2 && (r5 = { type: "attribute", name: r5 }), e6 = r5)), le[a4] = { nextPos: ae, result: e6 }, e6);
-                }()) !== s2 && me() !== s2 ? (93 === t2.charCodeAt(ae) ? (o3 = "]", ae++) : (o3 = s2, ye(E)), o3 !== s2 ? e5 = r4 = n4 : (ae = e5, e5 = s2)) : (ae = e5, e5 = s2), le[a3] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3, i3, u3, l3, c3 = 30 * ae + 21, f3 = le[c3];
-                if (f3)
-                  return ae = f3.nextPos, f3.result;
-                if (e5 = ae, 46 === t2.charCodeAt(ae) ? (r4 = ".", ae++) : (r4 = s2, ye(k)), r4 !== s2)
-                  if ((n4 = xe()) !== s2) {
-                    for (o3 = [], a3 = ae, 46 === t2.charCodeAt(ae) ? (i3 = ".", ae++) : (i3 = s2, ye(k)), i3 !== s2 && (u3 = xe()) !== s2 ? a3 = i3 = [i3, u3] : (ae = a3, a3 = s2); a3 !== s2; )
-                      o3.push(a3), a3 = ae, 46 === t2.charCodeAt(ae) ? (i3 = ".", ae++) : (i3 = s2, ye(k)), i3 !== s2 && (u3 = xe()) !== s2 ? a3 = i3 = [i3, u3] : (ae = a3, a3 = s2);
-                    o3 !== s2 ? (l3 = n4, r4 = { type: "field", name: o3.reduce(function(e6, t3) {
-                      return e6 + t3[0] + t3[1];
-                    }, l3) }, e5 = r4) : (ae = e5, e5 = s2);
-                  } else
-                    ae = e5, e5 = s2;
-                else
-                  ae = e5, e5 = s2;
-                return le[c3] = { nextPos: ae, result: e5 }, e5;
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3 = 30 * ae + 22, i3 = le[a3];
-                return i3 ? (ae = i3.nextPos, i3.result) : (e5 = ae, ":not(" === t2.substr(ae, 5) ? (r4 = ":not(", ae += 5) : (r4 = s2, ye(Q)), r4 !== s2 && me() !== s2 && (n4 = ge()) !== s2 && me() !== s2 ? (41 === t2.charCodeAt(ae) ? (o3 = ")", ae++) : (o3 = s2, ye(G)), o3 !== s2 ? e5 = r4 = { type: "not", selectors: n4 } : (ae = e5, e5 = s2)) : (ae = e5, e5 = s2), le[a3] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3 = 30 * ae + 23, i3 = le[a3];
-                return i3 ? (ae = i3.nextPos, i3.result) : (e5 = ae, ":matches(" === t2.substr(ae, 9) ? (r4 = ":matches(", ae += 9) : (r4 = s2, ye(X)), r4 !== s2 && me() !== s2 && (n4 = ge()) !== s2 && me() !== s2 ? (41 === t2.charCodeAt(ae) ? (o3 = ")", ae++) : (o3 = s2, ye(G)), o3 !== s2 ? e5 = r4 = { type: "matches", selectors: n4 } : (ae = e5, e5 = s2)) : (ae = e5, e5 = s2), le[a3] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3 = 30 * ae + 24, i3 = le[a3];
-                return i3 ? (ae = i3.nextPos, i3.result) : (e5 = ae, ":has(" === t2.substr(ae, 5) ? (r4 = ":has(", ae += 5) : (r4 = s2, ye(Z)), r4 !== s2 && me() !== s2 && (n4 = ge()) !== s2 && me() !== s2 ? (41 === t2.charCodeAt(ae) ? (o3 = ")", ae++) : (o3 = s2, ye(G)), o3 !== s2 ? e5 = r4 = { type: "has", selectors: n4 } : (ae = e5, e5 = s2)) : (ae = e5, e5 = s2), le[a3] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4 = 30 * ae + 25, o3 = le[n4];
-                return o3 ? (ae = o3.nextPos, o3.result) : (":first-child" === t2.substr(ae, 12) ? (r4 = ":first-child", ae += 12) : (r4 = s2, ye(ee)), r4 !== s2 && (r4 = _e(1)), e5 = r4, le[n4] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4 = 30 * ae + 26, o3 = le[n4];
-                return o3 ? (ae = o3.nextPos, o3.result) : (":last-child" === t2.substr(ae, 11) ? (r4 = ":last-child", ae += 11) : (r4 = s2, ye(te)), r4 !== s2 && (r4 = Ce(1)), e5 = r4, le[n4] = { nextPos: ae, result: e5 }, e5);
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3, i3 = 30 * ae + 27, u3 = le[i3];
-                if (u3)
-                  return ae = u3.nextPos, u3.result;
-                if (e5 = ae, ":nth-child(" === t2.substr(ae, 11) ? (r4 = ":nth-child(", ae += 11) : (r4 = s2, ye(re)), r4 !== s2)
-                  if (me() !== s2) {
-                    if (n4 = [], K.test(t2.charAt(ae)) ? (o3 = t2.charAt(ae), ae++) : (o3 = s2, ye(W)), o3 !== s2)
-                      for (; o3 !== s2; )
-                        n4.push(o3), K.test(t2.charAt(ae)) ? (o3 = t2.charAt(ae), ae++) : (o3 = s2, ye(W));
-                    else
-                      n4 = s2;
-                    n4 !== s2 && (o3 = me()) !== s2 ? (41 === t2.charCodeAt(ae) ? (a3 = ")", ae++) : (a3 = s2, ye(G)), a3 !== s2 ? (r4 = _e(parseInt(n4.join(""), 10)), e5 = r4) : (ae = e5, e5 = s2)) : (ae = e5, e5 = s2);
-                  } else
-                    ae = e5, e5 = s2;
-                else
-                  ae = e5, e5 = s2;
-                return le[i3] = { nextPos: ae, result: e5 }, e5;
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3, a3, i3 = 30 * ae + 28, u3 = le[i3];
-                if (u3)
-                  return ae = u3.nextPos, u3.result;
-                if (e5 = ae, ":nth-last-child(" === t2.substr(ae, 16) ? (r4 = ":nth-last-child(", ae += 16) : (r4 = s2, ye(ne)), r4 !== s2)
-                  if (me() !== s2) {
-                    if (n4 = [], K.test(t2.charAt(ae)) ? (o3 = t2.charAt(ae), ae++) : (o3 = s2, ye(W)), o3 !== s2)
-                      for (; o3 !== s2; )
-                        n4.push(o3), K.test(t2.charAt(ae)) ? (o3 = t2.charAt(ae), ae++) : (o3 = s2, ye(W));
-                    else
-                      n4 = s2;
-                    n4 !== s2 && (o3 = me()) !== s2 ? (41 === t2.charCodeAt(ae) ? (a3 = ")", ae++) : (a3 = s2, ye(G)), a3 !== s2 ? (r4 = Ce(parseInt(n4.join(""), 10)), e5 = r4) : (ae = e5, e5 = s2)) : (ae = e5, e5 = s2);
-                  } else
-                    ae = e5, e5 = s2;
-                else
-                  ae = e5, e5 = s2;
-                return le[i3] = { nextPos: ae, result: e5 }, e5;
-              }()) === s2 && (e4 = function() {
-                var e5, r4, n4, o3 = 30 * ae + 29, a3 = le[o3];
-                return a3 ? (ae = a3.nextPos, a3.result) : (e5 = ae, 58 === t2.charCodeAt(ae) ? (r4 = ":", ae++) : (r4 = s2, ye(oe)), r4 !== s2 && (n4 = xe()) !== s2 ? e5 = r4 = { type: "class", name: n4 } : (ae = e5, e5 = s2), le[o3] = { nextPos: ae, result: e5 }, e5);
-              }()), le[r3] = { nextPos: ae, result: e4 }, e4);
+              var e4, t3, r3, n3, o3, a3, i3, u3 = 32 * ie + 7, l3 = ce[u3];
+              if (l3)
+                return ie = l3.nextPos, l3.result;
+              if (e4 = ie, (t3 = Se()) !== s2) {
+                for (r3 = [], n3 = ie, (o3 = ge()) !== s2 && (a3 = Se()) !== s2 ? n3 = o3 = [o3, a3] : (ie = n3, n3 = s2); n3 !== s2; )
+                  r3.push(n3), n3 = ie, (o3 = ge()) !== s2 && (a3 = Se()) !== s2 ? n3 = o3 = [o3, a3] : (ie = n3, n3 = s2);
+                r3 !== s2 ? (i3 = t3, e4 = t3 = r3.reduce(function(e5, t4) {
+                  return { type: t4[0], left: e5, right: t4[1] };
+                }, i3)) : (ie = e4, e4 = s2);
+              } else
+                ie = e4, e4 = s2;
+              return ce[u3] = { nextPos: ie, result: e4 }, e4;
             }
             function Se() {
-              var e4, r3, n3, o3, a3, i3, u3, l3, c3 = 30 * ae + 13, f3 = le[c3];
-              if (f3)
-                return ae = f3.nextPos, f3.result;
-              if (e4 = ae, (r3 = xe()) !== s2) {
-                for (n3 = [], o3 = ae, 46 === t2.charCodeAt(ae) ? (a3 = ".", ae++) : (a3 = s2, ye(k)), a3 !== s2 && (i3 = xe()) !== s2 ? o3 = a3 = [a3, i3] : (ae = o3, o3 = s2); o3 !== s2; )
-                  n3.push(o3), o3 = ae, 46 === t2.charCodeAt(ae) ? (a3 = ".", ae++) : (a3 = s2, ye(k)), a3 !== s2 && (i3 = xe()) !== s2 ? o3 = a3 = [a3, i3] : (ae = o3, o3 = s2);
-                n3 !== s2 ? (u3 = r3, l3 = n3, e4 = r3 = [].concat.apply([u3], l3).join("")) : (ae = e4, e4 = s2);
+              var e4, r3, n3, o3, a3, i3, u3, l3 = 32 * ie + 8, c3 = ce[l3];
+              if (c3)
+                return ie = c3.nextPos, c3.result;
+              if (e4 = ie, 33 === t2.charCodeAt(ie) ? (r3 = "!", ie++) : (r3 = s2, de(v2)), r3 === s2 && (r3 = null), r3 !== s2) {
+                if (n3 = [], (o3 = _e()) !== s2)
+                  for (; o3 !== s2; )
+                    n3.push(o3), o3 = _e();
+                else
+                  n3 = s2;
+                n3 !== s2 ? (a3 = r3, u3 = 1 === (i3 = n3).length ? i3[0] : { type: "compound", selectors: i3 }, a3 && (u3.subject = true), e4 = r3 = u3) : (ie = e4, e4 = s2);
               } else
-                ae = e4, e4 = s2;
-              return le[c3] = { nextPos: ae, result: e4 }, e4;
+                ie = e4, e4 = s2;
+              return ce[l3] = { nextPos: ie, result: e4 }, e4;
             }
-            function _e(e4) {
+            function _e() {
+              var e4, r3 = 32 * ie + 9, n3 = ce[r3];
+              return n3 ? (ie = n3.nextPos, n3.result) : ((e4 = function() {
+                var e5, r4, n4 = 32 * ie + 10, o3 = ce[n4];
+                return o3 ? (ie = o3.nextPos, o3.result) : (42 === t2.charCodeAt(ie) ? (r4 = "*", ie++) : (r4 = s2, de(g2)), r4 !== s2 && (r4 = { type: "wildcard", value: r4 }), e5 = r4, ce[n4] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3 = 32 * ie + 11, a3 = ce[o3];
+                return a3 ? (ie = a3.nextPos, a3.result) : (e5 = ie, 35 === t2.charCodeAt(ie) ? (r4 = "#", ie++) : (r4 = s2, de(A2)), r4 === s2 && (r4 = null), r4 !== s2 && (n4 = ve()) !== s2 ? e5 = r4 = { type: "identifier", value: n4 } : (ie = e5, e5 = s2), ce[o3] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3 = 32 * ie + 12, i3 = ce[a3];
+                return i3 ? (ie = i3.nextPos, i3.result) : (e5 = ie, 91 === t2.charCodeAt(ie) ? (r4 = "[", ie++) : (r4 = s2, de(E)), r4 !== s2 && xe() !== s2 && (n4 = function() {
+                  var e6, r5, n5, o4, a4 = 32 * ie + 16, i4 = ce[a4];
+                  return i4 ? (ie = i4.nextPos, i4.result) : (e6 = ie, (r5 = Ce()) !== s2 && xe() !== s2 && (n5 = function() {
+                    var e7, r6, n6, o5 = 32 * ie + 14, a5 = ce[o5];
+                    return a5 ? (ie = a5.nextPos, a5.result) : (e7 = ie, 33 === t2.charCodeAt(ie) ? (r6 = "!", ie++) : (r6 = s2, de(v2)), r6 === s2 && (r6 = null), r6 !== s2 ? (61 === t2.charCodeAt(ie) ? (n6 = "=", ie++) : (n6 = s2, de(C)), n6 !== s2 ? (r6 = w(r6), e7 = r6) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2), ce[o5] = { nextPos: ie, result: e7 }, e7);
+                  }()) !== s2 && xe() !== s2 ? ((o4 = function() {
+                    var e7, r6, n6, o5, a5, i5 = 32 * ie + 20, u3 = ce[i5];
+                    if (u3)
+                      return ie = u3.nextPos, u3.result;
+                    if (e7 = ie, "type(" === t2.substr(ie, 5) ? (r6 = "type(", ie += 5) : (r6 = s2, de(q)), r6 !== s2)
+                      if (xe() !== s2) {
+                        if (n6 = [], V.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(G)), o5 !== s2)
+                          for (; o5 !== s2; )
+                            n6.push(o5), V.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(G));
+                        else
+                          n6 = s2;
+                        n6 !== s2 && (o5 = xe()) !== s2 ? (41 === t2.charCodeAt(ie) ? (a5 = ")", ie++) : (a5 = s2, de(z)), a5 !== s2 ? (r6 = { type: "type", value: n6.join("") }, e7 = r6) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2);
+                      } else
+                        ie = e7, e7 = s2;
+                    else
+                      ie = e7, e7 = s2;
+                    return ce[i5] = { nextPos: ie, result: e7 }, e7;
+                  }()) === s2 && (o4 = function() {
+                    var e7, r6, n6, o5, a5, i5, u3 = 32 * ie + 22, l3 = ce[u3];
+                    if (l3)
+                      return ie = l3.nextPos, l3.result;
+                    if (e7 = ie, 47 === t2.charCodeAt(ie) ? (r6 = "/", ie++) : (r6 = s2, de($)), r6 !== s2) {
+                      if (n6 = [], J.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(Q)), o5 !== s2)
+                        for (; o5 !== s2; )
+                          n6.push(o5), J.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(Q));
+                      else
+                        n6 = s2;
+                      n6 !== s2 ? (47 === t2.charCodeAt(ie) ? (o5 = "/", ie++) : (o5 = s2, de($)), o5 !== s2 ? ((a5 = function() {
+                        var e8, r7, n7 = 32 * ie + 21, o6 = ce[n7];
+                        if (o6)
+                          return ie = o6.nextPos, o6.result;
+                        if (e8 = [], H.test(t2.charAt(ie)) ? (r7 = t2.charAt(ie), ie++) : (r7 = s2, de(Y)), r7 !== s2)
+                          for (; r7 !== s2; )
+                            e8.push(r7), H.test(t2.charAt(ie)) ? (r7 = t2.charAt(ie), ie++) : (r7 = s2, de(Y));
+                        else
+                          e8 = s2;
+                        return ce[n7] = { nextPos: ie, result: e8 }, e8;
+                      }()) === s2 && (a5 = null), a5 !== s2 ? (i5 = a5, r6 = { type: "regexp", value: new RegExp(n6.join(""), i5 ? i5.join("") : "") }, e7 = r6) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2);
+                    } else
+                      ie = e7, e7 = s2;
+                    return ce[u3] = { nextPos: ie, result: e7 }, e7;
+                  }()), o4 !== s2 ? (r5 = I(r5, n5, o4), e6 = r5) : (ie = e6, e6 = s2)) : (ie = e6, e6 = s2), e6 === s2 && (e6 = ie, (r5 = Ce()) !== s2 && xe() !== s2 && (n5 = function() {
+                    var e7, r6, n6, o5 = 32 * ie + 13, a5 = ce[o5];
+                    return a5 ? (ie = a5.nextPos, a5.result) : (e7 = ie, S.test(t2.charAt(ie)) ? (r6 = t2.charAt(ie), ie++) : (r6 = s2, de(_)), r6 === s2 && (r6 = null), r6 !== s2 ? (61 === t2.charCodeAt(ie) ? (n6 = "=", ie++) : (n6 = s2, de(C)), n6 !== s2 ? (r6 = w(r6), e7 = r6) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2), e7 === s2 && (P.test(t2.charAt(ie)) ? (e7 = t2.charAt(ie), ie++) : (e7 = s2, de(k))), ce[o5] = { nextPos: ie, result: e7 }, e7);
+                  }()) !== s2 && xe() !== s2 ? ((o4 = function() {
+                    var e7, r6, n6, o5, a5, i5, u3 = 32 * ie + 17, l3 = ce[u3];
+                    if (l3)
+                      return ie = l3.nextPos, l3.result;
+                    if (e7 = ie, 34 === t2.charCodeAt(ie) ? (r6 = '"', ie++) : (r6 = s2, de(j)), r6 !== s2) {
+                      for (n6 = [], T.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(F)), o5 === s2 && (o5 = ie, 92 === t2.charCodeAt(ie) ? (a5 = "\\", ie++) : (a5 = s2, de(R)), a5 !== s2 ? (t2.length > ie ? (i5 = t2.charAt(ie), ie++) : (i5 = s2, de(O)), i5 !== s2 ? (a5 = L(a5, i5), o5 = a5) : (ie = o5, o5 = s2)) : (ie = o5, o5 = s2)); o5 !== s2; )
+                        n6.push(o5), T.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(F)), o5 === s2 && (o5 = ie, 92 === t2.charCodeAt(ie) ? (a5 = "\\", ie++) : (a5 = s2, de(R)), a5 !== s2 ? (t2.length > ie ? (i5 = t2.charAt(ie), ie++) : (i5 = s2, de(O)), i5 !== s2 ? (a5 = L(a5, i5), o5 = a5) : (ie = o5, o5 = s2)) : (ie = o5, o5 = s2));
+                      n6 !== s2 ? (34 === t2.charCodeAt(ie) ? (o5 = '"', ie++) : (o5 = s2, de(j)), o5 !== s2 ? (r6 = M(n6), e7 = r6) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2);
+                    } else
+                      ie = e7, e7 = s2;
+                    if (e7 === s2)
+                      if (e7 = ie, 39 === t2.charCodeAt(ie) ? (r6 = "'", ie++) : (r6 = s2, de(B)), r6 !== s2) {
+                        for (n6 = [], U.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(K)), o5 === s2 && (o5 = ie, 92 === t2.charCodeAt(ie) ? (a5 = "\\", ie++) : (a5 = s2, de(R)), a5 !== s2 ? (t2.length > ie ? (i5 = t2.charAt(ie), ie++) : (i5 = s2, de(O)), i5 !== s2 ? (a5 = L(a5, i5), o5 = a5) : (ie = o5, o5 = s2)) : (ie = o5, o5 = s2)); o5 !== s2; )
+                          n6.push(o5), U.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(K)), o5 === s2 && (o5 = ie, 92 === t2.charCodeAt(ie) ? (a5 = "\\", ie++) : (a5 = s2, de(R)), a5 !== s2 ? (t2.length > ie ? (i5 = t2.charAt(ie), ie++) : (i5 = s2, de(O)), i5 !== s2 ? (a5 = L(a5, i5), o5 = a5) : (ie = o5, o5 = s2)) : (ie = o5, o5 = s2));
+                        n6 !== s2 ? (39 === t2.charCodeAt(ie) ? (o5 = "'", ie++) : (o5 = s2, de(B)), o5 !== s2 ? (r6 = M(n6), e7 = r6) : (ie = e7, e7 = s2)) : (ie = e7, e7 = s2);
+                      } else
+                        ie = e7, e7 = s2;
+                    return ce[u3] = { nextPos: ie, result: e7 }, e7;
+                  }()) === s2 && (o4 = function() {
+                    var e7, r6, n6, o5, a5, i5, u3, l3 = 32 * ie + 18, c3 = ce[l3];
+                    if (c3)
+                      return ie = c3.nextPos, c3.result;
+                    for (e7 = ie, r6 = ie, n6 = [], N.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(W)); o5 !== s2; )
+                      n6.push(o5), N.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(W));
+                    if (n6 !== s2 ? (46 === t2.charCodeAt(ie) ? (o5 = ".", ie++) : (o5 = s2, de(D)), o5 !== s2 ? r6 = n6 = [n6, o5] : (ie = r6, r6 = s2)) : (ie = r6, r6 = s2), r6 === s2 && (r6 = null), r6 !== s2) {
+                      if (n6 = [], N.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(W)), o5 !== s2)
+                        for (; o5 !== s2; )
+                          n6.push(o5), N.test(t2.charAt(ie)) ? (o5 = t2.charAt(ie), ie++) : (o5 = s2, de(W));
+                      else
+                        n6 = s2;
+                      n6 !== s2 ? (i5 = n6, u3 = (a5 = r6) ? [].concat.apply([], a5).join("") : "", r6 = { type: "literal", value: parseFloat(u3 + i5.join("")) }, e7 = r6) : (ie = e7, e7 = s2);
+                    } else
+                      ie = e7, e7 = s2;
+                    return ce[l3] = { nextPos: ie, result: e7 }, e7;
+                  }()) === s2 && (o4 = function() {
+                    var e7, t3, r6 = 32 * ie + 19, n6 = ce[r6];
+                    return n6 ? (ie = n6.nextPos, n6.result) : ((t3 = ve()) !== s2 && (t3 = { type: "literal", value: t3 }), e7 = t3, ce[r6] = { nextPos: ie, result: e7 }, e7);
+                  }()), o4 !== s2 ? (r5 = I(r5, n5, o4), e6 = r5) : (ie = e6, e6 = s2)) : (ie = e6, e6 = s2), e6 === s2 && (e6 = ie, (r5 = Ce()) !== s2 && (r5 = { type: "attribute", name: r5 }), e6 = r5)), ce[a4] = { nextPos: ie, result: e6 }, e6);
+                }()) !== s2 && xe() !== s2 ? (93 === t2.charCodeAt(ie) ? (o3 = "]", ie++) : (o3 = s2, de(b)), o3 !== s2 ? e5 = r4 = n4 : (ie = e5, e5 = s2)) : (ie = e5, e5 = s2), ce[a3] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3, i3, u3, l3, c3 = 32 * ie + 23, f3 = ce[c3];
+                if (f3)
+                  return ie = f3.nextPos, f3.result;
+                if (e5 = ie, 46 === t2.charCodeAt(ie) ? (r4 = ".", ie++) : (r4 = s2, de(D)), r4 !== s2)
+                  if ((n4 = ve()) !== s2) {
+                    for (o3 = [], a3 = ie, 46 === t2.charCodeAt(ie) ? (i3 = ".", ie++) : (i3 = s2, de(D)), i3 !== s2 && (u3 = ve()) !== s2 ? a3 = i3 = [i3, u3] : (ie = a3, a3 = s2); a3 !== s2; )
+                      o3.push(a3), a3 = ie, 46 === t2.charCodeAt(ie) ? (i3 = ".", ie++) : (i3 = s2, de(D)), i3 !== s2 && (u3 = ve()) !== s2 ? a3 = i3 = [i3, u3] : (ie = a3, a3 = s2);
+                    o3 !== s2 ? (l3 = n4, r4 = { type: "field", name: o3.reduce(function(e6, t3) {
+                      return e6 + t3[0] + t3[1];
+                    }, l3) }, e5 = r4) : (ie = e5, e5 = s2);
+                  } else
+                    ie = e5, e5 = s2;
+                else
+                  ie = e5, e5 = s2;
+                return ce[c3] = { nextPos: ie, result: e5 }, e5;
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3 = 32 * ie + 24, i3 = ce[a3];
+                return i3 ? (ie = i3.nextPos, i3.result) : (e5 = ie, ":not(" === t2.substr(ie, 5) ? (r4 = ":not(", ie += 5) : (r4 = s2, de(X)), r4 !== s2 && xe() !== s2 && (n4 = Ae()) !== s2 && xe() !== s2 ? (41 === t2.charCodeAt(ie) ? (o3 = ")", ie++) : (o3 = s2, de(z)), o3 !== s2 ? e5 = r4 = { type: "not", selectors: n4 } : (ie = e5, e5 = s2)) : (ie = e5, e5 = s2), ce[a3] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3 = 32 * ie + 25, i3 = ce[a3];
+                return i3 ? (ie = i3.nextPos, i3.result) : (e5 = ie, ":matches(" === t2.substr(ie, 9) ? (r4 = ":matches(", ie += 9) : (r4 = s2, de(Z)), r4 !== s2 && xe() !== s2 && (n4 = Ae()) !== s2 && xe() !== s2 ? (41 === t2.charCodeAt(ie) ? (o3 = ")", ie++) : (o3 = s2, de(z)), o3 !== s2 ? e5 = r4 = { type: "matches", selectors: n4 } : (ie = e5, e5 = s2)) : (ie = e5, e5 = s2), ce[a3] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3 = 32 * ie + 26, i3 = ce[a3];
+                return i3 ? (ie = i3.nextPos, i3.result) : (e5 = ie, ":has(" === t2.substr(ie, 5) ? (r4 = ":has(", ie += 5) : (r4 = s2, de(ee)), r4 !== s2 && xe() !== s2 && (n4 = function() {
+                  var e6, r5, n5, o4, a4, i4, u3, l3, c3 = 32 * ie + 4, f3 = ce[c3];
+                  if (f3)
+                    return ie = f3.nextPos, f3.result;
+                  if (e6 = ie, (r5 = Ee()) !== s2) {
+                    for (n5 = [], o4 = ie, (a4 = xe()) !== s2 ? (44 === t2.charCodeAt(ie) ? (i4 = ",", ie++) : (i4 = s2, de(m2)), i4 !== s2 && (u3 = xe()) !== s2 && (l3 = Ee()) !== s2 ? o4 = a4 = [a4, i4, u3, l3] : (ie = o4, o4 = s2)) : (ie = o4, o4 = s2); o4 !== s2; )
+                      n5.push(o4), o4 = ie, (a4 = xe()) !== s2 ? (44 === t2.charCodeAt(ie) ? (i4 = ",", ie++) : (i4 = s2, de(m2)), i4 !== s2 && (u3 = xe()) !== s2 && (l3 = Ee()) !== s2 ? o4 = a4 = [a4, i4, u3, l3] : (ie = o4, o4 = s2)) : (ie = o4, o4 = s2);
+                    n5 !== s2 ? e6 = r5 = x2(r5, n5) : (ie = e6, e6 = s2);
+                  } else
+                    ie = e6, e6 = s2;
+                  return ce[c3] = { nextPos: ie, result: e6 }, e6;
+                }()) !== s2 && xe() !== s2 ? (41 === t2.charCodeAt(ie) ? (o3 = ")", ie++) : (o3 = s2, de(z)), o3 !== s2 ? e5 = r4 = { type: "has", selectors: n4 } : (ie = e5, e5 = s2)) : (ie = e5, e5 = s2), ce[a3] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4 = 32 * ie + 27, o3 = ce[n4];
+                return o3 ? (ie = o3.nextPos, o3.result) : (":first-child" === t2.substr(ie, 12) ? (r4 = ":first-child", ie += 12) : (r4 = s2, de(te)), r4 !== s2 && (r4 = we(1)), e5 = r4, ce[n4] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4 = 32 * ie + 28, o3 = ce[n4];
+                return o3 ? (ie = o3.nextPos, o3.result) : (":last-child" === t2.substr(ie, 11) ? (r4 = ":last-child", ie += 11) : (r4 = s2, de(re)), r4 !== s2 && (r4 = Pe(1)), e5 = r4, ce[n4] = { nextPos: ie, result: e5 }, e5);
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3, i3 = 32 * ie + 29, u3 = ce[i3];
+                if (u3)
+                  return ie = u3.nextPos, u3.result;
+                if (e5 = ie, ":nth-child(" === t2.substr(ie, 11) ? (r4 = ":nth-child(", ie += 11) : (r4 = s2, de(ne)), r4 !== s2)
+                  if (xe() !== s2) {
+                    if (n4 = [], N.test(t2.charAt(ie)) ? (o3 = t2.charAt(ie), ie++) : (o3 = s2, de(W)), o3 !== s2)
+                      for (; o3 !== s2; )
+                        n4.push(o3), N.test(t2.charAt(ie)) ? (o3 = t2.charAt(ie), ie++) : (o3 = s2, de(W));
+                    else
+                      n4 = s2;
+                    n4 !== s2 && (o3 = xe()) !== s2 ? (41 === t2.charCodeAt(ie) ? (a3 = ")", ie++) : (a3 = s2, de(z)), a3 !== s2 ? (r4 = we(parseInt(n4.join(""), 10)), e5 = r4) : (ie = e5, e5 = s2)) : (ie = e5, e5 = s2);
+                  } else
+                    ie = e5, e5 = s2;
+                else
+                  ie = e5, e5 = s2;
+                return ce[i3] = { nextPos: ie, result: e5 }, e5;
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3, a3, i3 = 32 * ie + 30, u3 = ce[i3];
+                if (u3)
+                  return ie = u3.nextPos, u3.result;
+                if (e5 = ie, ":nth-last-child(" === t2.substr(ie, 16) ? (r4 = ":nth-last-child(", ie += 16) : (r4 = s2, de(oe)), r4 !== s2)
+                  if (xe() !== s2) {
+                    if (n4 = [], N.test(t2.charAt(ie)) ? (o3 = t2.charAt(ie), ie++) : (o3 = s2, de(W)), o3 !== s2)
+                      for (; o3 !== s2; )
+                        n4.push(o3), N.test(t2.charAt(ie)) ? (o3 = t2.charAt(ie), ie++) : (o3 = s2, de(W));
+                    else
+                      n4 = s2;
+                    n4 !== s2 && (o3 = xe()) !== s2 ? (41 === t2.charCodeAt(ie) ? (a3 = ")", ie++) : (a3 = s2, de(z)), a3 !== s2 ? (r4 = Pe(parseInt(n4.join(""), 10)), e5 = r4) : (ie = e5, e5 = s2)) : (ie = e5, e5 = s2);
+                  } else
+                    ie = e5, e5 = s2;
+                else
+                  ie = e5, e5 = s2;
+                return ce[i3] = { nextPos: ie, result: e5 }, e5;
+              }()) === s2 && (e4 = function() {
+                var e5, r4, n4, o3 = 32 * ie + 31, a3 = ce[o3];
+                return a3 ? (ie = a3.nextPos, a3.result) : (e5 = ie, 58 === t2.charCodeAt(ie) ? (r4 = ":", ie++) : (r4 = s2, de(ae)), r4 !== s2 && (n4 = ve()) !== s2 ? e5 = r4 = { type: "class", name: n4 } : (ie = e5, e5 = s2), ce[o3] = { nextPos: ie, result: e5 }, e5);
+              }()), ce[r3] = { nextPos: ie, result: e4 }, e4);
+            }
+            function Ce() {
+              var e4, r3, n3, o3, a3, i3, u3, l3, c3 = 32 * ie + 15, f3 = ce[c3];
+              if (f3)
+                return ie = f3.nextPos, f3.result;
+              if (e4 = ie, (r3 = ve()) !== s2) {
+                for (n3 = [], o3 = ie, 46 === t2.charCodeAt(ie) ? (a3 = ".", ie++) : (a3 = s2, de(D)), a3 !== s2 && (i3 = ve()) !== s2 ? o3 = a3 = [a3, i3] : (ie = o3, o3 = s2); o3 !== s2; )
+                  n3.push(o3), o3 = ie, 46 === t2.charCodeAt(ie) ? (a3 = ".", ie++) : (a3 = s2, de(D)), a3 !== s2 && (i3 = ve()) !== s2 ? o3 = a3 = [a3, i3] : (ie = o3, o3 = s2);
+                n3 !== s2 ? (u3 = r3, l3 = n3, e4 = r3 = [].concat.apply([u3], l3).join("")) : (ie = e4, e4 = s2);
+              } else
+                ie = e4, e4 = s2;
+              return ce[c3] = { nextPos: ie, result: e4 }, e4;
+            }
+            function we(e4) {
               return { type: "nth-child", index: { type: "literal", value: e4 } };
             }
-            function Ce(e4) {
+            function Pe(e4) {
               return { type: "nth-last-child", index: { type: "literal", value: e4 } };
             }
-            if ((n2 = l2()) !== s2 && ae === t2.length)
+            if ((n2 = l2()) !== s2 && ie === t2.length)
               return n2;
-            throw n2 !== s2 && ae < t2.length && ye({ type: "end" }), o2 = ue, a2 = se < t2.length ? t2.charAt(se) : null, i2 = se < t2.length ? he(se, se + 1) : he(se, se), new e3(e3.buildMessage(o2, a2), o2, a2, i2);
+            throw n2 !== s2 && ie < t2.length && de({ type: "end" }), o2 = le, a2 = ue < t2.length ? t2.charAt(ue) : null, i2 = ue < t2.length ? ye(ue, ue + 1) : ye(ue, ue), new e3(e3.buildMessage(o2, a2), o2, a2, i2);
           } };
         }());
       });
@@ -33194,6 +34784,10 @@ var require_esquery_min = __commonJS({
             return function(e2, t3, n3) {
               var o3 = n3 && n3.nodeTypeKey || "type";
               return r2 === e2[o3].toLowerCase();
+            };
+          case "exactNode":
+            return function(e2, t3) {
+              return 0 === t3.length;
             };
           case "field":
             var n2 = t2.name.split(".");
@@ -33347,12 +34941,13 @@ var require_esquery_min = __commonJS({
               return k(e2, t3, r3) && m(e2, t3, P, r3);
             };
           case "class":
+            var D = t2.name.toLowerCase();
             return function(e2, r3, n3) {
               if (n3 && n3.matchClass)
                 return n3.matchClass(t2.name, e2, r3);
               if (n3 && n3.nodeTypeKey)
                 return false;
-              switch (t2.name.toLowerCase()) {
+              switch (D) {
                 case "statement":
                   if ("Statement" === e2.type.slice(-9))
                     return true;
@@ -34473,8 +36068,8 @@ var require_ast_utils2 = __commonJS({
     } = require_ast_utils();
     var anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/u;
     var anyLoopPattern = /^(?:DoWhile|For|ForIn|ForOf|While)Statement$/u;
+    var arrayMethodWithThisArgPattern = /^(?:every|filter|find(?:Last)?(?:Index)?|flatMap|forEach|map|some)$/u;
     var arrayOrTypedArrayPattern = /Array$/u;
-    var arrayMethodPattern = /^(?:every|filter|find|findIndex|forEach|map|some)$/u;
     var bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/u;
     var thisTagPattern = /^[\s*]*@this/mu;
     var COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs)/u;
@@ -34650,7 +36245,7 @@ var require_ast_utils2 = __commonJS({
       return isSpecificMemberAccess(node, arrayOrTypedArrayPattern, "from");
     }
     function isMethodWhichHasThisArg(node) {
-      return isSpecificMemberAccess(node, null, arrayMethodPattern);
+      return isSpecificMemberAccess(node, null, arrayMethodWithThisArgPattern);
     }
     function negate(f) {
       return (token) => !f(token);
@@ -34859,6 +36454,67 @@ var require_ast_utils2 = __commonJS({
     }
     function isDirective(node) {
       return node.type === "ExpressionStatement" && typeof node.directive === "string";
+    }
+    function isStartOfExpressionStatement(node) {
+      const start = node.range[0];
+      let ancestor = node;
+      while ((ancestor = ancestor.parent) && ancestor.range[0] === start) {
+        if (ancestor.type === "ExpressionStatement") {
+          return true;
+        }
+      }
+      return false;
+    }
+    var needsPrecedingSemicolon;
+    {
+      const BREAK_OR_CONTINUE = /* @__PURE__ */ new Set(["BreakStatement", "ContinueStatement"]);
+      const DECLARATIONS = /* @__PURE__ */ new Set(["ExportAllDeclaration", "ExportNamedDeclaration", "ImportDeclaration"]);
+      const IDENTIFIER_OR_KEYWORD = /* @__PURE__ */ new Set(["Identifier", "Keyword"]);
+      const NODE_TYPES_BY_KEYWORD = {
+        __proto__: null,
+        break: "BreakStatement",
+        continue: "ContinueStatement",
+        debugger: "DebuggerStatement",
+        do: "DoWhileStatement",
+        else: "IfStatement",
+        return: "ReturnStatement",
+        yield: "YieldExpression"
+      };
+      const PUNCTUATORS = /* @__PURE__ */ new Set([":", ";", "{", "=>", "++", "--"]);
+      const STATEMENTS = /* @__PURE__ */ new Set([
+        "DoWhileStatement",
+        "ForInStatement",
+        "ForOfStatement",
+        "ForStatement",
+        "IfStatement",
+        "WhileStatement",
+        "WithStatement"
+      ]);
+      needsPrecedingSemicolon = function(sourceCode, node) {
+        const prevToken = sourceCode.getTokenBefore(node);
+        if (!prevToken || prevToken.type === "Punctuator" && PUNCTUATORS.has(prevToken.value)) {
+          return false;
+        }
+        const prevNode = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
+        if (isClosingParenToken(prevToken)) {
+          return !STATEMENTS.has(prevNode.type);
+        }
+        if (isClosingBraceToken(prevToken)) {
+          return prevNode.type === "BlockStatement" && prevNode.parent.type === "FunctionExpression" || prevNode.type === "ClassBody" && prevNode.parent.type === "ClassExpression" || prevNode.type === "ObjectExpression";
+        }
+        if (IDENTIFIER_OR_KEYWORD.has(prevToken.type)) {
+          if (BREAK_OR_CONTINUE.has(prevNode.parent.type)) {
+            return false;
+          }
+          const keyword = prevToken.value;
+          const nodeType = NODE_TYPES_BY_KEYWORD[keyword];
+          return prevNode.type !== nodeType;
+        }
+        if (prevToken.type === "String") {
+          return !DECLARATIONS.has(prevNode.parent.type);
+        }
+        return true;
+      };
     }
     module.exports = {
       COMMENTS_IGNORE_PATTERN,
@@ -35738,7 +37394,9 @@ var require_ast_utils2 = __commonJS({
       getModuleExportName,
       isConstant,
       isTopLevelExpressionStatement,
-      isDirective
+      isDirective,
+      isStartOfExpressionStatement,
+      needsPrecedingSemicolon
     };
   }
 });
@@ -35932,6 +37590,8 @@ var require_array_bracket_newline = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce linebreaks after opening and before closing array brackets",
@@ -36088,6 +37748,8 @@ var require_array_bracket_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing inside array brackets",
@@ -36233,11 +37895,16 @@ var require_array_callback_return = __commonJS({
     var astUtils = require_ast_utils2();
     var TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/u;
     var TARGET_METHODS = /^(?:every|filter|find(?:Last)?(?:Index)?|flatMap|forEach|map|reduce(?:Right)?|some|sort|toSorted)$/u;
-    function isReachable(segment) {
-      return segment.reachable;
-    }
     function isTargetMethod(node) {
       return astUtils.isSpecificMemberAccess(node, null, TARGET_METHODS);
+    }
+    function isAnySegmentReachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return true;
+        }
+      }
+      return false;
     }
     function fullMethodName(arrayMethodName) {
       if (["from", "of", "isArray"].includes(arrayMethodName)) {
@@ -36281,6 +37948,39 @@ var require_array_callback_return = __commonJS({
       }
       return null;
     }
+    function isExpressionVoid(node) {
+      return node.type === "UnaryExpression" && node.operator === "void";
+    }
+    function voidPrependFixer(sourceCode, node, fixer) {
+      const requiresParens = (
+        // prepending `void ` will fail if the node has a lower precedence than void
+        astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression", operator: "void" }) && // check if there are parentheses around the node to avoid redundant parentheses
+        !astUtils.isParenthesised(sourceCode, node)
+      );
+      const returnOrArrowToken = sourceCode.getTokenBefore(
+        node,
+        node.parent.type === "ArrowFunctionExpression" ? astUtils.isArrowToken : (token) => token.type === "Keyword" && token.value === "return"
+      );
+      const firstToken = sourceCode.getTokenAfter(returnOrArrowToken);
+      const prependSpace = (
+        // is return token, as => allows void to be adjacent
+        returnOrArrowToken.value === "return" && // If two tokens (return and "(") are adjacent
+        returnOrArrowToken.range[1] === firstToken.range[0]
+      );
+      return [
+        fixer.insertTextBefore(firstToken, `${prependSpace ? " " : ""}void ${requiresParens ? "(" : ""}`),
+        fixer.insertTextAfter(node, requiresParens ? ")" : "")
+      ];
+    }
+    function curlyWrapFixer(sourceCode, node, fixer) {
+      const arrowToken = sourceCode.getTokenBefore(node.body, astUtils.isArrowToken);
+      const firstToken = sourceCode.getTokenAfter(arrowToken);
+      const lastToken = sourceCode.getLastToken(node);
+      return [
+        fixer.insertTextBefore(firstToken, "{"),
+        fixer.insertTextAfter(lastToken, "}")
+      ];
+    }
     module.exports = {
       meta: {
         type: "problem",
@@ -36289,6 +37989,8 @@ var require_array_callback_return = __commonJS({
           recommended: false,
           url: "https://eslint.org/docs/latest/rules/array-callback-return"
         },
+        // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions -- false positive
+        hasSuggestions: true,
         schema: [
           {
             type: "object",
@@ -36300,6 +38002,10 @@ var require_array_callback_return = __commonJS({
               checkForEach: {
                 type: "boolean",
                 default: false
+              },
+              allowVoid: {
+                type: "boolean",
+                default: false
               }
             },
             additionalProperties: false
@@ -36309,11 +38015,13 @@ var require_array_callback_return = __commonJS({
           expectedAtEnd: "{{arrayMethodName}}() expects a value to be returned at the end of {{name}}.",
           expectedInside: "{{arrayMethodName}}() expects a return value from {{name}}.",
           expectedReturnValue: "{{arrayMethodName}}() expects a return value from {{name}}.",
-          expectedNoReturnValue: "{{arrayMethodName}}() expects no useless return value from {{name}}."
+          expectedNoReturnValue: "{{arrayMethodName}}() expects no useless return value from {{name}}.",
+          wrapBraces: "Wrap the expression in `{}`.",
+          prependVoid: "Prepend `void` to the expression."
         }
       },
       create(context) {
-        const options = context.options[0] || { allowImplicit: false, checkForEach: false };
+        const options = context.options[0] || { allowImplicit: false, checkForEach: false, allowVoid: false };
         const sourceCode = context.sourceCode;
         let funcInfo = {
           arrayMethodName: null,
@@ -36327,23 +38035,51 @@ var require_array_callback_return = __commonJS({
           if (!funcInfo.shouldCheck) {
             return;
           }
-          let messageId = null;
+          const messageAndSuggestions = { messageId: "", suggest: [] };
           if (funcInfo.arrayMethodName === "forEach") {
             if (options.checkForEach && node.type === "ArrowFunctionExpression" && node.expression) {
-              messageId = "expectedNoReturnValue";
+              if (options.allowVoid) {
+                if (isExpressionVoid(node.body)) {
+                  return;
+                }
+                messageAndSuggestions.messageId = "expectedNoReturnValue";
+                messageAndSuggestions.suggest = [
+                  {
+                    messageId: "wrapBraces",
+                    fix(fixer) {
+                      return curlyWrapFixer(sourceCode, node, fixer);
+                    }
+                  },
+                  {
+                    messageId: "prependVoid",
+                    fix(fixer) {
+                      return voidPrependFixer(sourceCode, node.body, fixer);
+                    }
+                  }
+                ];
+              } else {
+                messageAndSuggestions.messageId = "expectedNoReturnValue";
+                messageAndSuggestions.suggest = [{
+                  messageId: "wrapBraces",
+                  fix(fixer) {
+                    return curlyWrapFixer(sourceCode, node, fixer);
+                  }
+                }];
+              }
             }
           } else {
-            if (node.body.type === "BlockStatement" && funcInfo.codePath.currentSegments.some(isReachable)) {
-              messageId = funcInfo.hasReturn ? "expectedAtEnd" : "expectedInside";
+            if (node.body.type === "BlockStatement" && isAnySegmentReachable(funcInfo.currentSegments)) {
+              messageAndSuggestions.messageId = funcInfo.hasReturn ? "expectedAtEnd" : "expectedInside";
             }
           }
-          if (messageId) {
+          if (messageAndSuggestions.messageId) {
             const name = astUtils.getFunctionNameWithKind(node);
             context.report({
               node,
               loc: astUtils.getFunctionHeadLoc(node, sourceCode),
-              messageId,
-              data: { name, arrayMethodName: fullMethodName(funcInfo.arrayMethodName) }
+              messageId: messageAndSuggestions.messageId,
+              data: { name, arrayMethodName: fullMethodName(funcInfo.arrayMethodName) },
+              suggest: messageAndSuggestions.suggest.length !== 0 ? messageAndSuggestions.suggest : null
             });
           }
         }
@@ -36360,12 +38096,25 @@ var require_array_callback_return = __commonJS({
               codePath,
               hasReturn: false,
               shouldCheck: methodName && !node.async && !node.generator,
-              node
+              node,
+              currentSegments: /* @__PURE__ */ new Set()
             };
           },
           // Pops this function's information.
           onCodePathEnd() {
             funcInfo = funcInfo.upper;
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
+          },
+          onCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
           },
           // Checks the return statement is valid.
           ReturnStatement(node) {
@@ -36373,24 +38122,38 @@ var require_array_callback_return = __commonJS({
               return;
             }
             funcInfo.hasReturn = true;
-            let messageId = null;
+            const messageAndSuggestions = { messageId: "", suggest: [] };
             if (funcInfo.arrayMethodName === "forEach") {
               if (options.checkForEach && node.argument) {
-                messageId = "expectedNoReturnValue";
+                if (options.allowVoid) {
+                  if (isExpressionVoid(node.argument)) {
+                    return;
+                  }
+                  messageAndSuggestions.messageId = "expectedNoReturnValue";
+                  messageAndSuggestions.suggest = [{
+                    messageId: "prependVoid",
+                    fix(fixer) {
+                      return voidPrependFixer(sourceCode, node.argument, fixer);
+                    }
+                  }];
+                } else {
+                  messageAndSuggestions.messageId = "expectedNoReturnValue";
+                }
               }
             } else {
               if (!options.allowImplicit && !node.argument) {
-                messageId = "expectedReturnValue";
+                messageAndSuggestions.messageId = "expectedReturnValue";
               }
             }
-            if (messageId) {
+            if (messageAndSuggestions.messageId) {
               context.report({
                 node,
-                messageId,
+                messageId: messageAndSuggestions.messageId,
                 data: {
                   name: astUtils.getFunctionNameWithKind(funcInfo.node),
                   arrayMethodName: fullMethodName(funcInfo.arrayMethodName)
-                }
+                },
+                suggest: messageAndSuggestions.suggest.length !== 0 ? messageAndSuggestions.suggest : null
               });
             }
           },
@@ -36410,6 +38173,8 @@ var require_array_element_newline = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce line breaks after each array element",
@@ -36813,6 +38578,8 @@ var require_arrow_parens = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require parentheses around arrow function arguments",
@@ -36910,6 +38677,8 @@ var require_arrow_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before and after the arrow in arrow functions",
@@ -37099,6 +38868,8 @@ var require_block_spacing = __commonJS({
     var util = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow or enforce spaces inside of blocks after opening block and before closing block",
@@ -37208,6 +38979,8 @@ var require_brace_style = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent brace style for blocks",
@@ -37994,6 +39767,8 @@ var require_comma_dangle = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow trailing commas",
@@ -38192,6 +39967,8 @@ var require_comma_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before and after commas",
@@ -38318,6 +40095,8 @@ var require_comma_style = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent comma style",
@@ -47497,6 +49276,8 @@ var require_computed_property_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing inside computed property brackets",
@@ -47632,8 +49413,13 @@ var require_consistent_return = __commonJS({
     "use strict";
     var astUtils = require_ast_utils2();
     var { upperCaseFirst } = require_string_utils();
-    function isUnreachable(segment) {
-      return !segment.reachable;
+    function areAllSegmentsUnreachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return false;
+        }
+      }
+      return true;
     }
     function isClassConstructor(node) {
       return node.type === "FunctionExpression" && node.parent && node.parent.type === "MethodDefinition" && node.parent.kind === "constructor";
@@ -47668,7 +49454,7 @@ var require_consistent_return = __commonJS({
         let funcInfo = null;
         function checkLastSegment(node) {
           let loc, name;
-          if (!funcInfo.hasReturnValue || funcInfo.codePath.currentSegments.every(isUnreachable) || astUtils.isES5Constructor(node) || isClassConstructor(node)) {
+          if (!funcInfo.hasReturnValue || areAllSegmentsUnreachable(funcInfo.currentSegments) || astUtils.isES5Constructor(node) || isClassConstructor(node)) {
             return;
           }
           if (node.type === "Program") {
@@ -47700,11 +49486,24 @@ var require_consistent_return = __commonJS({
               hasReturn: false,
               hasReturnValue: false,
               messageId: "",
-              node
+              node,
+              currentSegments: /* @__PURE__ */ new Set()
             };
           },
           onCodePathEnd() {
             funcInfo = funcInfo.upper;
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
+          },
+          onCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
           },
           // Reports a given return statement if it's inconsistent.
           ReturnStatement(node) {
@@ -47834,8 +49633,13 @@ var require_consistent_this = __commonJS({
 var require_constructor_super = __commonJS({
   "../../node_modules/eslint/lib/rules/constructor-super.js"(exports, module) {
     "use strict";
-    function isReachable(segment) {
-      return segment.reachable;
+    function isAnySegmentReachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return true;
+        }
+      }
+      return false;
     }
     function isConstructorFunction(node) {
       return node.type === "FunctionExpression" && node.parent.type === "MethodDefinition" && node.parent.kind === "constructor";
@@ -47926,7 +49730,8 @@ var require_constructor_super = __commonJS({
                 isConstructor: true,
                 hasExtends: Boolean(superClass),
                 superIsConstructor: isPossibleConstructor(superClass),
-                codePath
+                codePath,
+                currentSegments: /* @__PURE__ */ new Set()
               };
             } else {
               funcInfo = {
@@ -47934,7 +49739,8 @@ var require_constructor_super = __commonJS({
                 isConstructor: false,
                 hasExtends: false,
                 superIsConstructor: false,
-                codePath
+                codePath,
+                currentSegments: /* @__PURE__ */ new Set()
               };
             }
           },
@@ -47967,6 +49773,7 @@ var require_constructor_super = __commonJS({
            * @returns {void}
            */
           onCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
             if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
               return;
             }
@@ -47980,6 +49787,15 @@ var require_constructor_super = __commonJS({
               info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
               info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
             }
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
           },
           /**
            * Update information of the code path segment when a code path was
@@ -48029,11 +49845,10 @@ var require_constructor_super = __commonJS({
               return;
             }
             if (funcInfo.hasExtends) {
-              const segments = funcInfo.codePath.currentSegments;
+              const segments = funcInfo.currentSegments;
               let duplicate = false;
               let info = null;
-              for (let i = 0; i < segments.length; ++i) {
-                const segment = segments[i];
+              for (const segment of segments) {
                 if (segment.reachable) {
                   info = segInfoMap[segment.id];
                   duplicate = duplicate || info.calledInSomePaths;
@@ -48055,7 +49870,7 @@ var require_constructor_super = __commonJS({
                   info.validNodes.push(node);
                 }
               }
-            } else if (funcInfo.codePath.currentSegments.some(isReachable)) {
+            } else if (isAnySegmentReachable(funcInfo.currentSegments)) {
               context.report({
                 messageId: "unexpected",
                 node
@@ -48074,9 +49889,8 @@ var require_constructor_super = __commonJS({
             if (!node.argument) {
               return;
             }
-            const segments = funcInfo.codePath.currentSegments;
-            for (let i = 0; i < segments.length; ++i) {
-              const segment = segments[i];
+            const segments = funcInfo.currentSegments;
+            for (const segment of segments) {
               if (segment.reachable) {
                 const info = segInfoMap[segment.id];
                 info.calledInSomePaths = info.calledInEveryPaths = true;
@@ -48479,6 +50293,8 @@ var require_dot_location = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent newlines before and after dots",
@@ -48735,6 +50551,8 @@ var require_eol_last = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow newline at the end of files",
@@ -48915,6 +50733,7 @@ var require_eqeqeq = __commonJS({
 var require_for_direction = __commonJS({
   "../../node_modules/eslint/lib/rules/for-direction.js"(exports, module) {
     "use strict";
+    var { getStaticValue } = require_eslint_utils();
     module.exports = {
       meta: {
         type: "problem",
@@ -48930,6 +50749,7 @@ var require_for_direction = __commonJS({
         }
       },
       create(context) {
+        const { sourceCode } = context;
         function report(node) {
           context.report({
             node,
@@ -48937,14 +50757,12 @@ var require_for_direction = __commonJS({
           });
         }
         function getRightDirection(update, dir) {
-          if (update.right.type === "UnaryExpression") {
-            if (update.right.operator === "-") {
-              return -dir;
-            }
-          } else if (update.right.type === "Identifier") {
-            return 0;
+          const staticValue = getStaticValue(update.right, sourceCode.getScope(update));
+          if (staticValue && ["bigint", "boolean", "number"].includes(typeof staticValue.value)) {
+            const sign = Math.sign(Number(staticValue.value)) || 0;
+            return dir * sign;
           }
-          return dir;
+          return 0;
         }
         function getUpdateDirection(update, counter) {
           if (update.argument.type === "Identifier" && update.argument.name === counter) {
@@ -48970,24 +50788,29 @@ var require_for_direction = __commonJS({
         }
         return {
           ForStatement(node) {
-            if (node.test && node.test.type === "BinaryExpression" && node.test.left.type === "Identifier" && node.update) {
-              const counter = node.test.left.name;
-              const operator = node.test.operator;
-              const update = node.update;
-              let wrongDirection;
-              if (operator === "<" || operator === "<=") {
-                wrongDirection = -1;
-              } else if (operator === ">" || operator === ">=") {
-                wrongDirection = 1;
-              } else {
-                return;
-              }
-              if (update.type === "UpdateExpression") {
-                if (getUpdateDirection(update, counter) === wrongDirection) {
+            if (node.test && node.test.type === "BinaryExpression" && node.update) {
+              for (const counterPosition of ["left", "right"]) {
+                if (node.test[counterPosition].type !== "Identifier") {
+                  continue;
+                }
+                const counter = node.test[counterPosition].name;
+                const operator = node.test.operator;
+                const update = node.update;
+                let wrongDirection;
+                if (operator === "<" || operator === "<=") {
+                  wrongDirection = counterPosition === "left" ? -1 : 1;
+                } else if (operator === ">" || operator === ">=") {
+                  wrongDirection = counterPosition === "left" ? 1 : -1;
+                } else {
+                  return;
+                }
+                if (update.type === "UpdateExpression") {
+                  if (getUpdateDirection(update, counter) === wrongDirection) {
+                    report(node);
+                  }
+                } else if (update.type === "AssignmentExpression" && getAssignmentDirection(update, counter) === wrongDirection) {
                   report(node);
                 }
-              } else if (update.type === "AssignmentExpression" && getAssignmentDirection(update, counter) === wrongDirection) {
-                report(node);
               }
             }
           }
@@ -49004,6 +50827,8 @@ var require_func_call_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow spacing between function identifiers and their invocations",
@@ -49501,6 +51326,8 @@ var require_function_call_argument_newline = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce line breaks between arguments of a function call",
@@ -49589,6 +51416,8 @@ var require_function_paren_newline = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent line breaks inside function parentheses",
@@ -49797,6 +51626,8 @@ var require_generator_star_spacing = __commonJS({
     };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing around `*` operators in generator functions",
@@ -49919,8 +51750,13 @@ var require_getter_return = __commonJS({
     "use strict";
     var astUtils = require_ast_utils2();
     var TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/u;
-    function isReachable(segment) {
-      return segment.reachable;
+    function isAnySegmentReachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return true;
+        }
+      }
+      return false;
     }
     module.exports = {
       meta: {
@@ -49956,10 +51792,11 @@ var require_getter_return = __commonJS({
           codePath: null,
           hasReturn: false,
           shouldCheck: false,
-          node: null
+          node: null,
+          currentSegments: []
         };
         function checkLastSegment(node) {
-          if (funcInfo.shouldCheck && funcInfo.codePath.currentSegments.some(isReachable)) {
+          if (funcInfo.shouldCheck && isAnySegmentReachable(funcInfo.currentSegments)) {
             context.report({
               node,
               loc: astUtils.getFunctionHeadLoc(node, sourceCode),
@@ -49999,12 +51836,25 @@ var require_getter_return = __commonJS({
               codePath,
               hasReturn: false,
               shouldCheck: isGetter(node),
-              node
+              node,
+              currentSegments: /* @__PURE__ */ new Set()
             };
           },
           // Pops this function's information.
           onCodePathEnd() {
             funcInfo = funcInfo.upper;
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
+          },
+          onCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
           },
           // Checks the return statement is valid.
           ReturnStatement(node) {
@@ -50790,6 +52640,8 @@ var require_implicit_arrow_linebreak = __commonJS({
     var { isCommentToken, isNotOpeningParenToken } = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce the location of arrow function bodies",
@@ -51213,6 +53065,8 @@ var require_indent = __commonJS({
     };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent indentation",
@@ -52855,6 +54709,8 @@ var require_jsx_quotes = __commonJS({
     };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce the consistent use of either double or single quotes in JSX attributes",
@@ -52966,6 +54822,8 @@ var require_key_spacing = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing between keys and values in object literal properties",
@@ -53363,6 +55221,8 @@ var require_keyword_spacing = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before and after keywords",
@@ -53781,6 +55641,8 @@ var require_linebreak_style = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent linebreak style",
@@ -53863,6 +55725,8 @@ var require_lines_around_comment = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require empty lines around comments",
@@ -54215,8 +56079,15 @@ var require_lines_between_class_members = __commonJS({
   "../../node_modules/eslint/lib/rules/lines-between-class-members.js"(exports, module) {
     "use strict";
     var astUtils = require_ast_utils2();
+    var ClassMemberTypes = {
+      "*": { test: () => true },
+      field: { test: (node) => node.type === "PropertyDefinition" },
+      method: { test: (node) => node.type === "MethodDefinition" }
+    };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow an empty line between class members",
@@ -54226,7 +56097,32 @@ var require_lines_between_class_members = __commonJS({
         fixable: "whitespace",
         schema: [
           {
-            enum: ["always", "never"]
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  enforce: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        blankLine: { enum: ["always", "never"] },
+                        prev: { enum: ["method", "field", "*"] },
+                        next: { enum: ["method", "field", "*"] }
+                      },
+                      additionalProperties: false,
+                      required: ["blankLine", "prev", "next"]
+                    },
+                    minItems: 1
+                  }
+                },
+                additionalProperties: false,
+                required: ["enforce"]
+              },
+              {
+                enum: ["always", "never"]
+              }
+            ]
           },
           {
             type: "object",
@@ -54248,6 +56144,7 @@ var require_lines_between_class_members = __commonJS({
         const options = [];
         options[0] = context.options[0] || "always";
         options[1] = context.options[1] || { exceptAfterSingleLine: false };
+        const configureList = typeof options[0] === "object" ? options[0].enforce : [{ blankLine: options[0], prev: "*", next: "*" }];
         const sourceCode = context.sourceCode;
         function getBoundaryTokens(curNode, nextNode) {
           const lastToken = sourceCode.getLastToken(curNode);
@@ -54273,6 +56170,19 @@ var require_lines_between_class_members = __commonJS({
         function hasTokenOrCommentBetween(before, after) {
           return sourceCode.getTokensBetween(before, after, { includeComments: true }).length !== 0;
         }
+        function match(node, type) {
+          return ClassMemberTypes[type].test(node);
+        }
+        function getPaddingType(prevNode, nextNode) {
+          for (let i = configureList.length - 1; i >= 0; --i) {
+            const configure = configureList[i];
+            const matched = match(prevNode, configure.prev) && match(nextNode, configure.next);
+            if (matched) {
+              return configure.blankLine;
+            }
+          }
+          return null;
+        }
         return {
           ClassBody(node) {
             const body = node.body;
@@ -54286,15 +56196,27 @@ var require_lines_between_class_members = __commonJS({
               const isPadded = afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
               const hasTokenInPadding = hasTokenOrCommentBetween(beforePadding, afterPadding);
               const curLineLastToken = findLastConsecutiveTokenAfter(curLast, nextFirst, 0);
-              if (options[0] === "always" && !skip && !isPadded || options[0] === "never" && isPadded) {
+              const paddingType = getPaddingType(body[i], body[i + 1]);
+              if (paddingType === "never" && isPadded) {
                 context.report({
                   node: body[i + 1],
-                  messageId: isPadded ? "never" : "always",
+                  messageId: "never",
                   fix(fixer) {
                     if (hasTokenInPadding) {
                       return null;
                     }
-                    return isPadded ? fixer.replaceTextRange([beforePadding.range[1], afterPadding.range[0]], "\n") : fixer.insertTextAfter(curLineLastToken, "\n");
+                    return fixer.replaceTextRange([beforePadding.range[1], afterPadding.range[0]], "\n");
+                  }
+                });
+              } else if (paddingType === "always" && !skip && !isPadded) {
+                context.report({
+                  node: body[i + 1],
+                  messageId: "always",
+                  fix(fixer) {
+                    if (hasTokenInPadding) {
+                      return null;
+                    }
+                    return fixer.insertTextAfter(curLineLastToken, "\n");
                   }
                 });
               }
@@ -54368,6 +56290,16 @@ var require_logical_assignment_operators = __commonJS({
         return false;
       }
       return node.parent.type === "WithStatement" && node.parent.body === node ? true : isInsideWithBlock(node.parent);
+    }
+    function getLeftmostOperand(sourceCode, node) {
+      let left = node.left;
+      while (left.type === "LogicalExpression" && left.operator === node.operator) {
+        if (astUtils.isParenthesised(sourceCode, left)) {
+          return left;
+        }
+        left = left.left;
+      }
+      return left;
     }
     module.exports = {
       meta: {
@@ -54481,7 +56413,8 @@ var require_logical_assignment_operators = __commonJS({
         return {
           // foo = foo || bar
           "AssignmentExpression[operator='='][right.type='LogicalExpression']"(assignment) {
-            if (!astUtils.isSameReference(assignment.left, assignment.right.left)) {
+            const leftOperand = getLeftmostOperand(sourceCode, assignment.right);
+            if (!astUtils.isSameReference(assignment.left, leftOperand)) {
               return;
             }
             const descriptor = {
@@ -54498,9 +56431,9 @@ var require_logical_assignment_operators = __commonJS({
                 }
                 const assignmentOperatorToken = getOperatorToken(assignment);
                 yield ruleFixer.insertTextBefore(assignmentOperatorToken, assignment.right.operator);
-                const logicalOperatorToken = getOperatorToken(assignment.right);
+                const logicalOperatorToken = getOperatorToken(leftOperand.parent);
                 const firstRightOperandToken = sourceCode.getTokenAfter(logicalOperatorToken);
-                yield ruleFixer.removeRange([assignment.right.range[0], firstRightOperandToken.range[0]]);
+                yield ruleFixer.removeRange([leftOperand.parent.range[0], firstRightOperandToken.range[0]]);
               }
             };
             context.report(createConditionalFixer(descriptor, suggestion, cannotBeGetter(assignment.left)));
@@ -54816,6 +56749,8 @@ var require_max_len = __commonJS({
     };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce a maximum line length",
@@ -55533,6 +57468,8 @@ var require_max_statements_per_line = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce a maximum number of statements allowed per line",
@@ -55969,6 +57906,8 @@ var require_multiline_ternary = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce newlines between operands of ternary expressions",
@@ -56272,6 +58211,8 @@ var require_new_parens = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce or disallow parentheses when invoking a constructor with no arguments",
@@ -56564,6 +58505,8 @@ var require_newline_per_chained_call = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require a newline after each call in a method chain",
@@ -56724,6 +58667,13 @@ var require_no_alert = __commonJS({
 var require_no_array_constructor = __commonJS({
   "../../node_modules/eslint/lib/rules/no-array-constructor.js"(exports, module) {
     "use strict";
+    var {
+      getVariableByName,
+      isClosingParenToken,
+      isOpeningParenToken,
+      isStartOfExpressionStatement,
+      needsPrecedingSemicolon
+    } = require_ast_utils2();
     module.exports = {
       meta: {
         type: "suggestion",
@@ -56732,15 +58682,56 @@ var require_no_array_constructor = __commonJS({
           recommended: false,
           url: "https://eslint.org/docs/latest/rules/no-array-constructor"
         },
+        hasSuggestions: true,
         schema: [],
         messages: {
-          preferLiteral: "The array literal notation [] is preferable."
+          preferLiteral: "The array literal notation [] is preferable.",
+          useLiteral: "Replace with an array literal.",
+          useLiteralAfterSemicolon: "Replace with an array literal, add preceding semicolon."
         }
       },
       create(context) {
+        const sourceCode = context.sourceCode;
+        function getArgumentsText(node) {
+          const lastToken = sourceCode.getLastToken(node);
+          if (!isClosingParenToken(lastToken)) {
+            return "";
+          }
+          let firstToken = node.callee;
+          do {
+            firstToken = sourceCode.getTokenAfter(firstToken);
+            if (!firstToken || firstToken === lastToken) {
+              return "";
+            }
+          } while (!isOpeningParenToken(firstToken));
+          return sourceCode.text.slice(firstToken.range[1], lastToken.range[0]);
+        }
         function check(node) {
-          if (node.arguments.length !== 1 && node.callee.type === "Identifier" && node.callee.name === "Array") {
-            context.report({ node, messageId: "preferLiteral" });
+          if (node.callee.type !== "Identifier" || node.callee.name !== "Array" || node.arguments.length === 1 && node.arguments[0].type !== "SpreadElement") {
+            return;
+          }
+          const variable = getVariableByName(sourceCode.getScope(node), "Array");
+          if (variable && variable.identifiers.length === 0) {
+            const argsText = getArgumentsText(node);
+            let fixText;
+            let messageId;
+            if (isStartOfExpressionStatement(node) && needsPrecedingSemicolon(sourceCode, node)) {
+              fixText = `;[${argsText}]`;
+              messageId = "useLiteralAfterSemicolon";
+            } else {
+              fixText = `[${argsText}]`;
+              messageId = "useLiteral";
+            }
+            context.report({
+              node,
+              messageId: "preferLiteral",
+              suggest: [
+                {
+                  messageId,
+                  fix: (fixer) => fixer.replaceText(node, fixText)
+                }
+              ]
+            });
           }
         }
         return {
@@ -57260,6 +59251,8 @@ var require_no_confusing_arrow = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Disallow arrow functions where they could be confused with comparisons",
@@ -57333,8 +59326,10 @@ var require_no_console = __commonJS({
             additionalProperties: false
           }
         ],
+        hasSuggestions: true,
         messages: {
-          unexpected: "Unexpected console statement."
+          unexpected: "Unexpected console statement.",
+          removeConsole: "Remove the console.{{ propertyName }}()."
         }
       },
       create(context) {
@@ -57354,12 +59349,30 @@ var require_no_console = __commonJS({
           const parent = node.parent;
           return parent.type === "MemberExpression" && parent.object === node && !isAllowed(parent);
         }
+        function maybeAsiHazard(node) {
+          const SAFE_TOKENS_BEFORE = /^[:;{]$/u;
+          const UNSAFE_CHARS_AFTER = /^[-[(/+`]/u;
+          const tokenBefore = sourceCode.getTokenBefore(node);
+          const tokenAfter = sourceCode.getTokenAfter(node);
+          return Boolean(tokenAfter) && UNSAFE_CHARS_AFTER.test(tokenAfter.value) && tokenAfter.value !== "++" && tokenAfter.value !== "--" && Boolean(tokenBefore) && !SAFE_TOKENS_BEFORE.test(tokenBefore.value);
+        }
+        function canProvideSuggestions(node) {
+          return node.parent.type === "CallExpression" && node.parent.callee === node && node.parent.parent.type === "ExpressionStatement" && astUtils.STATEMENT_LIST_PARENTS.has(node.parent.parent.parent.type) && !maybeAsiHazard(node.parent.parent);
+        }
         function report(reference) {
           const node = reference.identifier.parent;
+          const propertyName = astUtils.getStaticPropertyName(node);
           context.report({
             node,
             loc: node.loc,
-            messageId: "unexpected"
+            messageId: "unexpected",
+            suggest: canProvideSuggestions(node) ? [{
+              messageId: "removeConsole",
+              data: { propertyName },
+              fix(fixer) {
+                return fixer.remove(node.parent.parent);
+              }
+            }] : []
           });
         }
         return {
@@ -57415,11 +59428,2023 @@ var require_no_const_assign = __commonJS({
   }
 });
 
+// ../../node_modules/eslint/node_modules/globals/globals.json
+var require_globals4 = __commonJS({
+  "../../node_modules/eslint/node_modules/globals/globals.json"(exports, module) {
+    module.exports = {
+      builtin: {
+        AggregateError: false,
+        Array: false,
+        ArrayBuffer: false,
+        Atomics: false,
+        BigInt: false,
+        BigInt64Array: false,
+        BigUint64Array: false,
+        Boolean: false,
+        constructor: false,
+        DataView: false,
+        Date: false,
+        decodeURI: false,
+        decodeURIComponent: false,
+        encodeURI: false,
+        encodeURIComponent: false,
+        Error: false,
+        escape: false,
+        eval: false,
+        EvalError: false,
+        FinalizationRegistry: false,
+        Float32Array: false,
+        Float64Array: false,
+        Function: false,
+        globalThis: false,
+        hasOwnProperty: false,
+        Infinity: false,
+        Int16Array: false,
+        Int32Array: false,
+        Int8Array: false,
+        isFinite: false,
+        isNaN: false,
+        isPrototypeOf: false,
+        JSON: false,
+        Map: false,
+        Math: false,
+        NaN: false,
+        Number: false,
+        Object: false,
+        parseFloat: false,
+        parseInt: false,
+        Promise: false,
+        propertyIsEnumerable: false,
+        Proxy: false,
+        RangeError: false,
+        ReferenceError: false,
+        Reflect: false,
+        RegExp: false,
+        Set: false,
+        SharedArrayBuffer: false,
+        String: false,
+        Symbol: false,
+        SyntaxError: false,
+        toLocaleString: false,
+        toString: false,
+        TypeError: false,
+        Uint16Array: false,
+        Uint32Array: false,
+        Uint8Array: false,
+        Uint8ClampedArray: false,
+        undefined: false,
+        unescape: false,
+        URIError: false,
+        valueOf: false,
+        WeakMap: false,
+        WeakRef: false,
+        WeakSet: false
+      },
+      es5: {
+        Array: false,
+        Boolean: false,
+        constructor: false,
+        Date: false,
+        decodeURI: false,
+        decodeURIComponent: false,
+        encodeURI: false,
+        encodeURIComponent: false,
+        Error: false,
+        escape: false,
+        eval: false,
+        EvalError: false,
+        Function: false,
+        hasOwnProperty: false,
+        Infinity: false,
+        isFinite: false,
+        isNaN: false,
+        isPrototypeOf: false,
+        JSON: false,
+        Math: false,
+        NaN: false,
+        Number: false,
+        Object: false,
+        parseFloat: false,
+        parseInt: false,
+        propertyIsEnumerable: false,
+        RangeError: false,
+        ReferenceError: false,
+        RegExp: false,
+        String: false,
+        SyntaxError: false,
+        toLocaleString: false,
+        toString: false,
+        TypeError: false,
+        undefined: false,
+        unescape: false,
+        URIError: false,
+        valueOf: false
+      },
+      es2015: {
+        Array: false,
+        ArrayBuffer: false,
+        Boolean: false,
+        constructor: false,
+        DataView: false,
+        Date: false,
+        decodeURI: false,
+        decodeURIComponent: false,
+        encodeURI: false,
+        encodeURIComponent: false,
+        Error: false,
+        escape: false,
+        eval: false,
+        EvalError: false,
+        Float32Array: false,
+        Float64Array: false,
+        Function: false,
+        hasOwnProperty: false,
+        Infinity: false,
+        Int16Array: false,
+        Int32Array: false,
+        Int8Array: false,
+        isFinite: false,
+        isNaN: false,
+        isPrototypeOf: false,
+        JSON: false,
+        Map: false,
+        Math: false,
+        NaN: false,
+        Number: false,
+        Object: false,
+        parseFloat: false,
+        parseInt: false,
+        Promise: false,
+        propertyIsEnumerable: false,
+        Proxy: false,
+        RangeError: false,
+        ReferenceError: false,
+        Reflect: false,
+        RegExp: false,
+        Set: false,
+        String: false,
+        Symbol: false,
+        SyntaxError: false,
+        toLocaleString: false,
+        toString: false,
+        TypeError: false,
+        Uint16Array: false,
+        Uint32Array: false,
+        Uint8Array: false,
+        Uint8ClampedArray: false,
+        undefined: false,
+        unescape: false,
+        URIError: false,
+        valueOf: false,
+        WeakMap: false,
+        WeakSet: false
+      },
+      es2017: {
+        Array: false,
+        ArrayBuffer: false,
+        Atomics: false,
+        Boolean: false,
+        constructor: false,
+        DataView: false,
+        Date: false,
+        decodeURI: false,
+        decodeURIComponent: false,
+        encodeURI: false,
+        encodeURIComponent: false,
+        Error: false,
+        escape: false,
+        eval: false,
+        EvalError: false,
+        Float32Array: false,
+        Float64Array: false,
+        Function: false,
+        hasOwnProperty: false,
+        Infinity: false,
+        Int16Array: false,
+        Int32Array: false,
+        Int8Array: false,
+        isFinite: false,
+        isNaN: false,
+        isPrototypeOf: false,
+        JSON: false,
+        Map: false,
+        Math: false,
+        NaN: false,
+        Number: false,
+        Object: false,
+        parseFloat: false,
+        parseInt: false,
+        Promise: false,
+        propertyIsEnumerable: false,
+        Proxy: false,
+        RangeError: false,
+        ReferenceError: false,
+        Reflect: false,
+        RegExp: false,
+        Set: false,
+        SharedArrayBuffer: false,
+        String: false,
+        Symbol: false,
+        SyntaxError: false,
+        toLocaleString: false,
+        toString: false,
+        TypeError: false,
+        Uint16Array: false,
+        Uint32Array: false,
+        Uint8Array: false,
+        Uint8ClampedArray: false,
+        undefined: false,
+        unescape: false,
+        URIError: false,
+        valueOf: false,
+        WeakMap: false,
+        WeakSet: false
+      },
+      es2020: {
+        Array: false,
+        ArrayBuffer: false,
+        Atomics: false,
+        BigInt: false,
+        BigInt64Array: false,
+        BigUint64Array: false,
+        Boolean: false,
+        constructor: false,
+        DataView: false,
+        Date: false,
+        decodeURI: false,
+        decodeURIComponent: false,
+        encodeURI: false,
+        encodeURIComponent: false,
+        Error: false,
+        escape: false,
+        eval: false,
+        EvalError: false,
+        Float32Array: false,
+        Float64Array: false,
+        Function: false,
+        globalThis: false,
+        hasOwnProperty: false,
+        Infinity: false,
+        Int16Array: false,
+        Int32Array: false,
+        Int8Array: false,
+        isFinite: false,
+        isNaN: false,
+        isPrototypeOf: false,
+        JSON: false,
+        Map: false,
+        Math: false,
+        NaN: false,
+        Number: false,
+        Object: false,
+        parseFloat: false,
+        parseInt: false,
+        Promise: false,
+        propertyIsEnumerable: false,
+        Proxy: false,
+        RangeError: false,
+        ReferenceError: false,
+        Reflect: false,
+        RegExp: false,
+        Set: false,
+        SharedArrayBuffer: false,
+        String: false,
+        Symbol: false,
+        SyntaxError: false,
+        toLocaleString: false,
+        toString: false,
+        TypeError: false,
+        Uint16Array: false,
+        Uint32Array: false,
+        Uint8Array: false,
+        Uint8ClampedArray: false,
+        undefined: false,
+        unescape: false,
+        URIError: false,
+        valueOf: false,
+        WeakMap: false,
+        WeakSet: false
+      },
+      es2021: {
+        AggregateError: false,
+        Array: false,
+        ArrayBuffer: false,
+        Atomics: false,
+        BigInt: false,
+        BigInt64Array: false,
+        BigUint64Array: false,
+        Boolean: false,
+        constructor: false,
+        DataView: false,
+        Date: false,
+        decodeURI: false,
+        decodeURIComponent: false,
+        encodeURI: false,
+        encodeURIComponent: false,
+        Error: false,
+        escape: false,
+        eval: false,
+        EvalError: false,
+        FinalizationRegistry: false,
+        Float32Array: false,
+        Float64Array: false,
+        Function: false,
+        globalThis: false,
+        hasOwnProperty: false,
+        Infinity: false,
+        Int16Array: false,
+        Int32Array: false,
+        Int8Array: false,
+        isFinite: false,
+        isNaN: false,
+        isPrototypeOf: false,
+        JSON: false,
+        Map: false,
+        Math: false,
+        NaN: false,
+        Number: false,
+        Object: false,
+        parseFloat: false,
+        parseInt: false,
+        Promise: false,
+        propertyIsEnumerable: false,
+        Proxy: false,
+        RangeError: false,
+        ReferenceError: false,
+        Reflect: false,
+        RegExp: false,
+        Set: false,
+        SharedArrayBuffer: false,
+        String: false,
+        Symbol: false,
+        SyntaxError: false,
+        toLocaleString: false,
+        toString: false,
+        TypeError: false,
+        Uint16Array: false,
+        Uint32Array: false,
+        Uint8Array: false,
+        Uint8ClampedArray: false,
+        undefined: false,
+        unescape: false,
+        URIError: false,
+        valueOf: false,
+        WeakMap: false,
+        WeakRef: false,
+        WeakSet: false
+      },
+      browser: {
+        AbortController: false,
+        AbortSignal: false,
+        addEventListener: false,
+        alert: false,
+        AnalyserNode: false,
+        Animation: false,
+        AnimationEffectReadOnly: false,
+        AnimationEffectTiming: false,
+        AnimationEffectTimingReadOnly: false,
+        AnimationEvent: false,
+        AnimationPlaybackEvent: false,
+        AnimationTimeline: false,
+        applicationCache: false,
+        ApplicationCache: false,
+        ApplicationCacheErrorEvent: false,
+        atob: false,
+        Attr: false,
+        Audio: false,
+        AudioBuffer: false,
+        AudioBufferSourceNode: false,
+        AudioContext: false,
+        AudioDestinationNode: false,
+        AudioListener: false,
+        AudioNode: false,
+        AudioParam: false,
+        AudioProcessingEvent: false,
+        AudioScheduledSourceNode: false,
+        AudioWorkletGlobalScope: false,
+        AudioWorkletNode: false,
+        AudioWorkletProcessor: false,
+        BarProp: false,
+        BaseAudioContext: false,
+        BatteryManager: false,
+        BeforeUnloadEvent: false,
+        BiquadFilterNode: false,
+        Blob: false,
+        BlobEvent: false,
+        blur: false,
+        BroadcastChannel: false,
+        btoa: false,
+        BudgetService: false,
+        ByteLengthQueuingStrategy: false,
+        Cache: false,
+        caches: false,
+        CacheStorage: false,
+        cancelAnimationFrame: false,
+        cancelIdleCallback: false,
+        CanvasCaptureMediaStreamTrack: false,
+        CanvasGradient: false,
+        CanvasPattern: false,
+        CanvasRenderingContext2D: false,
+        ChannelMergerNode: false,
+        ChannelSplitterNode: false,
+        CharacterData: false,
+        clearInterval: false,
+        clearTimeout: false,
+        clientInformation: false,
+        ClipboardEvent: false,
+        ClipboardItem: false,
+        close: false,
+        closed: false,
+        CloseEvent: false,
+        Comment: false,
+        CompositionEvent: false,
+        CompressionStream: false,
+        confirm: false,
+        console: false,
+        ConstantSourceNode: false,
+        ConvolverNode: false,
+        CountQueuingStrategy: false,
+        createImageBitmap: false,
+        Credential: false,
+        CredentialsContainer: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CSS: false,
+        CSSConditionRule: false,
+        CSSFontFaceRule: false,
+        CSSGroupingRule: false,
+        CSSImportRule: false,
+        CSSKeyframeRule: false,
+        CSSKeyframesRule: false,
+        CSSMatrixComponent: false,
+        CSSMediaRule: false,
+        CSSNamespaceRule: false,
+        CSSPageRule: false,
+        CSSPerspective: false,
+        CSSRotate: false,
+        CSSRule: false,
+        CSSRuleList: false,
+        CSSScale: false,
+        CSSSkew: false,
+        CSSSkewX: false,
+        CSSSkewY: false,
+        CSSStyleDeclaration: false,
+        CSSStyleRule: false,
+        CSSStyleSheet: false,
+        CSSSupportsRule: false,
+        CSSTransformValue: false,
+        CSSTranslate: false,
+        CustomElementRegistry: false,
+        customElements: false,
+        CustomEvent: false,
+        DataTransfer: false,
+        DataTransferItem: false,
+        DataTransferItemList: false,
+        DecompressionStream: false,
+        defaultstatus: false,
+        defaultStatus: false,
+        DelayNode: false,
+        DeviceMotionEvent: false,
+        DeviceOrientationEvent: false,
+        devicePixelRatio: false,
+        dispatchEvent: false,
+        document: false,
+        Document: false,
+        DocumentFragment: false,
+        DocumentType: false,
+        DOMError: false,
+        DOMException: false,
+        DOMImplementation: false,
+        DOMMatrix: false,
+        DOMMatrixReadOnly: false,
+        DOMParser: false,
+        DOMPoint: false,
+        DOMPointReadOnly: false,
+        DOMQuad: false,
+        DOMRect: false,
+        DOMRectList: false,
+        DOMRectReadOnly: false,
+        DOMStringList: false,
+        DOMStringMap: false,
+        DOMTokenList: false,
+        DragEvent: false,
+        DynamicsCompressorNode: false,
+        Element: false,
+        ErrorEvent: false,
+        event: false,
+        Event: false,
+        EventSource: false,
+        EventTarget: false,
+        external: false,
+        fetch: false,
+        File: false,
+        FileList: false,
+        FileReader: false,
+        find: false,
+        focus: false,
+        FocusEvent: false,
+        FontFace: false,
+        FontFaceSetLoadEvent: false,
+        FormData: false,
+        FormDataEvent: false,
+        frameElement: false,
+        frames: false,
+        GainNode: false,
+        Gamepad: false,
+        GamepadButton: false,
+        GamepadEvent: false,
+        getComputedStyle: false,
+        getSelection: false,
+        HashChangeEvent: false,
+        Headers: false,
+        history: false,
+        History: false,
+        HTMLAllCollection: false,
+        HTMLAnchorElement: false,
+        HTMLAreaElement: false,
+        HTMLAudioElement: false,
+        HTMLBaseElement: false,
+        HTMLBodyElement: false,
+        HTMLBRElement: false,
+        HTMLButtonElement: false,
+        HTMLCanvasElement: false,
+        HTMLCollection: false,
+        HTMLContentElement: false,
+        HTMLDataElement: false,
+        HTMLDataListElement: false,
+        HTMLDetailsElement: false,
+        HTMLDialogElement: false,
+        HTMLDirectoryElement: false,
+        HTMLDivElement: false,
+        HTMLDListElement: false,
+        HTMLDocument: false,
+        HTMLElement: false,
+        HTMLEmbedElement: false,
+        HTMLFieldSetElement: false,
+        HTMLFontElement: false,
+        HTMLFormControlsCollection: false,
+        HTMLFormElement: false,
+        HTMLFrameElement: false,
+        HTMLFrameSetElement: false,
+        HTMLHeadElement: false,
+        HTMLHeadingElement: false,
+        HTMLHRElement: false,
+        HTMLHtmlElement: false,
+        HTMLIFrameElement: false,
+        HTMLImageElement: false,
+        HTMLInputElement: false,
+        HTMLLabelElement: false,
+        HTMLLegendElement: false,
+        HTMLLIElement: false,
+        HTMLLinkElement: false,
+        HTMLMapElement: false,
+        HTMLMarqueeElement: false,
+        HTMLMediaElement: false,
+        HTMLMenuElement: false,
+        HTMLMetaElement: false,
+        HTMLMeterElement: false,
+        HTMLModElement: false,
+        HTMLObjectElement: false,
+        HTMLOListElement: false,
+        HTMLOptGroupElement: false,
+        HTMLOptionElement: false,
+        HTMLOptionsCollection: false,
+        HTMLOutputElement: false,
+        HTMLParagraphElement: false,
+        HTMLParamElement: false,
+        HTMLPictureElement: false,
+        HTMLPreElement: false,
+        HTMLProgressElement: false,
+        HTMLQuoteElement: false,
+        HTMLScriptElement: false,
+        HTMLSelectElement: false,
+        HTMLShadowElement: false,
+        HTMLSlotElement: false,
+        HTMLSourceElement: false,
+        HTMLSpanElement: false,
+        HTMLStyleElement: false,
+        HTMLTableCaptionElement: false,
+        HTMLTableCellElement: false,
+        HTMLTableColElement: false,
+        HTMLTableElement: false,
+        HTMLTableRowElement: false,
+        HTMLTableSectionElement: false,
+        HTMLTemplateElement: false,
+        HTMLTextAreaElement: false,
+        HTMLTimeElement: false,
+        HTMLTitleElement: false,
+        HTMLTrackElement: false,
+        HTMLUListElement: false,
+        HTMLUnknownElement: false,
+        HTMLVideoElement: false,
+        IDBCursor: false,
+        IDBCursorWithValue: false,
+        IDBDatabase: false,
+        IDBFactory: false,
+        IDBIndex: false,
+        IDBKeyRange: false,
+        IDBObjectStore: false,
+        IDBOpenDBRequest: false,
+        IDBRequest: false,
+        IDBTransaction: false,
+        IDBVersionChangeEvent: false,
+        IdleDeadline: false,
+        IIRFilterNode: false,
+        Image: false,
+        ImageBitmap: false,
+        ImageBitmapRenderingContext: false,
+        ImageCapture: false,
+        ImageData: false,
+        indexedDB: false,
+        innerHeight: false,
+        innerWidth: false,
+        InputEvent: false,
+        IntersectionObserver: false,
+        IntersectionObserverEntry: false,
+        Intl: false,
+        isSecureContext: false,
+        KeyboardEvent: false,
+        KeyframeEffect: false,
+        KeyframeEffectReadOnly: false,
+        length: false,
+        localStorage: false,
+        location: true,
+        Location: false,
+        locationbar: false,
+        matchMedia: false,
+        MediaDeviceInfo: false,
+        MediaDevices: false,
+        MediaElementAudioSourceNode: false,
+        MediaEncryptedEvent: false,
+        MediaError: false,
+        MediaKeyMessageEvent: false,
+        MediaKeySession: false,
+        MediaKeyStatusMap: false,
+        MediaKeySystemAccess: false,
+        MediaList: false,
+        MediaMetadata: false,
+        MediaQueryList: false,
+        MediaQueryListEvent: false,
+        MediaRecorder: false,
+        MediaSettingsRange: false,
+        MediaSource: false,
+        MediaStream: false,
+        MediaStreamAudioDestinationNode: false,
+        MediaStreamAudioSourceNode: false,
+        MediaStreamConstraints: false,
+        MediaStreamEvent: false,
+        MediaStreamTrack: false,
+        MediaStreamTrackEvent: false,
+        menubar: false,
+        MessageChannel: false,
+        MessageEvent: false,
+        MessagePort: false,
+        MIDIAccess: false,
+        MIDIConnectionEvent: false,
+        MIDIInput: false,
+        MIDIInputMap: false,
+        MIDIMessageEvent: false,
+        MIDIOutput: false,
+        MIDIOutputMap: false,
+        MIDIPort: false,
+        MimeType: false,
+        MimeTypeArray: false,
+        MouseEvent: false,
+        moveBy: false,
+        moveTo: false,
+        MutationEvent: false,
+        MutationObserver: false,
+        MutationRecord: false,
+        name: false,
+        NamedNodeMap: false,
+        NavigationPreloadManager: false,
+        navigator: false,
+        Navigator: false,
+        NavigatorUAData: false,
+        NetworkInformation: false,
+        Node: false,
+        NodeFilter: false,
+        NodeIterator: false,
+        NodeList: false,
+        Notification: false,
+        OfflineAudioCompletionEvent: false,
+        OfflineAudioContext: false,
+        offscreenBuffering: false,
+        OffscreenCanvas: true,
+        OffscreenCanvasRenderingContext2D: false,
+        onabort: true,
+        onafterprint: true,
+        onanimationend: true,
+        onanimationiteration: true,
+        onanimationstart: true,
+        onappinstalled: true,
+        onauxclick: true,
+        onbeforeinstallprompt: true,
+        onbeforeprint: true,
+        onbeforeunload: true,
+        onblur: true,
+        oncancel: true,
+        oncanplay: true,
+        oncanplaythrough: true,
+        onchange: true,
+        onclick: true,
+        onclose: true,
+        oncontextmenu: true,
+        oncuechange: true,
+        ondblclick: true,
+        ondevicemotion: true,
+        ondeviceorientation: true,
+        ondeviceorientationabsolute: true,
+        ondrag: true,
+        ondragend: true,
+        ondragenter: true,
+        ondragleave: true,
+        ondragover: true,
+        ondragstart: true,
+        ondrop: true,
+        ondurationchange: true,
+        onemptied: true,
+        onended: true,
+        onerror: true,
+        onfocus: true,
+        ongotpointercapture: true,
+        onhashchange: true,
+        oninput: true,
+        oninvalid: true,
+        onkeydown: true,
+        onkeypress: true,
+        onkeyup: true,
+        onlanguagechange: true,
+        onload: true,
+        onloadeddata: true,
+        onloadedmetadata: true,
+        onloadstart: true,
+        onlostpointercapture: true,
+        onmessage: true,
+        onmessageerror: true,
+        onmousedown: true,
+        onmouseenter: true,
+        onmouseleave: true,
+        onmousemove: true,
+        onmouseout: true,
+        onmouseover: true,
+        onmouseup: true,
+        onmousewheel: true,
+        onoffline: true,
+        ononline: true,
+        onpagehide: true,
+        onpageshow: true,
+        onpause: true,
+        onplay: true,
+        onplaying: true,
+        onpointercancel: true,
+        onpointerdown: true,
+        onpointerenter: true,
+        onpointerleave: true,
+        onpointermove: true,
+        onpointerout: true,
+        onpointerover: true,
+        onpointerup: true,
+        onpopstate: true,
+        onprogress: true,
+        onratechange: true,
+        onrejectionhandled: true,
+        onreset: true,
+        onresize: true,
+        onscroll: true,
+        onsearch: true,
+        onseeked: true,
+        onseeking: true,
+        onselect: true,
+        onstalled: true,
+        onstorage: true,
+        onsubmit: true,
+        onsuspend: true,
+        ontimeupdate: true,
+        ontoggle: true,
+        ontransitionend: true,
+        onunhandledrejection: true,
+        onunload: true,
+        onvolumechange: true,
+        onwaiting: true,
+        onwheel: true,
+        open: false,
+        openDatabase: false,
+        opener: false,
+        Option: false,
+        origin: false,
+        OscillatorNode: false,
+        outerHeight: false,
+        outerWidth: false,
+        OverconstrainedError: false,
+        PageTransitionEvent: false,
+        pageXOffset: false,
+        pageYOffset: false,
+        PannerNode: false,
+        parent: false,
+        Path2D: false,
+        PaymentAddress: false,
+        PaymentRequest: false,
+        PaymentRequestUpdateEvent: false,
+        PaymentResponse: false,
+        performance: false,
+        Performance: false,
+        PerformanceEntry: false,
+        PerformanceLongTaskTiming: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceNavigation: false,
+        PerformanceNavigationTiming: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformancePaintTiming: false,
+        PerformanceResourceTiming: false,
+        PerformanceTiming: false,
+        PeriodicWave: false,
+        Permissions: false,
+        PermissionStatus: false,
+        personalbar: false,
+        PhotoCapabilities: false,
+        Plugin: false,
+        PluginArray: false,
+        PointerEvent: false,
+        PopStateEvent: false,
+        postMessage: false,
+        Presentation: false,
+        PresentationAvailability: false,
+        PresentationConnection: false,
+        PresentationConnectionAvailableEvent: false,
+        PresentationConnectionCloseEvent: false,
+        PresentationConnectionList: false,
+        PresentationReceiver: false,
+        PresentationRequest: false,
+        print: false,
+        ProcessingInstruction: false,
+        ProgressEvent: false,
+        PromiseRejectionEvent: false,
+        prompt: false,
+        PushManager: false,
+        PushSubscription: false,
+        PushSubscriptionOptions: false,
+        queueMicrotask: false,
+        RadioNodeList: false,
+        Range: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
+        registerProcessor: false,
+        RemotePlayback: false,
+        removeEventListener: false,
+        reportError: false,
+        Request: false,
+        requestAnimationFrame: false,
+        requestIdleCallback: false,
+        resizeBy: false,
+        ResizeObserver: false,
+        ResizeObserverEntry: false,
+        resizeTo: false,
+        Response: false,
+        RTCCertificate: false,
+        RTCDataChannel: false,
+        RTCDataChannelEvent: false,
+        RTCDtlsTransport: false,
+        RTCIceCandidate: false,
+        RTCIceGatherer: false,
+        RTCIceTransport: false,
+        RTCPeerConnection: false,
+        RTCPeerConnectionIceEvent: false,
+        RTCRtpContributingSource: false,
+        RTCRtpReceiver: false,
+        RTCRtpSender: false,
+        RTCSctpTransport: false,
+        RTCSessionDescription: false,
+        RTCStatsReport: false,
+        RTCTrackEvent: false,
+        screen: false,
+        Screen: false,
+        screenLeft: false,
+        ScreenOrientation: false,
+        screenTop: false,
+        screenX: false,
+        screenY: false,
+        ScriptProcessorNode: false,
+        scroll: false,
+        scrollbars: false,
+        scrollBy: false,
+        scrollTo: false,
+        scrollX: false,
+        scrollY: false,
+        SecurityPolicyViolationEvent: false,
+        Selection: false,
+        self: false,
+        ServiceWorker: false,
+        ServiceWorkerContainer: false,
+        ServiceWorkerRegistration: false,
+        sessionStorage: false,
+        setInterval: false,
+        setTimeout: false,
+        ShadowRoot: false,
+        SharedWorker: false,
+        SourceBuffer: false,
+        SourceBufferList: false,
+        speechSynthesis: false,
+        SpeechSynthesisEvent: false,
+        SpeechSynthesisUtterance: false,
+        StaticRange: false,
+        status: false,
+        statusbar: false,
+        StereoPannerNode: false,
+        stop: false,
+        Storage: false,
+        StorageEvent: false,
+        StorageManager: false,
+        structuredClone: false,
+        styleMedia: false,
+        StyleSheet: false,
+        StyleSheetList: false,
+        SubmitEvent: false,
+        SubtleCrypto: false,
+        SVGAElement: false,
+        SVGAngle: false,
+        SVGAnimatedAngle: false,
+        SVGAnimatedBoolean: false,
+        SVGAnimatedEnumeration: false,
+        SVGAnimatedInteger: false,
+        SVGAnimatedLength: false,
+        SVGAnimatedLengthList: false,
+        SVGAnimatedNumber: false,
+        SVGAnimatedNumberList: false,
+        SVGAnimatedPreserveAspectRatio: false,
+        SVGAnimatedRect: false,
+        SVGAnimatedString: false,
+        SVGAnimatedTransformList: false,
+        SVGAnimateElement: false,
+        SVGAnimateMotionElement: false,
+        SVGAnimateTransformElement: false,
+        SVGAnimationElement: false,
+        SVGCircleElement: false,
+        SVGClipPathElement: false,
+        SVGComponentTransferFunctionElement: false,
+        SVGDefsElement: false,
+        SVGDescElement: false,
+        SVGDiscardElement: false,
+        SVGElement: false,
+        SVGEllipseElement: false,
+        SVGFEBlendElement: false,
+        SVGFEColorMatrixElement: false,
+        SVGFEComponentTransferElement: false,
+        SVGFECompositeElement: false,
+        SVGFEConvolveMatrixElement: false,
+        SVGFEDiffuseLightingElement: false,
+        SVGFEDisplacementMapElement: false,
+        SVGFEDistantLightElement: false,
+        SVGFEDropShadowElement: false,
+        SVGFEFloodElement: false,
+        SVGFEFuncAElement: false,
+        SVGFEFuncBElement: false,
+        SVGFEFuncGElement: false,
+        SVGFEFuncRElement: false,
+        SVGFEGaussianBlurElement: false,
+        SVGFEImageElement: false,
+        SVGFEMergeElement: false,
+        SVGFEMergeNodeElement: false,
+        SVGFEMorphologyElement: false,
+        SVGFEOffsetElement: false,
+        SVGFEPointLightElement: false,
+        SVGFESpecularLightingElement: false,
+        SVGFESpotLightElement: false,
+        SVGFETileElement: false,
+        SVGFETurbulenceElement: false,
+        SVGFilterElement: false,
+        SVGForeignObjectElement: false,
+        SVGGElement: false,
+        SVGGeometryElement: false,
+        SVGGradientElement: false,
+        SVGGraphicsElement: false,
+        SVGImageElement: false,
+        SVGLength: false,
+        SVGLengthList: false,
+        SVGLinearGradientElement: false,
+        SVGLineElement: false,
+        SVGMarkerElement: false,
+        SVGMaskElement: false,
+        SVGMatrix: false,
+        SVGMetadataElement: false,
+        SVGMPathElement: false,
+        SVGNumber: false,
+        SVGNumberList: false,
+        SVGPathElement: false,
+        SVGPatternElement: false,
+        SVGPoint: false,
+        SVGPointList: false,
+        SVGPolygonElement: false,
+        SVGPolylineElement: false,
+        SVGPreserveAspectRatio: false,
+        SVGRadialGradientElement: false,
+        SVGRect: false,
+        SVGRectElement: false,
+        SVGScriptElement: false,
+        SVGSetElement: false,
+        SVGStopElement: false,
+        SVGStringList: false,
+        SVGStyleElement: false,
+        SVGSVGElement: false,
+        SVGSwitchElement: false,
+        SVGSymbolElement: false,
+        SVGTextContentElement: false,
+        SVGTextElement: false,
+        SVGTextPathElement: false,
+        SVGTextPositioningElement: false,
+        SVGTitleElement: false,
+        SVGTransform: false,
+        SVGTransformList: false,
+        SVGTSpanElement: false,
+        SVGUnitTypes: false,
+        SVGUseElement: false,
+        SVGViewElement: false,
+        TaskAttributionTiming: false,
+        Text: false,
+        TextDecoder: false,
+        TextDecoderStream: false,
+        TextEncoder: false,
+        TextEncoderStream: false,
+        TextEvent: false,
+        TextMetrics: false,
+        TextTrack: false,
+        TextTrackCue: false,
+        TextTrackCueList: false,
+        TextTrackList: false,
+        TimeRanges: false,
+        ToggleEvent: false,
+        toolbar: false,
+        top: false,
+        Touch: false,
+        TouchEvent: false,
+        TouchList: false,
+        TrackEvent: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
+        TransitionEvent: false,
+        TreeWalker: false,
+        UIEvent: false,
+        URL: false,
+        URLSearchParams: false,
+        ValidityState: false,
+        visualViewport: false,
+        VisualViewport: false,
+        VTTCue: false,
+        WaveShaperNode: false,
+        WebAssembly: false,
+        WebGL2RenderingContext: false,
+        WebGLActiveInfo: false,
+        WebGLBuffer: false,
+        WebGLContextEvent: false,
+        WebGLFramebuffer: false,
+        WebGLProgram: false,
+        WebGLQuery: false,
+        WebGLRenderbuffer: false,
+        WebGLRenderingContext: false,
+        WebGLSampler: false,
+        WebGLShader: false,
+        WebGLShaderPrecisionFormat: false,
+        WebGLSync: false,
+        WebGLTexture: false,
+        WebGLTransformFeedback: false,
+        WebGLUniformLocation: false,
+        WebGLVertexArrayObject: false,
+        WebSocket: false,
+        WheelEvent: false,
+        window: false,
+        Window: false,
+        Worker: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false,
+        XMLDocument: false,
+        XMLHttpRequest: false,
+        XMLHttpRequestEventTarget: false,
+        XMLHttpRequestUpload: false,
+        XMLSerializer: false,
+        XPathEvaluator: false,
+        XPathExpression: false,
+        XPathResult: false,
+        XRAnchor: false,
+        XRBoundedReferenceSpace: false,
+        XRCPUDepthInformation: false,
+        XRDepthInformation: false,
+        XRFrame: false,
+        XRInputSource: false,
+        XRInputSourceArray: false,
+        XRInputSourceEvent: false,
+        XRInputSourcesChangeEvent: false,
+        XRPose: false,
+        XRReferenceSpace: false,
+        XRReferenceSpaceEvent: false,
+        XRRenderState: false,
+        XRRigidTransform: false,
+        XRSession: false,
+        XRSessionEvent: false,
+        XRSpace: false,
+        XRSystem: false,
+        XRView: false,
+        XRViewerPose: false,
+        XRViewport: false,
+        XRWebGLBinding: false,
+        XRWebGLDepthInformation: false,
+        XRWebGLLayer: false,
+        XSLTProcessor: false
+      },
+      worker: {
+        addEventListener: false,
+        applicationCache: false,
+        atob: false,
+        Blob: false,
+        BroadcastChannel: false,
+        btoa: false,
+        ByteLengthQueuingStrategy: false,
+        Cache: false,
+        caches: false,
+        clearInterval: false,
+        clearTimeout: false,
+        close: true,
+        CompressionStream: false,
+        console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
+        ErrorEvent: false,
+        Event: false,
+        fetch: false,
+        File: false,
+        FileReaderSync: false,
+        FormData: false,
+        Headers: false,
+        IDBCursor: false,
+        IDBCursorWithValue: false,
+        IDBDatabase: false,
+        IDBFactory: false,
+        IDBIndex: false,
+        IDBKeyRange: false,
+        IDBObjectStore: false,
+        IDBOpenDBRequest: false,
+        IDBRequest: false,
+        IDBTransaction: false,
+        IDBVersionChangeEvent: false,
+        ImageData: false,
+        importScripts: true,
+        indexedDB: false,
+        location: false,
+        MessageChannel: false,
+        MessageEvent: false,
+        MessagePort: false,
+        name: false,
+        navigator: false,
+        Notification: false,
+        onclose: true,
+        onconnect: true,
+        onerror: true,
+        onlanguagechange: true,
+        onmessage: true,
+        onoffline: true,
+        ononline: true,
+        onrejectionhandled: true,
+        onunhandledrejection: true,
+        performance: false,
+        Performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceNavigation: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
+        PerformanceTiming: false,
+        postMessage: true,
+        Promise: false,
+        queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
+        removeEventListener: false,
+        reportError: false,
+        Request: false,
+        Response: false,
+        self: true,
+        ServiceWorkerRegistration: false,
+        setInterval: false,
+        setTimeout: false,
+        SubtleCrypto: false,
+        TextDecoder: false,
+        TextDecoderStream: false,
+        TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
+        URL: false,
+        URLSearchParams: false,
+        WebAssembly: false,
+        WebSocket: false,
+        Worker: false,
+        WorkerGlobalScope: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false,
+        XMLHttpRequest: false
+      },
+      node: {
+        __dirname: false,
+        __filename: false,
+        AbortController: false,
+        AbortSignal: false,
+        atob: false,
+        Blob: false,
+        BroadcastChannel: false,
+        btoa: false,
+        Buffer: false,
+        ByteLengthQueuingStrategy: false,
+        clearImmediate: false,
+        clearInterval: false,
+        clearTimeout: false,
+        CompressionStream: false,
+        console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
+        DOMException: false,
+        Event: false,
+        EventTarget: false,
+        exports: true,
+        fetch: false,
+        File: false,
+        FormData: false,
+        global: false,
+        Headers: false,
+        Intl: false,
+        MessageChannel: false,
+        MessageEvent: false,
+        MessagePort: false,
+        module: false,
+        performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
+        process: false,
+        queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
+        Request: false,
+        require: false,
+        Response: false,
+        setImmediate: false,
+        setInterval: false,
+        setTimeout: false,
+        structuredClone: false,
+        SubtleCrypto: false,
+        TextDecoder: false,
+        TextDecoderStream: false,
+        TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
+        URL: false,
+        URLSearchParams: false,
+        WebAssembly: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false
+      },
+      nodeBuiltin: {
+        AbortController: false,
+        AbortSignal: false,
+        atob: false,
+        Blob: false,
+        BroadcastChannel: false,
+        btoa: false,
+        Buffer: false,
+        ByteLengthQueuingStrategy: false,
+        clearImmediate: false,
+        clearInterval: false,
+        clearTimeout: false,
+        CompressionStream: false,
+        console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
+        DOMException: false,
+        Event: false,
+        EventTarget: false,
+        fetch: false,
+        File: false,
+        FormData: false,
+        global: false,
+        Headers: false,
+        Intl: false,
+        MessageChannel: false,
+        MessageEvent: false,
+        MessagePort: false,
+        performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
+        process: false,
+        queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
+        Request: false,
+        Response: false,
+        setImmediate: false,
+        setInterval: false,
+        setTimeout: false,
+        structuredClone: false,
+        SubtleCrypto: false,
+        TextDecoder: false,
+        TextDecoderStream: false,
+        TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
+        URL: false,
+        URLSearchParams: false,
+        WebAssembly: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false
+      },
+      commonjs: {
+        exports: true,
+        global: false,
+        module: false,
+        require: false
+      },
+      amd: {
+        define: false,
+        require: false
+      },
+      mocha: {
+        after: false,
+        afterEach: false,
+        before: false,
+        beforeEach: false,
+        context: false,
+        describe: false,
+        it: false,
+        mocha: false,
+        run: false,
+        setup: false,
+        specify: false,
+        suite: false,
+        suiteSetup: false,
+        suiteTeardown: false,
+        teardown: false,
+        test: false,
+        xcontext: false,
+        xdescribe: false,
+        xit: false,
+        xspecify: false
+      },
+      jasmine: {
+        afterAll: false,
+        afterEach: false,
+        beforeAll: false,
+        beforeEach: false,
+        describe: false,
+        expect: false,
+        expectAsync: false,
+        fail: false,
+        fdescribe: false,
+        fit: false,
+        it: false,
+        jasmine: false,
+        pending: false,
+        runs: false,
+        spyOn: false,
+        spyOnAllFunctions: false,
+        spyOnProperty: false,
+        waits: false,
+        waitsFor: false,
+        xdescribe: false,
+        xit: false
+      },
+      jest: {
+        afterAll: false,
+        afterEach: false,
+        beforeAll: false,
+        beforeEach: false,
+        describe: false,
+        expect: false,
+        fdescribe: false,
+        fit: false,
+        it: false,
+        jest: false,
+        pit: false,
+        require: false,
+        test: false,
+        xdescribe: false,
+        xit: false,
+        xtest: false
+      },
+      qunit: {
+        asyncTest: false,
+        deepEqual: false,
+        equal: false,
+        expect: false,
+        module: false,
+        notDeepEqual: false,
+        notEqual: false,
+        notOk: false,
+        notPropEqual: false,
+        notStrictEqual: false,
+        ok: false,
+        propEqual: false,
+        QUnit: false,
+        raises: false,
+        start: false,
+        stop: false,
+        strictEqual: false,
+        test: false,
+        throws: false
+      },
+      phantomjs: {
+        console: true,
+        exports: true,
+        phantom: true,
+        require: true,
+        WebPage: true
+      },
+      couch: {
+        emit: false,
+        exports: false,
+        getRow: false,
+        log: false,
+        module: false,
+        provides: false,
+        require: false,
+        respond: false,
+        send: false,
+        start: false,
+        sum: false
+      },
+      rhino: {
+        defineClass: false,
+        deserialize: false,
+        gc: false,
+        help: false,
+        importClass: false,
+        importPackage: false,
+        java: false,
+        load: false,
+        loadClass: false,
+        Packages: false,
+        print: false,
+        quit: false,
+        readFile: false,
+        readUrl: false,
+        runCommand: false,
+        seal: false,
+        serialize: false,
+        spawn: false,
+        sync: false,
+        toint32: false,
+        version: false
+      },
+      nashorn: {
+        __DIR__: false,
+        __FILE__: false,
+        __LINE__: false,
+        com: false,
+        edu: false,
+        exit: false,
+        java: false,
+        Java: false,
+        javafx: false,
+        JavaImporter: false,
+        javax: false,
+        JSAdapter: false,
+        load: false,
+        loadWithNewGlobal: false,
+        org: false,
+        Packages: false,
+        print: false,
+        quit: false
+      },
+      wsh: {
+        ActiveXObject: false,
+        CollectGarbage: false,
+        Debug: false,
+        Enumerator: false,
+        GetObject: false,
+        RuntimeObject: false,
+        ScriptEngine: false,
+        ScriptEngineBuildVersion: false,
+        ScriptEngineMajorVersion: false,
+        ScriptEngineMinorVersion: false,
+        VBArray: false,
+        WScript: false,
+        WSH: false
+      },
+      jquery: {
+        $: false,
+        jQuery: false
+      },
+      yui: {
+        YAHOO: false,
+        YAHOO_config: false,
+        YUI: false,
+        YUI_config: false
+      },
+      shelljs: {
+        cat: false,
+        cd: false,
+        chmod: false,
+        config: false,
+        cp: false,
+        dirs: false,
+        echo: false,
+        env: false,
+        error: false,
+        exec: false,
+        exit: false,
+        find: false,
+        grep: false,
+        ln: false,
+        ls: false,
+        mkdir: false,
+        mv: false,
+        popd: false,
+        pushd: false,
+        pwd: false,
+        rm: false,
+        sed: false,
+        set: false,
+        target: false,
+        tempdir: false,
+        test: false,
+        touch: false,
+        which: false
+      },
+      prototypejs: {
+        $: false,
+        $$: false,
+        $A: false,
+        $break: false,
+        $continue: false,
+        $F: false,
+        $H: false,
+        $R: false,
+        $w: false,
+        Abstract: false,
+        Ajax: false,
+        Autocompleter: false,
+        Builder: false,
+        Class: false,
+        Control: false,
+        Draggable: false,
+        Draggables: false,
+        Droppables: false,
+        Effect: false,
+        Element: false,
+        Enumerable: false,
+        Event: false,
+        Field: false,
+        Form: false,
+        Hash: false,
+        Insertion: false,
+        ObjectRange: false,
+        PeriodicalExecuter: false,
+        Position: false,
+        Prototype: false,
+        Scriptaculous: false,
+        Selector: false,
+        Sortable: false,
+        SortableObserver: false,
+        Sound: false,
+        Template: false,
+        Toggle: false,
+        Try: false
+      },
+      meteor: {
+        $: false,
+        Accounts: false,
+        AccountsClient: false,
+        AccountsCommon: false,
+        AccountsServer: false,
+        App: false,
+        Assets: false,
+        Blaze: false,
+        check: false,
+        Cordova: false,
+        DDP: false,
+        DDPRateLimiter: false,
+        DDPServer: false,
+        Deps: false,
+        EJSON: false,
+        Email: false,
+        HTTP: false,
+        Log: false,
+        Match: false,
+        Meteor: false,
+        Mongo: false,
+        MongoInternals: false,
+        Npm: false,
+        Package: false,
+        Plugin: false,
+        process: false,
+        Random: false,
+        ReactiveDict: false,
+        ReactiveVar: false,
+        Router: false,
+        ServiceConfiguration: false,
+        Session: false,
+        share: false,
+        Spacebars: false,
+        Template: false,
+        Tinytest: false,
+        Tracker: false,
+        UI: false,
+        Utils: false,
+        WebApp: false,
+        WebAppInternals: false
+      },
+      mongo: {
+        _isWindows: false,
+        _rand: false,
+        BulkWriteResult: false,
+        cat: false,
+        cd: false,
+        connect: false,
+        db: false,
+        getHostName: false,
+        getMemInfo: false,
+        hostname: false,
+        ISODate: false,
+        listFiles: false,
+        load: false,
+        ls: false,
+        md5sumFile: false,
+        mkdir: false,
+        Mongo: false,
+        NumberInt: false,
+        NumberLong: false,
+        ObjectId: false,
+        PlanCache: false,
+        print: false,
+        printjson: false,
+        pwd: false,
+        quit: false,
+        removeFile: false,
+        rs: false,
+        sh: false,
+        UUID: false,
+        version: false,
+        WriteResult: false
+      },
+      applescript: {
+        $: false,
+        Application: false,
+        Automation: false,
+        console: false,
+        delay: false,
+        Library: false,
+        ObjC: false,
+        ObjectSpecifier: false,
+        Path: false,
+        Progress: false,
+        Ref: false
+      },
+      serviceworker: {
+        addEventListener: false,
+        applicationCache: false,
+        atob: false,
+        Blob: false,
+        BroadcastChannel: false,
+        btoa: false,
+        ByteLengthQueuingStrategy: false,
+        Cache: false,
+        caches: false,
+        CacheStorage: false,
+        clearInterval: false,
+        clearTimeout: false,
+        Client: false,
+        clients: false,
+        Clients: false,
+        close: true,
+        CompressionStream: false,
+        console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
+        ErrorEvent: false,
+        Event: false,
+        ExtendableEvent: false,
+        ExtendableMessageEvent: false,
+        fetch: false,
+        FetchEvent: false,
+        File: false,
+        FileReaderSync: false,
+        FormData: false,
+        Headers: false,
+        IDBCursor: false,
+        IDBCursorWithValue: false,
+        IDBDatabase: false,
+        IDBFactory: false,
+        IDBIndex: false,
+        IDBKeyRange: false,
+        IDBObjectStore: false,
+        IDBOpenDBRequest: false,
+        IDBRequest: false,
+        IDBTransaction: false,
+        IDBVersionChangeEvent: false,
+        ImageData: false,
+        importScripts: false,
+        indexedDB: false,
+        location: false,
+        MessageChannel: false,
+        MessageEvent: false,
+        MessagePort: false,
+        name: false,
+        navigator: false,
+        Notification: false,
+        onclose: true,
+        onconnect: true,
+        onerror: true,
+        onfetch: true,
+        oninstall: true,
+        onlanguagechange: true,
+        onmessage: true,
+        onmessageerror: true,
+        onnotificationclick: true,
+        onnotificationclose: true,
+        onoffline: true,
+        ononline: true,
+        onpush: true,
+        onpushsubscriptionchange: true,
+        onrejectionhandled: true,
+        onsync: true,
+        onunhandledrejection: true,
+        performance: false,
+        Performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceNavigation: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
+        PerformanceTiming: false,
+        postMessage: true,
+        Promise: false,
+        queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
+        registration: false,
+        removeEventListener: false,
+        Request: false,
+        Response: false,
+        self: false,
+        ServiceWorker: false,
+        ServiceWorkerContainer: false,
+        ServiceWorkerGlobalScope: false,
+        ServiceWorkerMessageEvent: false,
+        ServiceWorkerRegistration: false,
+        setInterval: false,
+        setTimeout: false,
+        skipWaiting: false,
+        SubtleCrypto: false,
+        TextDecoder: false,
+        TextDecoderStream: false,
+        TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
+        URL: false,
+        URLSearchParams: false,
+        WebAssembly: false,
+        WebSocket: false,
+        WindowClient: false,
+        Worker: false,
+        WorkerGlobalScope: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false,
+        XMLHttpRequest: false
+      },
+      atomtest: {
+        advanceClock: false,
+        atom: false,
+        fakeClearInterval: false,
+        fakeClearTimeout: false,
+        fakeSetInterval: false,
+        fakeSetTimeout: false,
+        resetTimeouts: false,
+        waitsForPromise: false
+      },
+      embertest: {
+        andThen: false,
+        click: false,
+        currentPath: false,
+        currentRouteName: false,
+        currentURL: false,
+        fillIn: false,
+        find: false,
+        findAll: false,
+        findWithAssert: false,
+        keyEvent: false,
+        pauseTest: false,
+        resumeTest: false,
+        triggerEvent: false,
+        visit: false,
+        wait: false
+      },
+      protractor: {
+        $: false,
+        $$: false,
+        browser: false,
+        by: false,
+        By: false,
+        DartObject: false,
+        element: false,
+        protractor: false
+      },
+      "shared-node-browser": {
+        AbortController: false,
+        AbortSignal: false,
+        atob: false,
+        Blob: false,
+        BroadcastChannel: false,
+        btoa: false,
+        ByteLengthQueuingStrategy: false,
+        clearInterval: false,
+        clearTimeout: false,
+        CompressionStream: false,
+        console: false,
+        CountQueuingStrategy: false,
+        crypto: false,
+        Crypto: false,
+        CryptoKey: false,
+        CustomEvent: false,
+        DecompressionStream: false,
+        DOMException: false,
+        Event: false,
+        EventTarget: false,
+        fetch: false,
+        File: false,
+        FormData: false,
+        Headers: false,
+        Intl: false,
+        MessageChannel: false,
+        MessageEvent: false,
+        MessagePort: false,
+        performance: false,
+        PerformanceEntry: false,
+        PerformanceMark: false,
+        PerformanceMeasure: false,
+        PerformanceObserver: false,
+        PerformanceObserverEntryList: false,
+        PerformanceResourceTiming: false,
+        queueMicrotask: false,
+        ReadableByteStreamController: false,
+        ReadableStream: false,
+        ReadableStreamBYOBReader: false,
+        ReadableStreamBYOBRequest: false,
+        ReadableStreamDefaultController: false,
+        ReadableStreamDefaultReader: false,
+        Request: false,
+        Response: false,
+        setInterval: false,
+        setTimeout: false,
+        structuredClone: false,
+        SubtleCrypto: false,
+        TextDecoder: false,
+        TextDecoderStream: false,
+        TextEncoder: false,
+        TextEncoderStream: false,
+        TransformStream: false,
+        TransformStreamDefaultController: false,
+        URL: false,
+        URLSearchParams: false,
+        WebAssembly: false,
+        WritableStream: false,
+        WritableStreamDefaultController: false,
+        WritableStreamDefaultWriter: false
+      },
+      webextensions: {
+        browser: false,
+        chrome: false,
+        opr: false
+      },
+      greasemonkey: {
+        cloneInto: false,
+        createObjectIn: false,
+        exportFunction: false,
+        GM: false,
+        GM_addElement: false,
+        GM_addStyle: false,
+        GM_addValueChangeListener: false,
+        GM_deleteValue: false,
+        GM_download: false,
+        GM_getResourceText: false,
+        GM_getResourceURL: false,
+        GM_getTab: false,
+        GM_getTabs: false,
+        GM_getValue: false,
+        GM_info: false,
+        GM_listValues: false,
+        GM_log: false,
+        GM_notification: false,
+        GM_openInTab: false,
+        GM_registerMenuCommand: false,
+        GM_removeValueChangeListener: false,
+        GM_saveTab: false,
+        GM_setClipboard: false,
+        GM_setValue: false,
+        GM_unregisterMenuCommand: false,
+        GM_xmlhttpRequest: false,
+        unsafeWindow: false
+      },
+      devtools: {
+        $: false,
+        $_: false,
+        $$: false,
+        $0: false,
+        $1: false,
+        $2: false,
+        $3: false,
+        $4: false,
+        $x: false,
+        chrome: false,
+        clear: false,
+        copy: false,
+        debug: false,
+        dir: false,
+        dirxml: false,
+        getEventListeners: false,
+        inspect: false,
+        keys: false,
+        monitor: false,
+        monitorEvents: false,
+        profile: false,
+        profileEnd: false,
+        queryObjects: false,
+        table: false,
+        undebug: false,
+        unmonitor: false,
+        unmonitorEvents: false,
+        values: false
+      }
+    };
+  }
+});
+
+// ../../node_modules/eslint/node_modules/globals/index.js
+var require_globals5 = __commonJS({
+  "../../node_modules/eslint/node_modules/globals/index.js"(exports, module) {
+    "use strict";
+    module.exports = require_globals4();
+  }
+});
+
 // ../../node_modules/eslint/lib/rules/no-constant-binary-expression.js
 var require_no_constant_binary_expression = __commonJS({
   "../../node_modules/eslint/lib/rules/no-constant-binary-expression.js"(exports, module) {
     "use strict";
-    var globals = require_globals2();
+    var globals = require_globals5();
     var { isNullLiteral, isConstant, isReferenceToGlobalVariable, isLogicalAssignmentOperator } = require_ast_utils2();
     var NUMERIC_OR_STRING_BINARY_OPERATORS = /* @__PURE__ */ new Set(["+", "-", "*", "/", "%", "|", "^", "&", "**", "<<", ">>", ">>>"]);
     function isNullOrUndefined(scope, node) {
@@ -57869,6 +61894,7 @@ var require_regexpp = __commonJS({
     var ast = /* @__PURE__ */ Object.freeze({
       __proto__: null
     });
+    var latestEcmaVersion = 2025;
     var largeIdStartRanges = void 0;
     var largeIdContinueRanges = void 0;
     function isIdStart(cp) {
@@ -57906,10 +61932,10 @@ var require_regexpp = __commonJS({
       return isInRange(cp, largeIdContinueRanges !== null && largeIdContinueRanges !== void 0 ? largeIdContinueRanges : largeIdContinueRanges = initLargeIdContinueRanges());
     }
     function initLargeIdStartRanges() {
-      return restoreRanges("4q 0 b 0 5 0 6 m 2 u 2 cp 5 b f 4 8 0 2 0 3m 4 2 1 3 3 2 0 7 0 2 2 2 0 2 j 2 2a 2 3u 9 4l 2 11 3 0 7 14 20 q 5 3 1a 16 10 1 2 2q 2 0 g 1 8 1 b 2 3 0 h 0 2 t u 2g c 0 p w a 1 5 0 6 l 5 0 a 0 4 0 o o 8 a 6 n 2 5 i 15 1n 1h 4 0 j 0 8 9 g f 5 7 3 1 3 l 2 6 2 0 4 3 4 0 h 0 e 1 2 2 f 1 b 0 9 5 5 1 3 l 2 6 2 1 2 1 2 1 w 3 2 0 k 2 h 8 2 2 2 l 2 6 2 1 2 4 4 0 j 0 g 1 o 0 c 7 3 1 3 l 2 6 2 1 2 4 4 0 v 1 2 2 g 0 i 0 2 5 4 2 2 3 4 1 2 0 2 1 4 1 4 2 4 b n 0 1h 7 2 2 2 m 2 f 4 0 r 2 3 0 3 1 v 0 5 7 2 2 2 m 2 9 2 4 4 0 w 1 2 1 g 1 i 8 2 2 2 14 3 0 h 0 6 2 9 2 p 5 6 h 4 n 2 8 2 0 3 6 1n 1b 2 1 d 6 1n 1 2 0 2 4 2 n 2 0 2 9 2 1 a 0 3 4 2 0 m 3 x 0 1s 7 2 z s 4 38 16 l 0 h 5 5 3 4 0 4 1 8 2 5 c d 0 i 11 2 0 6 0 3 16 2 98 2 3 3 6 2 0 2 3 3 14 2 3 3 w 2 3 3 6 2 0 2 3 3 e 2 1k 2 3 3 1u 12 f h 2d 3 5 4 h7 3 g 2 p 6 22 4 a 8 h e i f h f c 2 2 g 1f 10 0 5 0 1w 2g 8 14 2 0 6 1x b u 1e t 3 4 c 17 5 p 1j m a 1g 2b 0 2m 1a i 7 1j t e 1 b 17 r z 16 2 b z 3 8 8 16 3 2 16 3 2 5 2 1 4 0 6 5b 1t 7p 3 5 3 11 3 5 3 7 2 0 2 0 2 0 2 u 3 1g 2 6 2 0 4 2 2 6 4 3 3 5 5 c 6 2 2 6 39 0 e 0 h c 2u 0 5 0 3 9 2 0 3 5 7 0 2 0 2 0 2 f 3 3 6 4 5 0 i 14 22g 6c 7 3 4 1 d 11 2 0 6 0 3 1j 8 0 h m a 6 2 6 2 6 2 6 2 6 2 6 2 6 2 6 fb 2 q 8 8 4 3 4 5 2d 5 4 2 2h 2 3 6 16 2 2l i v 1d f e9 533 1t h3g 1w 19 3 7g 4 f b 1 l 1a h u 3 27 14 8 3 2u 3 1r 6 1 2 0 2 4 p f 2 2 2 3 2 m u 1f f 1d 1r 5 4 0 2 1 c r b m q s 8 1a t 0 h 4 2 9 b 4 2 14 o 2 2 7 l m 4 0 4 1d 2 0 4 1 3 4 3 0 2 0 p 2 3 a 8 2 d 5 3 5 3 5 a 6 2 6 2 16 2 d 7 36 u 8mb d m 5 1c 6it a5 3 2x 13 6 d 4 6 0 2 9 2 c 2 4 2 0 2 1 2 1 2 2z y a2 j 1r 3 1h 15 b 39 4 2 3q 11 p 7 p c 2g 4 5 3 5 3 5 3 2 10 b 2 p 2 i 2 1 2 e 3 d z 3e 1y 1g 7g s 4 1c 1c v e t 6 11 b t 3 z 5 7 2 4 17 4d j z 5 z 5 13 9 1f d a 2 e 2 6 2 1 2 a 2 e 2 6 2 1 1w 8m a l b 7 p 5 2 15 2 8 1y 5 3 0 2 17 2 1 4 0 3 m b m a u 1u i 2 1 b l b p 1z 1j 7 1 1t 0 g 3 2 2 2 s 17 s 4 s 10 7 2 r s 1h b l b i e h 33 20 1k 1e e 1e e z 9p 15 7 1 27 s b 0 9 l 17 h 1b k s m d 1g 1m 1 3 0 e 18 x o r z u 0 3 0 9 y 4 0 d 1b f 3 m 0 2 0 10 h 2 o k 1 1s 6 2 0 2 3 2 e 2 9 8 1a 13 7 3 1 3 l 2 6 2 1 2 4 4 0 j 0 d 4 4f 1g j 3 l 2 v 1b l 1 2 0 55 1a 16 3 11 1b l 0 1o 16 e 0 20 q 12 6 56 17 39 1r w 7 3 0 3 7 2 1 2 n g 0 2 0 2n 7 3 12 h 0 2 0 t 0 b 13 8 0 m 0 c 19 k 0 j 20 7c 8 2 10 i 0 1e t 35 6 2 1 2 11 m 0 q 5 2 1 2 v f 0 94 i g 0 2 c 2 x 3h 0 28 pl 2v 32 i 5f 219 2o g tr i 5 33u g6 6nu fs 8 u i 26 i t j 1b h 3 w k 6 i j5 1r 3l 22 6 0 1v c 1t 1 2 0 t 4qf 9 yd 17 8 6w8 3 2 6 2 1 2 82 g 0 u 2 3 0 f 3 9 az 1s5 2y 6 c 4 8 8 9 4mf 2c 2 1y 2 1 3 0 3 1 3 3 2 b 2 0 2 6 2 1s 2 3 3 7 2 6 2 r 2 3 2 4 2 0 4 6 2 9f 3 o 2 o 2 u 2 o 2 u 2 o 2 u 2 o 2 u 2 o 2 7 1f9 u 7 5 7a 1p 43 18 b 6 h 0 8y t j 17 dh r l1 6 2 3 2 1 2 e 2 5g 1o 1v 8 0 xh 3 2 q 2 1 2 0 3 0 2 9 2 3 2 0 2 0 7 0 5 0 2 0 2 0 2 2 2 1 2 0 3 0 2 0 2 0 2 0 2 0 2 1 2 0 3 3 2 6 2 3 2 3 2 0 2 9 2 g 6 2 2 4 2 g 3et wyn x 37d 7 65 3 4g1 f 5rk 2e8 f1 15v 3t6 6 38f");
+      return restoreRanges("4q 0 b 0 5 0 6 m 2 u 2 cp 5 b f 4 8 0 2 0 3m 4 2 1 3 3 2 0 7 0 2 2 2 0 2 j 2 2a 2 3u 9 4l 2 11 3 0 7 14 20 q 5 3 1a 16 10 1 2 2q 2 0 g 1 8 1 b 2 3 0 h 0 2 t u 2g c 0 p w a 1 5 0 6 l 5 0 a 0 4 0 o o 8 a 6 n 2 5 i 15 1n 1h 4 0 j 0 8 9 g f 5 7 3 1 3 l 2 6 2 0 4 3 4 0 h 0 e 1 2 2 f 1 b 0 9 5 5 1 3 l 2 6 2 1 2 1 2 1 w 3 2 0 k 2 h 8 2 2 2 l 2 6 2 1 2 4 4 0 j 0 g 1 o 0 c 7 3 1 3 l 2 6 2 1 2 4 4 0 v 1 2 2 g 0 i 0 2 5 4 2 2 3 4 1 2 0 2 1 4 1 4 2 4 b n 0 1h 7 2 2 2 m 2 f 4 0 r 2 3 0 3 1 v 0 5 7 2 2 2 m 2 9 2 4 4 0 w 1 2 1 g 1 i 8 2 2 2 14 3 0 h 0 6 2 9 2 p 5 6 h 4 n 2 8 2 0 3 6 1n 1b 2 1 d 6 1n 1 2 0 2 4 2 n 2 0 2 9 2 1 a 0 3 4 2 0 m 3 x 0 1s 7 2 z s 4 38 16 l 0 h 5 5 3 4 0 4 1 8 2 5 c d 0 i 11 2 0 6 0 3 16 2 98 2 3 3 6 2 0 2 3 3 14 2 3 3 w 2 3 3 6 2 0 2 3 3 e 2 1k 2 3 3 1u 12 f h 2d 3 5 4 h7 3 g 2 p 6 22 4 a 8 h e i f h f c 2 2 g 1f 10 0 5 0 1w 2g 8 14 2 0 6 1x b u 1e t 3 4 c 17 5 p 1j m a 1g 2b 0 2m 1a i 7 1j t e 1 b 17 r z 16 2 b z 3 a 6 16 3 2 16 3 2 5 2 1 4 0 6 5b 1t 7p 3 5 3 11 3 5 3 7 2 0 2 0 2 0 2 u 3 1g 2 6 2 0 4 2 2 6 4 3 3 5 5 c 6 2 2 6 39 0 e 0 h c 2u 0 5 0 3 9 2 0 3 5 7 0 2 0 2 0 2 f 3 3 6 4 5 0 i 14 22g 6c 7 3 4 1 d 11 2 0 6 0 3 1j 8 0 h m a 6 2 6 2 6 2 6 2 6 2 6 2 6 2 6 fb 2 q 8 8 4 3 4 5 2d 5 4 2 2h 2 3 6 16 2 2l i v 1d f e9 533 1t h3g 1w 19 3 7g 4 f b 1 l 1a h u 3 27 14 8 3 2u 3 1u 3 1 2 0 2 7 m f 2 2 2 3 2 m u 1f f 1d 1r 5 4 0 2 1 c r b m q s 8 1a t 0 h 4 2 9 b 4 2 14 o 2 2 7 l m 4 0 4 1d 2 0 4 1 3 4 3 0 2 0 p 2 3 a 8 2 d 5 3 5 3 5 a 6 2 6 2 16 2 d 7 36 u 8mb d m 5 1c 6it a5 3 2x 13 6 d 4 6 0 2 9 2 c 2 4 2 0 2 1 2 1 2 2z y a2 j 1r 3 1h 15 b 39 4 2 3q 11 p 7 p c 2g 4 5 3 5 3 5 3 2 10 b 2 p 2 i 2 1 2 e 3 d z 3e 1y 1g 7g s 4 1c 1c v e t 6 11 b t 3 z 5 7 2 4 17 4d j z 5 z 5 13 9 1f d a 2 e 2 6 2 1 2 a 2 e 2 6 2 1 4 1f d 8m a l b 7 p 5 2 15 2 8 1y 5 3 0 2 17 2 1 4 0 3 m b m a u 1u i 2 1 b l b p 1z 1j 7 1 1t 0 g 3 2 2 2 s 17 s 4 s 10 7 2 r s 1h b l b i e h 33 20 1k 1e e 1e e z 13 r a m 6z 15 7 1 h 2 1o s b 0 9 l 17 h 1b k s m d 1g 1m 1 3 0 e 18 x o r z u 0 3 0 9 y 4 0 d 1b f 3 m 0 2 0 10 h 2 o k 1 1s 6 2 0 2 3 2 e 2 9 8 1a 13 7 3 1 3 l 2 6 2 1 2 4 4 0 j 0 d 4 v 9 2 0 3 0 2 11 2 0 q 0 2 0 19 1g j 3 l 2 v 1b l 1 2 0 55 1a 16 3 11 1b l 0 1o 16 e 0 20 q 12 6 56 17 39 1r w 7 3 0 3 7 2 1 2 n g 0 2 0 2n 7 3 12 h 0 2 0 t 0 b 13 8 0 m 0 c 19 k 0 j 20 5k w w 8 2 10 i 0 1e t 35 6 2 1 2 11 m 0 q 5 2 1 2 v f 0 94 i g 0 2 c 2 x 3h 0 28 pl 2v 32 i 5f 219 2o g tr i 5 q 32y 6 g6 5a2 t 1cz fs 8 u i 26 i t j 1b h 3 w k 6 i c1 18 5w 1r 3l 22 6 0 1v c 1t 1 2 0 t 4qf 9 yd 16 9 6w8 3 2 6 2 1 2 82 g 0 u 2 3 0 f 3 9 az 1s5 2y 6 c 4 8 8 9 4mf 2c 2 1y 2 1 3 0 3 1 3 3 2 b 2 0 2 6 2 1s 2 3 3 7 2 6 2 r 2 3 2 4 2 0 4 6 2 9f 3 o 2 o 2 u 2 o 2 u 2 o 2 u 2 o 2 u 2 o 2 7 1f9 u 7 5 7a 1p 43 18 b 6 h 0 8y t j 17 dh r 6d t 3 0 ds 6 2 3 2 1 2 e 2 5g 1o 1v 8 0 xh 3 2 q 2 1 2 0 3 0 2 9 2 3 2 0 2 0 7 0 5 0 2 0 2 0 2 2 2 1 2 0 3 0 2 0 2 0 2 0 2 0 2 1 2 0 3 3 2 6 2 3 2 3 2 0 2 9 2 g 6 2 2 4 2 g 3et wyn x 37d 7 65 3 4g1 f 5rk g h9 1wj f1 15v 3t6 6 38f");
     }
     function initLargeIdContinueRanges() {
-      return restoreRanges("53 0 g9 33 o 0 70 4 7e 18 2 0 2 1 2 1 2 0 21 a 1d u 7 0 2u 6 3 5 3 1 2 3 3 9 o 0 v q 2k a g 9 y 8 a 0 p 3 2 8 2 2 2 4 18 2 1p 7 17 n 2 w 1j 2 2 h 2 6 b 1 3 9 i 2 1l 0 2 6 3 1 3 2 a 0 b 1 3 9 f 0 3 2 1l 0 2 4 5 1 3 2 4 0 l b 4 0 c 2 1l 0 2 7 2 2 2 2 l 1 3 9 b 5 2 2 1l 0 2 6 3 1 3 2 8 2 b 1 3 9 j 0 1o 4 4 2 2 3 a 0 f 9 h 4 1k 0 2 6 2 2 2 3 8 1 c 1 3 9 i 2 1l 0 2 6 2 2 2 3 8 1 c 1 3 9 4 0 d 3 1k 1 2 6 2 2 2 3 a 0 b 1 3 9 i 2 1z 0 5 5 2 0 2 7 7 9 3 1 1q 0 3 6 d 7 2 9 2g 0 3 8 c 6 2 9 1r 1 7 9 c 0 2 0 2 0 5 1 1e j 2 1 6 a 2 z a 0 2t j 2 9 d 3 5 2 2 2 3 6 4 3 e b 2 e jk 2 a 8 pt 3 t 2 u 1 v 1 1t v a 0 3 9 y 2 2 a 40 0 3b b 5 b b 9 3l a 1p 4 1m 9 2 s 3 a 7 9 n d 2 f 1e 4 1c g c 9 i 8 d 2 v c 3 9 19 d 1d j 9 9 7 9 3b 2 2 k 5 0 7 0 3 2 5j 1r g0 1 k 0 3g c 5 0 4 b 2db 2 3y 0 2p v ff 5 2y 1 n7q 9 1y 0 5 9 x 1 29 1 7l 0 4 0 5 0 o 4 5 0 2c 1 1f h b 9 7 h e a t 7 q c 19 3 1c d g 9 c 0 b 9 1c d d 0 9 1 3 9 y 2 1f 0 2 2 3 1 6 1 2 0 16 4 6 1 6l 7 2 1 3 9 fmt 0 ki f h f 4 1 p 2 5d 9 12 0 ji 0 6b 0 46 4 86 9 120 2 2 1 6 3 15 2 5 0 4m 1 fy 3 9 9 aa 1 29 2 1z a 1e 3 3f 2 1i e w a 3 1 b 3 1a a 8 0 1a 9 7 2 11 d 2 9 6 1 19 0 d 2 1d d 9 3 2 b 2b b 7 0 3 0 4e b 6 9 7 3 1k 1 2 6 3 1 3 2 a 0 b 1 3 6 4 4 5d h a 9 5 0 2a j d 9 5y 6 3 8 s 1 2b g g 9 2a c 9 9 2c e 5 9 6r e 4m 9 1z 5 2 1 3 3 2 0 2 1 d 9 3c 6 3 6 4 0 t 9 15 6 2 3 9 0 a a 1b f ba 7 2 7 h 9 1l l 2 d 3f 5 4 0 2 1 2 6 2 0 9 9 1d 4 2 1 2 4 9 9 96 3 a 1 2 0 1d 6 4 4 e 9 44n 0 7 e aob 9 2f 9 13 4 1o 6 q 9 s6 0 2 1i 8 3 2a 0 c 1 f58 1 3mq 19 3 m f3 4 4 5 9 7 3 6 v 3 45 2 13e 1d e9 1i 5 1d 9 0 f 0 n 4 2 e 11t 6 2 g 3 6 2 1 2 4 2t 0 4h 6 a 9 9x 0 1q d dv d rb 6 32 6 6 9 3o7 9 gvt3 6n");
+      return restoreRanges("53 0 g9 33 o 0 70 4 7e 18 2 0 2 1 2 1 2 0 21 a 1d u 7 0 2u 6 3 5 3 1 2 3 3 9 o 0 v q 2k a g 9 y 8 a 0 p 3 2 8 2 2 2 4 18 2 1o 8 17 n 2 w 1j 2 2 h 2 6 b 1 3 9 i 2 1l 0 2 6 3 1 3 2 a 0 b 1 3 9 f 0 3 2 1l 0 2 4 5 1 3 2 4 0 l b 4 0 c 2 1l 0 2 7 2 2 2 2 l 1 3 9 b 5 2 2 1l 0 2 6 3 1 3 2 8 2 b 1 3 9 j 0 1o 4 4 2 2 3 a 0 f 9 h 4 1k 0 2 6 2 2 2 3 8 1 c 1 3 9 i 2 1l 0 2 6 2 2 2 3 8 1 c 1 3 9 4 0 d 3 1k 1 2 6 2 2 2 3 a 0 b 1 3 9 i 2 1z 0 5 5 2 0 2 7 7 9 3 1 1q 0 3 6 d 7 2 9 2g 0 3 8 c 6 2 9 1r 1 7 9 c 0 2 0 2 0 5 1 1e j 2 1 6 a 2 z a 0 2t j 2 9 d 3 5 2 2 2 3 6 4 3 e b 2 e jk 2 a 8 pt 3 t 2 u 1 v 1 1t v a 0 3 9 y 2 2 a 40 0 3b b 5 b b 9 3l a 1p 4 1m 9 2 s 3 a 7 9 n d 2 f 1e 4 1c g c 9 i 8 d 2 v c 3 9 19 d 1d j 9 9 7 9 3b 2 2 k 5 0 7 0 3 2 5j 1r el 1 1e 1 k 0 3g c 5 0 4 b 2db 2 3y 0 2p v ff 5 2y 1 2p 0 n51 9 1y 0 5 9 x 1 29 1 7l 0 4 0 5 0 o 4 5 0 2c 1 1f h b 9 7 h e a t 7 q c 19 3 1c d g 9 c 0 b 9 1c d d 0 9 1 3 9 y 2 1f 0 2 2 3 1 6 1 2 0 16 4 6 1 6l 7 2 1 3 9 fmt 0 ki f h f 4 1 p 2 5d 9 12 0 12 0 ig 0 6b 0 46 4 86 9 120 2 2 1 6 3 15 2 5 0 4m 1 fy 3 9 9 7 9 w 4 8u 1 28 3 1z a 1e 3 3f 2 1i e w a 3 1 b 3 1a a 8 0 1a 9 7 2 11 d 2 9 6 1 19 0 d 2 1d d 9 3 2 b 2b b 7 0 3 0 4e b 6 9 7 3 1k 1 2 6 3 1 3 2 a 0 b 1 3 6 4 4 1w 8 2 0 3 0 2 3 2 4 2 0 f 1 2b h a 9 5 0 2a j d 9 5y 6 3 8 s 1 2b g g 9 2a c 9 9 7 j 1m e 5 9 6r e 4m 9 1z 5 2 1 3 3 2 0 2 1 d 9 3c 6 3 6 4 0 t 9 15 6 2 3 9 0 a a 1b f 9j 9 1i 7 2 7 h 9 1l l 2 d 3f 5 4 0 2 1 2 6 2 0 9 9 1d 4 2 1 2 4 9 9 96 3 a 1 2 0 1d 6 4 4 e a 44m 0 7 e 8uh r 1t3 9 2f 9 13 4 1o 6 q 9 ev 9 d2 0 2 1i 8 3 2a 0 c 1 f58 1 382 9 ef 19 3 m f3 4 4 5 9 7 3 6 v 3 45 2 13e 1d e9 1i 5 1d 9 0 f 0 n 4 2 e 11t 6 2 g 3 6 2 1 2 4 2t 0 4h 6 a 9 9x 0 1q d dv d 6t 1 2 9 k6 6 32 6 6 9 3o7 9 gvt3 6n");
     }
     function isInRange(cp, ranges) {
       let l = 0, r = ranges.length / 2 | 0, i = 0, min = 0, max = 0;
@@ -57932,7 +61958,7 @@ var require_regexpp = __commonJS({
       return data.split(" ").map((s) => last += parseInt(s, 36) | 0);
     }
     var DataSet = class {
-      constructor(raw2018, raw2019, raw2020, raw2021, raw2022, raw2023, raw2024) {
+      constructor(raw2018, raw2019, raw2020, raw2021, raw2022, raw2023, raw2024, raw2025) {
         this._raw2018 = raw2018;
         this._raw2019 = raw2019;
         this._raw2020 = raw2020;
@@ -57940,6 +61966,7 @@ var require_regexpp = __commonJS({
         this._raw2022 = raw2022;
         this._raw2023 = raw2023;
         this._raw2024 = raw2024;
+        this._raw2025 = raw2025;
       }
       get es2018() {
         var _a;
@@ -57969,12 +61996,17 @@ var require_regexpp = __commonJS({
         var _a;
         return (_a = this._set2024) !== null && _a !== void 0 ? _a : this._set2024 = new Set(this._raw2024.split(" "));
       }
+      get es2025() {
+        var _a;
+        return (_a = this._set2025) !== null && _a !== void 0 ? _a : this._set2025 = new Set(this._raw2025.split(" "));
+      }
     };
     var gcNameSet = /* @__PURE__ */ new Set(["General_Category", "gc"]);
     var scNameSet = /* @__PURE__ */ new Set(["Script", "Script_Extensions", "sc", "scx"]);
-    var gcValueSets = new DataSet("C Cased_Letter Cc Cf Close_Punctuation Cn Co Combining_Mark Connector_Punctuation Control Cs Currency_Symbol Dash_Punctuation Decimal_Number Enclosing_Mark Final_Punctuation Format Initial_Punctuation L LC Letter Letter_Number Line_Separator Ll Lm Lo Lowercase_Letter Lt Lu M Mark Math_Symbol Mc Me Mn Modifier_Letter Modifier_Symbol N Nd Nl No Nonspacing_Mark Number Open_Punctuation Other Other_Letter Other_Number Other_Punctuation Other_Symbol P Paragraph_Separator Pc Pd Pe Pf Pi Po Private_Use Ps Punctuation S Sc Separator Sk Sm So Space_Separator Spacing_Mark Surrogate Symbol Titlecase_Letter Unassigned Uppercase_Letter Z Zl Zp Zs cntrl digit punct", "", "", "", "", "", "");
-    var scValueSets = new DataSet("Adlam Adlm Aghb Ahom Anatolian_Hieroglyphs Arab Arabic Armenian Armi Armn Avestan Avst Bali Balinese Bamu Bamum Bass Bassa_Vah Batak Batk Beng Bengali Bhaiksuki Bhks Bopo Bopomofo Brah Brahmi Brai Braille Bugi Buginese Buhd Buhid Cakm Canadian_Aboriginal Cans Cari Carian Caucasian_Albanian Chakma Cham Cher Cherokee Common Copt Coptic Cprt Cuneiform Cypriot Cyrillic Cyrl Deseret Deva Devanagari Dsrt Dupl Duployan Egyp Egyptian_Hieroglyphs Elba Elbasan Ethi Ethiopic Geor Georgian Glag Glagolitic Gonm Goth Gothic Gran Grantha Greek Grek Gujarati Gujr Gurmukhi Guru Han Hang Hangul Hani Hano Hanunoo Hatr Hatran Hebr Hebrew Hira Hiragana Hluw Hmng Hung Imperial_Aramaic Inherited Inscriptional_Pahlavi Inscriptional_Parthian Ital Java Javanese Kaithi Kali Kana Kannada Katakana Kayah_Li Khar Kharoshthi Khmer Khmr Khoj Khojki Khudawadi Knda Kthi Lana Lao Laoo Latin Latn Lepc Lepcha Limb Limbu Lina Linb Linear_A Linear_B Lisu Lyci Lycian Lydi Lydian Mahajani Mahj Malayalam Mand Mandaic Mani Manichaean Marc Marchen Masaram_Gondi Meetei_Mayek Mend Mende_Kikakui Merc Mero Meroitic_Cursive Meroitic_Hieroglyphs Miao Mlym Modi Mong Mongolian Mro Mroo Mtei Mult Multani Myanmar Mymr Nabataean Narb Nbat New_Tai_Lue Newa Nko Nkoo Nshu Nushu Ogam Ogham Ol_Chiki Olck Old_Hungarian Old_Italic Old_North_Arabian Old_Permic Old_Persian Old_South_Arabian Old_Turkic Oriya Orkh Orya Osage Osge Osma Osmanya Pahawh_Hmong Palm Palmyrene Pau_Cin_Hau Pauc Perm Phag Phags_Pa Phli Phlp Phnx Phoenician Plrd Prti Psalter_Pahlavi Qaac Qaai Rejang Rjng Runic Runr Samaritan Samr Sarb Saur Saurashtra Sgnw Sharada Shavian Shaw Shrd Sidd Siddham SignWriting Sind Sinh Sinhala Sora Sora_Sompeng Soyo Soyombo Sund Sundanese Sylo Syloti_Nagri Syrc Syriac Tagalog Tagb Tagbanwa Tai_Le Tai_Tham Tai_Viet Takr Takri Tale Talu Tamil Taml Tang Tangut Tavt Telu Telugu Tfng Tglg Thaa Thaana Thai Tibetan Tibt Tifinagh Tirh Tirhuta Ugar Ugaritic Vai Vaii Wara Warang_Citi Xpeo Xsux Yi Yiii Zanabazar_Square Zanb Zinh Zyyy", "Dogr Dogra Gong Gunjala_Gondi Hanifi_Rohingya Maka Makasar Medefaidrin Medf Old_Sogdian Rohg Sogd Sogdian Sogo", "Elym Elymaic Hmnp Nand Nandinagari Nyiakeng_Puachue_Hmong Wancho Wcho", "Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi", "Cpmn Cypro_Minoan Old_Uyghur Ougr Tangsa Tnsa Toto Vith Vithkuqi", "Hrkt Katakana_Or_Hiragana Kawi Nag_Mundari Nagm Unknown Zzzz", "");
-    var binPropertySets = new DataSet("AHex ASCII ASCII_Hex_Digit Alpha Alphabetic Any Assigned Bidi_C Bidi_Control Bidi_M Bidi_Mirrored CI CWCF CWCM CWKCF CWL CWT CWU Case_Ignorable Cased Changes_When_Casefolded Changes_When_Casemapped Changes_When_Lowercased Changes_When_NFKC_Casefolded Changes_When_Titlecased Changes_When_Uppercased DI Dash Default_Ignorable_Code_Point Dep Deprecated Dia Diacritic Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Ext Extender Gr_Base Gr_Ext Grapheme_Base Grapheme_Extend Hex Hex_Digit IDC IDS IDSB IDST IDS_Binary_Operator IDS_Trinary_Operator ID_Continue ID_Start Ideo Ideographic Join_C Join_Control LOE Logical_Order_Exception Lower Lowercase Math NChar Noncharacter_Code_Point Pat_Syn Pat_WS Pattern_Syntax Pattern_White_Space QMark Quotation_Mark RI Radical Regional_Indicator SD STerm Sentence_Terminal Soft_Dotted Term Terminal_Punctuation UIdeo Unified_Ideograph Upper Uppercase VS Variation_Selector White_Space XIDC XIDS XID_Continue XID_Start space", "Extended_Pictographic", "", "EBase EComp EMod EPres ExtPict", "", "", "");
+    var gcValueSets = new DataSet("C Cased_Letter Cc Cf Close_Punctuation Cn Co Combining_Mark Connector_Punctuation Control Cs Currency_Symbol Dash_Punctuation Decimal_Number Enclosing_Mark Final_Punctuation Format Initial_Punctuation L LC Letter Letter_Number Line_Separator Ll Lm Lo Lowercase_Letter Lt Lu M Mark Math_Symbol Mc Me Mn Modifier_Letter Modifier_Symbol N Nd Nl No Nonspacing_Mark Number Open_Punctuation Other Other_Letter Other_Number Other_Punctuation Other_Symbol P Paragraph_Separator Pc Pd Pe Pf Pi Po Private_Use Ps Punctuation S Sc Separator Sk Sm So Space_Separator Spacing_Mark Surrogate Symbol Titlecase_Letter Unassigned Uppercase_Letter Z Zl Zp Zs cntrl digit punct", "", "", "", "", "", "", "");
+    var scValueSets = new DataSet("Adlam Adlm Aghb Ahom Anatolian_Hieroglyphs Arab Arabic Armenian Armi Armn Avestan Avst Bali Balinese Bamu Bamum Bass Bassa_Vah Batak Batk Beng Bengali Bhaiksuki Bhks Bopo Bopomofo Brah Brahmi Brai Braille Bugi Buginese Buhd Buhid Cakm Canadian_Aboriginal Cans Cari Carian Caucasian_Albanian Chakma Cham Cher Cherokee Common Copt Coptic Cprt Cuneiform Cypriot Cyrillic Cyrl Deseret Deva Devanagari Dsrt Dupl Duployan Egyp Egyptian_Hieroglyphs Elba Elbasan Ethi Ethiopic Geor Georgian Glag Glagolitic Gonm Goth Gothic Gran Grantha Greek Grek Gujarati Gujr Gurmukhi Guru Han Hang Hangul Hani Hano Hanunoo Hatr Hatran Hebr Hebrew Hira Hiragana Hluw Hmng Hung Imperial_Aramaic Inherited Inscriptional_Pahlavi Inscriptional_Parthian Ital Java Javanese Kaithi Kali Kana Kannada Katakana Kayah_Li Khar Kharoshthi Khmer Khmr Khoj Khojki Khudawadi Knda Kthi Lana Lao Laoo Latin Latn Lepc Lepcha Limb Limbu Lina Linb Linear_A Linear_B Lisu Lyci Lycian Lydi Lydian Mahajani Mahj Malayalam Mand Mandaic Mani Manichaean Marc Marchen Masaram_Gondi Meetei_Mayek Mend Mende_Kikakui Merc Mero Meroitic_Cursive Meroitic_Hieroglyphs Miao Mlym Modi Mong Mongolian Mro Mroo Mtei Mult Multani Myanmar Mymr Nabataean Narb Nbat New_Tai_Lue Newa Nko Nkoo Nshu Nushu Ogam Ogham Ol_Chiki Olck Old_Hungarian Old_Italic Old_North_Arabian Old_Permic Old_Persian Old_South_Arabian Old_Turkic Oriya Orkh Orya Osage Osge Osma Osmanya Pahawh_Hmong Palm Palmyrene Pau_Cin_Hau Pauc Perm Phag Phags_Pa Phli Phlp Phnx Phoenician Plrd Prti Psalter_Pahlavi Qaac Qaai Rejang Rjng Runic Runr Samaritan Samr Sarb Saur Saurashtra Sgnw Sharada Shavian Shaw Shrd Sidd Siddham SignWriting Sind Sinh Sinhala Sora Sora_Sompeng Soyo Soyombo Sund Sundanese Sylo Syloti_Nagri Syrc Syriac Tagalog Tagb Tagbanwa Tai_Le Tai_Tham Tai_Viet Takr Takri Tale Talu Tamil Taml Tang Tangut Tavt Telu Telugu Tfng Tglg Thaa Thaana Thai Tibetan Tibt Tifinagh Tirh Tirhuta Ugar Ugaritic Vai Vaii Wara Warang_Citi Xpeo Xsux Yi Yiii Zanabazar_Square Zanb Zinh Zyyy", "Dogr Dogra Gong Gunjala_Gondi Hanifi_Rohingya Maka Makasar Medefaidrin Medf Old_Sogdian Rohg Sogd Sogdian Sogo", "Elym Elymaic Hmnp Nand Nandinagari Nyiakeng_Puachue_Hmong Wancho Wcho", "Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi", "Cpmn Cypro_Minoan Old_Uyghur Ougr Tangsa Tnsa Toto Vith Vithkuqi", "Gara Garay Gukh Gurung_Khema Hrkt Katakana_Or_Hiragana Kawi Kirat_Rai Krai Nag_Mundari Nagm Ol_Onal Onao Sunu Sunuwar Todhri Todr Tulu_Tigalari Tutg Unknown Zzzz", "", "");
+    var binPropertySets = new DataSet("AHex ASCII ASCII_Hex_Digit Alpha Alphabetic Any Assigned Bidi_C Bidi_Control Bidi_M Bidi_Mirrored CI CWCF CWCM CWKCF CWL CWT CWU Case_Ignorable Cased Changes_When_Casefolded Changes_When_Casemapped Changes_When_Lowercased Changes_When_NFKC_Casefolded Changes_When_Titlecased Changes_When_Uppercased DI Dash Default_Ignorable_Code_Point Dep Deprecated Dia Diacritic Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Ext Extender Gr_Base Gr_Ext Grapheme_Base Grapheme_Extend Hex Hex_Digit IDC IDS IDSB IDST IDS_Binary_Operator IDS_Trinary_Operator ID_Continue ID_Start Ideo Ideographic Join_C Join_Control LOE Logical_Order_Exception Lower Lowercase Math NChar Noncharacter_Code_Point Pat_Syn Pat_WS Pattern_Syntax Pattern_White_Space QMark Quotation_Mark RI Radical Regional_Indicator SD STerm Sentence_Terminal Soft_Dotted Term Terminal_Punctuation UIdeo Unified_Ideograph Upper Uppercase VS Variation_Selector White_Space XIDC XIDS XID_Continue XID_Start space", "Extended_Pictographic", "", "EBase EComp EMod EPres ExtPict", "", "", "", "");
+    var binPropertyOfStringsSets = new DataSet("", "", "", "", "", "", "Basic_Emoji Emoji_Keycap_Sequence RGI_Emoji RGI_Emoji_Flag_Sequence RGI_Emoji_Modifier_Sequence RGI_Emoji_Tag_Sequence RGI_Emoji_ZWJ_Sequence", "");
     function isValidUnicodeProperty(version, name, value) {
       if (gcNameSet.has(name)) {
         return version >= 2018 && gcValueSets.es2018.has(value);
@@ -57987,6 +62019,9 @@ var require_regexpp = __commonJS({
     function isValidLoneUnicodeProperty(version, value) {
       return version >= 2018 && binPropertySets.es2018.has(value) || version >= 2019 && binPropertySets.es2019.has(value) || version >= 2021 && binPropertySets.es2021.has(value);
     }
+    function isValidLoneUnicodePropertyOfString(version, value) {
+      return version >= 2024 && binPropertyOfStringsSets.es2024.has(value);
+    }
     var BACKSPACE = 8;
     var CHARACTER_TABULATION = 9;
     var LINE_FEED = 10;
@@ -57994,7 +62029,10 @@ var require_regexpp = __commonJS({
     var FORM_FEED = 12;
     var CARRIAGE_RETURN = 13;
     var EXCLAMATION_MARK = 33;
+    var NUMBER_SIGN = 35;
     var DOLLAR_SIGN = 36;
+    var PERCENT_SIGN = 37;
+    var AMPERSAND = 38;
     var LEFT_PARENTHESIS = 40;
     var RIGHT_PARENTHESIS = 41;
     var ASTERISK = 42;
@@ -58008,10 +62046,12 @@ var require_regexpp = __commonJS({
     var DIGIT_SEVEN = 55;
     var DIGIT_NINE = 57;
     var COLON = 58;
+    var SEMICOLON = 59;
     var LESS_THAN_SIGN = 60;
     var EQUALS_SIGN = 61;
     var GREATER_THAN_SIGN = 62;
     var QUESTION_MARK = 63;
+    var COMMERCIAL_AT = 64;
     var LATIN_CAPITAL_LETTER_A = 65;
     var LATIN_CAPITAL_LETTER_B = 66;
     var LATIN_CAPITAL_LETTER_D = 68;
@@ -58032,6 +62072,7 @@ var require_regexpp = __commonJS({
     var LATIN_SMALL_LETTER_M = 109;
     var LATIN_SMALL_LETTER_N = 110;
     var LATIN_SMALL_LETTER_P = 112;
+    var LATIN_SMALL_LETTER_Q = 113;
     var LATIN_SMALL_LETTER_R = 114;
     var LATIN_SMALL_LETTER_S = 115;
     var LATIN_SMALL_LETTER_T = 116;
@@ -58045,9 +62086,11 @@ var require_regexpp = __commonJS({
     var REVERSE_SOLIDUS = 92;
     var RIGHT_SQUARE_BRACKET = 93;
     var CIRCUMFLEX_ACCENT = 94;
+    var GRAVE_ACCENT = 96;
     var LEFT_CURLY_BRACKET = 123;
     var VERTICAL_LINE = 124;
     var RIGHT_CURLY_BRACKET = 125;
+    var TILDE = 126;
     var ZERO_WIDTH_NON_JOINER = 8204;
     var ZERO_WIDTH_JOINER = 8205;
     var LINE_SEPARATOR = 8232;
@@ -58090,6 +62133,102 @@ var require_regexpp = __commonJS({
     function combineSurrogatePair(lead, trail) {
       return (lead - 55296) * 1024 + (trail - 56320) + 65536;
     }
+    var GroupSpecifiersAsES2018 = class {
+      constructor() {
+        this.groupName = /* @__PURE__ */ new Set();
+      }
+      clear() {
+        this.groupName.clear();
+      }
+      isEmpty() {
+        return !this.groupName.size;
+      }
+      hasInPattern(name) {
+        return this.groupName.has(name);
+      }
+      hasInScope(name) {
+        return this.hasInPattern(name);
+      }
+      addToScope(name) {
+        this.groupName.add(name);
+      }
+      enterDisjunction() {
+      }
+      enterAlternative() {
+      }
+      leaveDisjunction() {
+      }
+    };
+    var BranchID = class _BranchID {
+      constructor(parent, base) {
+        this.parent = parent;
+        this.base = base !== null && base !== void 0 ? base : this;
+      }
+      separatedFrom(other) {
+        var _a, _b;
+        if (this.base === other.base && this !== other) {
+          return true;
+        }
+        if (other.parent && this.separatedFrom(other.parent)) {
+          return true;
+        }
+        return (_b = (_a = this.parent) === null || _a === void 0 ? void 0 : _a.separatedFrom(other)) !== null && _b !== void 0 ? _b : false;
+      }
+      child() {
+        return new _BranchID(this, null);
+      }
+      sibling() {
+        return new _BranchID(this.parent, this.base);
+      }
+    };
+    var GroupSpecifiersAsES2025 = class {
+      constructor() {
+        this.branchID = new BranchID(null, null);
+        this.groupNames = /* @__PURE__ */ new Map();
+      }
+      clear() {
+        this.branchID = new BranchID(null, null);
+        this.groupNames.clear();
+      }
+      isEmpty() {
+        return !this.groupNames.size;
+      }
+      enterDisjunction() {
+        this.branchID = this.branchID.child();
+      }
+      enterAlternative(index) {
+        if (index === 0) {
+          return;
+        }
+        this.branchID = this.branchID.sibling();
+      }
+      leaveDisjunction() {
+        this.branchID = this.branchID.parent;
+      }
+      hasInPattern(name) {
+        return this.groupNames.has(name);
+      }
+      hasInScope(name) {
+        const branches = this.groupNames.get(name);
+        if (!branches) {
+          return false;
+        }
+        for (const branch of branches) {
+          if (!branch.separatedFrom(this.branchID)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      addToScope(name) {
+        const branches = this.groupNames.get(name);
+        if (branches) {
+          branches.push(this.branchID);
+          return;
+        }
+        this.groupNames.set(name, [this.branchID]);
+      }
+    };
     var legacyImpl = {
       at(s, end, i) {
         return i < end ? s.charCodeAt(i) : -1;
@@ -58194,25 +62333,118 @@ var require_regexpp = __commonJS({
       }
     };
     var RegExpSyntaxError = class extends SyntaxError {
-      constructor(source, uFlag, index, message) {
-        if (source) {
-          if (!source.startsWith("/")) {
-            source = `/${source}/${uFlag ? "u" : ""}`;
-          }
-          source = `: ${source}`;
-        }
-        super(`Invalid regular expression${source}: ${message}`);
+      constructor(message, index) {
+        super(message);
         this.index = index;
       }
     };
-    function isSyntaxCharacter(cp) {
-      return cp === CIRCUMFLEX_ACCENT || cp === DOLLAR_SIGN || cp === REVERSE_SOLIDUS || cp === FULL_STOP || cp === ASTERISK || cp === PLUS_SIGN || cp === QUESTION_MARK || cp === LEFT_PARENTHESIS || cp === RIGHT_PARENTHESIS || cp === LEFT_SQUARE_BRACKET || cp === RIGHT_SQUARE_BRACKET || cp === LEFT_CURLY_BRACKET || cp === RIGHT_CURLY_BRACKET || cp === VERTICAL_LINE;
+    function newRegExpSyntaxError(srcCtx, flags, index, message) {
+      let source = "";
+      if (srcCtx.kind === "literal") {
+        const literal = srcCtx.source.slice(srcCtx.start, srcCtx.end);
+        if (literal) {
+          source = `: ${literal}`;
+        }
+      } else if (srcCtx.kind === "pattern") {
+        const pattern = srcCtx.source.slice(srcCtx.start, srcCtx.end);
+        const flagsText = `${flags.unicode ? "u" : ""}${flags.unicodeSets ? "v" : ""}`;
+        source = `: /${pattern}/${flagsText}`;
+      }
+      return new RegExpSyntaxError(`Invalid regular expression${source}: ${message}`, index);
     }
-    function isRegExpIdentifierStart(cp) {
+    var SYNTAX_CHARACTER = /* @__PURE__ */ new Set([
+      CIRCUMFLEX_ACCENT,
+      DOLLAR_SIGN,
+      REVERSE_SOLIDUS,
+      FULL_STOP,
+      ASTERISK,
+      PLUS_SIGN,
+      QUESTION_MARK,
+      LEFT_PARENTHESIS,
+      RIGHT_PARENTHESIS,
+      LEFT_SQUARE_BRACKET,
+      RIGHT_SQUARE_BRACKET,
+      LEFT_CURLY_BRACKET,
+      RIGHT_CURLY_BRACKET,
+      VERTICAL_LINE
+    ]);
+    var CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR_CHARACTER = /* @__PURE__ */ new Set([
+      AMPERSAND,
+      EXCLAMATION_MARK,
+      NUMBER_SIGN,
+      DOLLAR_SIGN,
+      PERCENT_SIGN,
+      ASTERISK,
+      PLUS_SIGN,
+      COMMA,
+      FULL_STOP,
+      COLON,
+      SEMICOLON,
+      LESS_THAN_SIGN,
+      EQUALS_SIGN,
+      GREATER_THAN_SIGN,
+      QUESTION_MARK,
+      COMMERCIAL_AT,
+      CIRCUMFLEX_ACCENT,
+      GRAVE_ACCENT,
+      TILDE
+    ]);
+    var CLASS_SET_SYNTAX_CHARACTER = /* @__PURE__ */ new Set([
+      LEFT_PARENTHESIS,
+      RIGHT_PARENTHESIS,
+      LEFT_SQUARE_BRACKET,
+      RIGHT_SQUARE_BRACKET,
+      LEFT_CURLY_BRACKET,
+      RIGHT_CURLY_BRACKET,
+      SOLIDUS,
+      HYPHEN_MINUS,
+      REVERSE_SOLIDUS,
+      VERTICAL_LINE
+    ]);
+    var CLASS_SET_RESERVED_PUNCTUATOR = /* @__PURE__ */ new Set([
+      AMPERSAND,
+      HYPHEN_MINUS,
+      EXCLAMATION_MARK,
+      NUMBER_SIGN,
+      PERCENT_SIGN,
+      COMMA,
+      COLON,
+      SEMICOLON,
+      LESS_THAN_SIGN,
+      EQUALS_SIGN,
+      GREATER_THAN_SIGN,
+      COMMERCIAL_AT,
+      GRAVE_ACCENT,
+      TILDE
+    ]);
+    var FLAG_PROP_TO_CODEPOINT = {
+      global: LATIN_SMALL_LETTER_G,
+      ignoreCase: LATIN_SMALL_LETTER_I,
+      multiline: LATIN_SMALL_LETTER_M,
+      unicode: LATIN_SMALL_LETTER_U,
+      sticky: LATIN_SMALL_LETTER_Y,
+      dotAll: LATIN_SMALL_LETTER_S,
+      hasIndices: LATIN_SMALL_LETTER_D,
+      unicodeSets: LATIN_SMALL_LETTER_V
+    };
+    var FLAG_CODEPOINT_TO_PROP = Object.fromEntries(Object.entries(FLAG_PROP_TO_CODEPOINT).map(([k, v]) => [v, k]));
+    function isSyntaxCharacter(cp) {
+      return SYNTAX_CHARACTER.has(cp);
+    }
+    function isClassSetReservedDoublePunctuatorCharacter(cp) {
+      return CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR_CHARACTER.has(cp);
+    }
+    function isClassSetSyntaxCharacter(cp) {
+      return CLASS_SET_SYNTAX_CHARACTER.has(cp);
+    }
+    function isClassSetReservedPunctuator(cp) {
+      return CLASS_SET_RESERVED_PUNCTUATOR.has(cp);
+    }
+    function isIdentifierStartChar(cp) {
       return isIdStart(cp) || cp === DOLLAR_SIGN || cp === LOW_LINE;
     }
-    function isRegExpIdentifierPart(cp) {
-      return isIdContinue(cp) || cp === DOLLAR_SIGN || cp === LOW_LINE || cp === ZERO_WIDTH_NON_JOINER || cp === ZERO_WIDTH_JOINER;
+    function isIdentifierPartChar(cp) {
+      return isIdContinue(cp) || cp === DOLLAR_SIGN || cp === ZERO_WIDTH_NON_JOINER || cp === ZERO_WIDTH_JOINER;
     }
     function isUnicodePropertyNameCharacter(cp) {
       return isLatinLetter(cp) || cp === LOW_LINE;
@@ -58220,32 +62452,42 @@ var require_regexpp = __commonJS({
     function isUnicodePropertyValueCharacter(cp) {
       return isUnicodePropertyNameCharacter(cp) || isDecimalDigit(cp);
     }
+    function isRegularExpressionModifier(ch) {
+      return ch === LATIN_SMALL_LETTER_I || ch === LATIN_SMALL_LETTER_M || ch === LATIN_SMALL_LETTER_S;
+    }
     var RegExpValidator = class {
       constructor(options) {
         this._reader = new Reader();
-        this._uFlag = false;
+        this._unicodeMode = false;
+        this._unicodeSetsMode = false;
         this._nFlag = false;
         this._lastIntValue = 0;
-        this._lastMinValue = 0;
-        this._lastMaxValue = 0;
+        this._lastRange = {
+          min: 0,
+          max: Number.POSITIVE_INFINITY
+        };
         this._lastStrValue = "";
-        this._lastKeyValue = "";
-        this._lastValValue = "";
         this._lastAssertionIsQuantifiable = false;
         this._numCapturingParens = 0;
-        this._groupNames = /* @__PURE__ */ new Set();
         this._backreferenceNames = /* @__PURE__ */ new Set();
+        this._srcCtx = null;
         this._options = options !== null && options !== void 0 ? options : {};
+        this._groupSpecifiers = this.ecmaVersion >= 2025 ? new GroupSpecifiersAsES2025() : new GroupSpecifiersAsES2018();
       }
       validateLiteral(source, start = 0, end = source.length) {
-        this._uFlag = this._nFlag = false;
+        this._srcCtx = { source, start, end, kind: "literal" };
+        this._unicodeSetsMode = this._unicodeMode = this._nFlag = false;
         this.reset(source, start, end);
         this.onLiteralEnter(start);
         if (this.eat(SOLIDUS) && this.eatRegExpBody() && this.eat(SOLIDUS)) {
           const flagStart = this.index;
-          const uFlag = source.includes("u", flagStart);
-          this.validateFlags(source, flagStart, end);
-          this.validatePattern(source, start + 1, flagStart - 1, uFlag);
+          const unicode = source.includes("u", flagStart);
+          const unicodeSets = source.includes("v", flagStart);
+          this.validateFlagsInternal(source, flagStart, end);
+          this.validatePatternInternal(source, start + 1, flagStart - 1, {
+            unicode,
+            unicodeSets
+          });
         } else if (start >= end) {
           this.raise("Empty");
         } else {
@@ -58255,65 +62497,61 @@ var require_regexpp = __commonJS({
         this.onLiteralLeave(start, end);
       }
       validateFlags(source, start = 0, end = source.length) {
-        const existingFlags = /* @__PURE__ */ new Set();
-        let global2 = false;
-        let ignoreCase = false;
-        let multiline = false;
-        let sticky = false;
-        let unicode = false;
-        let dotAll = false;
-        let hasIndices = false;
-        for (let i = start; i < end; ++i) {
-          const flag = source.charCodeAt(i);
-          if (existingFlags.has(flag)) {
-            this.raise(`Duplicated flag '${source[i]}'`);
-          }
-          existingFlags.add(flag);
-          if (flag === LATIN_SMALL_LETTER_G) {
-            global2 = true;
-          } else if (flag === LATIN_SMALL_LETTER_I) {
-            ignoreCase = true;
-          } else if (flag === LATIN_SMALL_LETTER_M) {
-            multiline = true;
-          } else if (flag === LATIN_SMALL_LETTER_U && this.ecmaVersion >= 2015) {
-            unicode = true;
-          } else if (flag === LATIN_SMALL_LETTER_Y && this.ecmaVersion >= 2015) {
-            sticky = true;
-          } else if (flag === LATIN_SMALL_LETTER_S && this.ecmaVersion >= 2018) {
-            dotAll = true;
-          } else if (flag === LATIN_SMALL_LETTER_D && this.ecmaVersion >= 2022) {
-            hasIndices = true;
-          } else {
-            this.raise(`Invalid flag '${source[i]}'`);
-          }
-        }
-        this.onRegExpFlags(start, end, {
-          global: global2,
-          ignoreCase,
-          multiline,
-          unicode,
-          sticky,
-          dotAll,
-          hasIndices
-        });
+        this._srcCtx = { source, start, end, kind: "flags" };
+        this.validateFlagsInternal(source, start, end);
       }
-      validatePattern(source, start = 0, end = source.length, uFlag = false) {
-        this._uFlag = uFlag && this.ecmaVersion >= 2015;
-        this._nFlag = uFlag && this.ecmaVersion >= 2018 || Boolean(this._options.strict && this.ecmaVersion >= 2023);
+      validatePattern(source, start = 0, end = source.length, uFlagOrFlags = void 0) {
+        this._srcCtx = { source, start, end, kind: "pattern" };
+        this.validatePatternInternal(source, start, end, uFlagOrFlags);
+      }
+      validatePatternInternal(source, start = 0, end = source.length, uFlagOrFlags = void 0) {
+        const mode = this._parseFlagsOptionToMode(uFlagOrFlags, end);
+        this._unicodeMode = mode.unicodeMode;
+        this._nFlag = mode.nFlag;
+        this._unicodeSetsMode = mode.unicodeSetsMode;
         this.reset(source, start, end);
         this.consumePattern();
-        if (!this._nFlag && this.ecmaVersion >= 2018 && this._groupNames.size > 0) {
+        if (!this._nFlag && this.ecmaVersion >= 2018 && !this._groupSpecifiers.isEmpty()) {
           this._nFlag = true;
           this.rewind(start);
           this.consumePattern();
         }
       }
+      validateFlagsInternal(source, start, end) {
+        const flags = this.parseFlags(source, start, end);
+        this.onRegExpFlags(start, end, flags);
+      }
+      _parseFlagsOptionToMode(uFlagOrFlags, sourceEnd) {
+        let unicode = false;
+        let unicodeSets = false;
+        if (uFlagOrFlags && this.ecmaVersion >= 2015) {
+          if (typeof uFlagOrFlags === "object") {
+            unicode = Boolean(uFlagOrFlags.unicode);
+            if (this.ecmaVersion >= 2024) {
+              unicodeSets = Boolean(uFlagOrFlags.unicodeSets);
+            }
+          } else {
+            unicode = uFlagOrFlags;
+          }
+        }
+        if (unicode && unicodeSets) {
+          this.raise("Invalid regular expression flags", {
+            index: sourceEnd + 1,
+            unicode,
+            unicodeSets
+          });
+        }
+        const unicodeMode = unicode || unicodeSets;
+        const nFlag = unicode && this.ecmaVersion >= 2018 || unicodeSets || Boolean(this._options.strict && this.ecmaVersion >= 2023);
+        const unicodeSetsMode = unicodeSets;
+        return { unicodeMode, nFlag, unicodeSetsMode };
+      }
       get strict() {
-        return Boolean(this._options.strict) || this._uFlag;
+        return Boolean(this._options.strict) || this._unicodeMode;
       }
       get ecmaVersion() {
         var _a;
-        return (_a = this._options.ecmaVersion) !== null && _a !== void 0 ? _a : 2023;
+        return (_a = this._options.ecmaVersion) !== null && _a !== void 0 ? _a : latestEcmaVersion;
       }
       onLiteralEnter(start) {
         if (this._options.onLiteralEnter) {
@@ -58373,6 +62611,26 @@ var require_regexpp = __commonJS({
           this._options.onGroupLeave(start, end);
         }
       }
+      onModifiersEnter(start) {
+        if (this._options.onModifiersEnter) {
+          this._options.onModifiersEnter(start);
+        }
+      }
+      onModifiersLeave(start, end) {
+        if (this._options.onModifiersLeave) {
+          this._options.onModifiersLeave(start, end);
+        }
+      }
+      onAddModifiers(start, end, flags) {
+        if (this._options.onAddModifiers) {
+          this._options.onAddModifiers(start, end, flags);
+        }
+      }
+      onRemoveModifiers(start, end, flags) {
+        if (this._options.onRemoveModifiers) {
+          this._options.onRemoveModifiers(start, end, flags);
+        }
+      }
       onCapturingGroupEnter(start, name) {
         if (this._options.onCapturingGroupEnter) {
           this._options.onCapturingGroupEnter(start, name);
@@ -58418,9 +62676,9 @@ var require_regexpp = __commonJS({
           this._options.onEscapeCharacterSet(start, end, kind, negate);
         }
       }
-      onUnicodePropertyCharacterSet(start, end, kind, key, value, negate) {
+      onUnicodePropertyCharacterSet(start, end, kind, key, value, negate, strings) {
         if (this._options.onUnicodePropertyCharacterSet) {
-          this._options.onUnicodePropertyCharacterSet(start, end, kind, key, value, negate);
+          this._options.onUnicodePropertyCharacterSet(start, end, kind, key, value, negate, strings);
         }
       }
       onCharacter(start, end, value) {
@@ -58433,9 +62691,9 @@ var require_regexpp = __commonJS({
           this._options.onBackreference(start, end, ref);
         }
       }
-      onCharacterClassEnter(start, negate) {
+      onCharacterClassEnter(start, negate, unicodeSets) {
         if (this._options.onCharacterClassEnter) {
-          this._options.onCharacterClassEnter(start, negate);
+          this._options.onCharacterClassEnter(start, negate, unicodeSets);
         }
       }
       onCharacterClassLeave(start, end, negate) {
@@ -58448,8 +62706,35 @@ var require_regexpp = __commonJS({
           this._options.onCharacterClassRange(start, end, min, max);
         }
       }
-      get source() {
-        return this._reader.source;
+      onClassIntersection(start, end) {
+        if (this._options.onClassIntersection) {
+          this._options.onClassIntersection(start, end);
+        }
+      }
+      onClassSubtraction(start, end) {
+        if (this._options.onClassSubtraction) {
+          this._options.onClassSubtraction(start, end);
+        }
+      }
+      onClassStringDisjunctionEnter(start) {
+        if (this._options.onClassStringDisjunctionEnter) {
+          this._options.onClassStringDisjunctionEnter(start);
+        }
+      }
+      onClassStringDisjunctionLeave(start, end) {
+        if (this._options.onClassStringDisjunctionLeave) {
+          this._options.onClassStringDisjunctionLeave(start, end);
+        }
+      }
+      onStringAlternativeEnter(start, index) {
+        if (this._options.onStringAlternativeEnter) {
+          this._options.onStringAlternativeEnter(start, index);
+        }
+      }
+      onStringAlternativeLeave(start, end, index) {
+        if (this._options.onStringAlternativeLeave) {
+          this._options.onStringAlternativeLeave(start, end, index);
+        }
       }
       get index() {
         return this._reader.index;
@@ -58467,7 +62752,7 @@ var require_regexpp = __commonJS({
         return this._reader.nextCodePoint3;
       }
       reset(source, start, end) {
-        this._reader.reset(source, start, end, this._uFlag);
+        this._reader.reset(source, start, end, this._unicodeMode);
       }
       rewind(index) {
         this._reader.rewind(index);
@@ -58484,8 +62769,12 @@ var require_regexpp = __commonJS({
       eat3(cp1, cp2, cp3) {
         return this._reader.eat3(cp1, cp2, cp3);
       }
-      raise(message) {
-        throw new RegExpSyntaxError(this.source, this._uFlag, this.index, message);
+      raise(message, context) {
+        var _a, _b, _c;
+        throw newRegExpSyntaxError(this._srcCtx, {
+          unicode: (_a = context === null || context === void 0 ? void 0 : context.unicode) !== null && _a !== void 0 ? _a : this._unicodeMode && !this._unicodeSetsMode,
+          unicodeSets: (_b = context === null || context === void 0 ? void 0 : context.unicodeSets) !== null && _b !== void 0 ? _b : this._unicodeSetsMode
+        }, (_c = context === null || context === void 0 ? void 0 : context.index) !== null && _c !== void 0 ? _c : this.index, message);
       }
       eatRegExpBody() {
         const start = this.index;
@@ -58515,7 +62804,7 @@ var require_regexpp = __commonJS({
       consumePattern() {
         const start = this.index;
         this._numCapturingParens = this.countCapturingParens();
-        this._groupNames.clear();
+        this._groupSpecifiers.clear();
         this._backreferenceNames.clear();
         this.onPatternEnter(start);
         this.consumeDisjunction();
@@ -58534,7 +62823,7 @@ var require_regexpp = __commonJS({
           this.raise(`Unexpected character '${c}'`);
         }
         for (const name of this._backreferenceNames) {
-          if (!this._groupNames.has(name)) {
+          if (!this._groupSpecifiers.hasInPattern(name)) {
             this.raise("Invalid named capture referenced");
           }
         }
@@ -58566,6 +62855,7 @@ var require_regexpp = __commonJS({
       consumeDisjunction() {
         const start = this.index;
         let i = 0;
+        this._groupSpecifiers.enterDisjunction();
         this.onDisjunctionEnter(start);
         do {
           this.consumeAlternative(i++);
@@ -58577,16 +62867,18 @@ var require_regexpp = __commonJS({
           this.raise("Lone quantifier brackets");
         }
         this.onDisjunctionLeave(start, this.index);
+        this._groupSpecifiers.leaveDisjunction();
       }
       consumeAlternative(i) {
         const start = this.index;
+        this._groupSpecifiers.enterAlternative(i);
         this.onAlternativeEnter(start, i);
         while (this.currentCodePoint !== -1 && this.consumeTerm()) {
         }
         this.onAlternativeLeave(start, this.index, i);
       }
       consumeTerm() {
-        if (this._uFlag || this.strict) {
+        if (this._unicodeMode || this.strict) {
           return this.consumeAssertion() || this.consumeAtom() && this.consumeOptionalQuantifier();
         }
         return this.consumeAssertion() && (!this._lastAssertionIsQuantifiable || this.consumeOptionalQuantifier()) || this.consumeExtendedAtom() && this.consumeOptionalQuantifier();
@@ -58647,8 +62939,7 @@ var require_regexpp = __commonJS({
           min = 0;
           max = 1;
         } else if (this.eatBracedQuantifier(noConsume)) {
-          min = this._lastMinValue;
-          max = this._lastMaxValue;
+          ({ min, max } = this._lastRange);
         } else {
           return false;
         }
@@ -58661,21 +62952,21 @@ var require_regexpp = __commonJS({
       eatBracedQuantifier(noError) {
         const start = this.index;
         if (this.eat(LEFT_CURLY_BRACKET)) {
-          this._lastMinValue = 0;
-          this._lastMaxValue = Number.POSITIVE_INFINITY;
           if (this.eatDecimalDigits()) {
-            this._lastMinValue = this._lastMaxValue = this._lastIntValue;
+            const min = this._lastIntValue;
+            let max = min;
             if (this.eat(COMMA)) {
-              this._lastMaxValue = this.eatDecimalDigits() ? this._lastIntValue : Number.POSITIVE_INFINITY;
+              max = this.eatDecimalDigits() ? this._lastIntValue : Number.POSITIVE_INFINITY;
             }
             if (this.eat(RIGHT_CURLY_BRACKET)) {
-              if (!noError && this._lastMaxValue < this._lastMinValue) {
+              if (!noError && max < min) {
                 this.raise("numbers out of order in {} quantifier");
               }
+              this._lastRange = { min, max };
               return true;
             }
           }
-          if (!noError && (this._uFlag || this.strict)) {
+          if (!noError && (this._unicodeMode || this.strict)) {
             this.raise("Incomplete quantifier");
           }
           this.rewind(start);
@@ -58683,7 +62974,7 @@ var require_regexpp = __commonJS({
         return false;
       }
       consumeAtom() {
-        return this.consumePatternCharacter() || this.consumeDot() || this.consumeReverseSolidusAtomEscape() || this.consumeCharacterClass() || this.consumeUncapturingGroup() || this.consumeCapturingGroup();
+        return this.consumePatternCharacter() || this.consumeDot() || this.consumeReverseSolidusAtomEscape() || Boolean(this.consumeCharacterClass()) || this.consumeCapturingGroup() || this.consumeUncapturingGroup();
       }
       consumeDot() {
         if (this.eat(FULL_STOP)) {
@@ -58704,8 +62995,15 @@ var require_regexpp = __commonJS({
       }
       consumeUncapturingGroup() {
         const start = this.index;
-        if (this.eat3(LEFT_PARENTHESIS, QUESTION_MARK, COLON)) {
+        if (this.eat2(LEFT_PARENTHESIS, QUESTION_MARK)) {
           this.onGroupEnter(start);
+          if (this.ecmaVersion >= 2025) {
+            this.consumeModifiers();
+          }
+          if (!this.eat(COLON)) {
+            this.rewind(start + 1);
+            this.raise("Invalid group");
+          }
           this.consumeDisjunction();
           if (!this.eat(RIGHT_PARENTHESIS)) {
             this.raise("Unterminated group");
@@ -58715,6 +63013,33 @@ var require_regexpp = __commonJS({
         }
         return false;
       }
+      consumeModifiers() {
+        const start = this.index;
+        const hasAddModifiers = this.eatModifiers();
+        const addModifiersEnd = this.index;
+        const hasHyphen = this.eat(HYPHEN_MINUS);
+        if (!hasAddModifiers && !hasHyphen) {
+          return false;
+        }
+        this.onModifiersEnter(start);
+        const addModifiers = this.parseModifiers(start, addModifiersEnd);
+        this.onAddModifiers(start, addModifiersEnd, addModifiers);
+        if (hasHyphen) {
+          const modifiersStart = this.index;
+          if (!this.eatModifiers() && !hasAddModifiers && this.currentCodePoint === COLON) {
+            this.raise("Invalid empty flags");
+          }
+          const modifiers = this.parseModifiers(modifiersStart, this.index);
+          for (const [flagName] of Object.entries(modifiers).filter(([, enable]) => enable)) {
+            if (addModifiers[flagName]) {
+              this.raise(`Duplicated flag '${String.fromCodePoint(FLAG_PROP_TO_CODEPOINT[flagName])}'`);
+            }
+          }
+          this.onRemoveModifiers(modifiersStart, this.index, modifiers);
+        }
+        this.onModifiersLeave(start, this.index);
+        return true;
+      }
       consumeCapturingGroup() {
         const start = this.index;
         if (this.eat(LEFT_PARENTHESIS)) {
@@ -58722,9 +63047,13 @@ var require_regexpp = __commonJS({
           if (this.ecmaVersion >= 2018) {
             if (this.consumeGroupSpecifier()) {
               name = this._lastStrValue;
+            } else if (this.currentCodePoint === QUESTION_MARK) {
+              this.rewind(start);
+              return false;
             }
           } else if (this.currentCodePoint === QUESTION_MARK) {
-            this.raise("Invalid group");
+            this.rewind(start);
+            return false;
           }
           this.onCapturingGroupEnter(start, name);
           this.consumeDisjunction();
@@ -58737,7 +63066,7 @@ var require_regexpp = __commonJS({
         return false;
       }
       consumeExtendedAtom() {
-        return this.consumeDot() || this.consumeReverseSolidusAtomEscape() || this.consumeReverseSolidusFollowedByC() || this.consumeCharacterClass() || this.consumeUncapturingGroup() || this.consumeCapturingGroup() || this.consumeInvalidBracedQuantifier() || this.consumeExtendedPatternCharacter();
+        return this.consumeDot() || this.consumeReverseSolidusAtomEscape() || this.consumeReverseSolidusFollowedByC() || Boolean(this.consumeCharacterClass()) || this.consumeCapturingGroup() || this.consumeUncapturingGroup() || this.consumeInvalidBracedQuantifier() || this.consumeExtendedPatternCharacter();
       }
       consumeReverseSolidusFollowedByC() {
         const start = this.index;
@@ -58776,15 +63105,16 @@ var require_regexpp = __commonJS({
         return false;
       }
       consumeGroupSpecifier() {
+        const start = this.index;
         if (this.eat(QUESTION_MARK)) {
           if (this.eatGroupName()) {
-            if (!this._groupNames.has(this._lastStrValue)) {
-              this._groupNames.add(this._lastStrValue);
+            if (!this._groupSpecifiers.hasInScope(this._lastStrValue)) {
+              this._groupSpecifiers.addToScope(this._lastStrValue);
               return true;
             }
             this.raise("Duplicate capture group name");
           }
-          this.raise("Invalid group");
+          this.rewind(start);
         }
         return false;
       }
@@ -58792,7 +63122,7 @@ var require_regexpp = __commonJS({
         if (this.consumeBackreference() || this.consumeCharacterClassEscape() || this.consumeCharacterEscape() || this._nFlag && this.consumeKGroupName()) {
           return true;
         }
-        if (this.strict || this._uFlag) {
+        if (this.strict || this._unicodeMode) {
           this.raise("Invalid escape");
         }
         return false;
@@ -58805,7 +63135,7 @@ var require_regexpp = __commonJS({
             this.onBackreference(start - 1, this.index, n);
             return true;
           }
-          if (this.strict || this._uFlag) {
+          if (this.strict || this._unicodeMode) {
             this.raise("Invalid escape");
           }
           this.rewind(start);
@@ -58813,51 +63143,56 @@ var require_regexpp = __commonJS({
         return false;
       }
       consumeCharacterClassEscape() {
+        var _a;
         const start = this.index;
         if (this.eat(LATIN_SMALL_LETTER_D)) {
           this._lastIntValue = -1;
           this.onEscapeCharacterSet(start - 1, this.index, "digit", false);
-          return true;
+          return {};
         }
         if (this.eat(LATIN_CAPITAL_LETTER_D)) {
           this._lastIntValue = -1;
           this.onEscapeCharacterSet(start - 1, this.index, "digit", true);
-          return true;
+          return {};
         }
         if (this.eat(LATIN_SMALL_LETTER_S)) {
           this._lastIntValue = -1;
           this.onEscapeCharacterSet(start - 1, this.index, "space", false);
-          return true;
+          return {};
         }
         if (this.eat(LATIN_CAPITAL_LETTER_S)) {
           this._lastIntValue = -1;
           this.onEscapeCharacterSet(start - 1, this.index, "space", true);
-          return true;
+          return {};
         }
         if (this.eat(LATIN_SMALL_LETTER_W)) {
           this._lastIntValue = -1;
           this.onEscapeCharacterSet(start - 1, this.index, "word", false);
-          return true;
+          return {};
         }
         if (this.eat(LATIN_CAPITAL_LETTER_W)) {
           this._lastIntValue = -1;
           this.onEscapeCharacterSet(start - 1, this.index, "word", true);
-          return true;
+          return {};
         }
         let negate = false;
-        if (this._uFlag && this.ecmaVersion >= 2018 && (this.eat(LATIN_SMALL_LETTER_P) || (negate = this.eat(LATIN_CAPITAL_LETTER_P)))) {
+        if (this._unicodeMode && this.ecmaVersion >= 2018 && (this.eat(LATIN_SMALL_LETTER_P) || (negate = this.eat(LATIN_CAPITAL_LETTER_P)))) {
           this._lastIntValue = -1;
-          if (this.eat(LEFT_CURLY_BRACKET) && this.eatUnicodePropertyValueExpression() && this.eat(RIGHT_CURLY_BRACKET)) {
-            this.onUnicodePropertyCharacterSet(start - 1, this.index, "property", this._lastKeyValue, this._lastValValue || null, negate);
-            return true;
+          let result = null;
+          if (this.eat(LEFT_CURLY_BRACKET) && (result = this.eatUnicodePropertyValueExpression()) && this.eat(RIGHT_CURLY_BRACKET)) {
+            if (negate && result.strings) {
+              this.raise("Invalid property name");
+            }
+            this.onUnicodePropertyCharacterSet(start - 1, this.index, "property", result.key, result.value, negate, (_a = result.strings) !== null && _a !== void 0 ? _a : false);
+            return { mayContainStrings: result.strings };
           }
           this.raise("Invalid property name");
         }
-        return false;
+        return null;
       }
       consumeCharacterEscape() {
         const start = this.index;
-        if (this.eatControlEscape() || this.eatCControlLetter() || this.eatZero() || this.eatHexEscapeSequence() || this.eatRegExpUnicodeEscapeSequence() || !this.strict && !this._uFlag && this.eatLegacyOctalEscapeSequence() || this.eatIdentityEscape()) {
+        if (this.eatControlEscape() || this.eatCControlLetter() || this.eatZero() || this.eatHexEscapeSequence() || this.eatRegExpUnicodeEscapeSequence() || !this.strict && !this._unicodeMode && this.eatLegacyOctalEscapeSequence() || this.eatIdentityEscape()) {
           this.onCharacter(start - 1, this.index, this._lastIntValue);
           return true;
         }
@@ -58880,18 +63215,31 @@ var require_regexpp = __commonJS({
         const start = this.index;
         if (this.eat(LEFT_SQUARE_BRACKET)) {
           const negate = this.eat(CIRCUMFLEX_ACCENT);
-          this.onCharacterClassEnter(start, negate);
-          this.consumeClassRanges();
+          this.onCharacterClassEnter(start, negate, this._unicodeSetsMode);
+          const result = this.consumeClassContents();
           if (!this.eat(RIGHT_SQUARE_BRACKET)) {
-            this.raise("Unterminated character class");
+            if (this.currentCodePoint === -1) {
+              this.raise("Unterminated character class");
+            }
+            this.raise("Invalid character in character class");
+          }
+          if (negate && result.mayContainStrings) {
+            this.raise("Negated character class may contain strings");
           }
           this.onCharacterClassLeave(start, this.index, negate);
-          return true;
+          return result;
         }
-        return false;
+        return null;
       }
-      consumeClassRanges() {
-        const strict = this.strict || this._uFlag;
+      consumeClassContents() {
+        if (this._unicodeSetsMode) {
+          if (this.currentCodePoint === RIGHT_SQUARE_BRACKET) {
+            return {};
+          }
+          const result = this.consumeClassSetExpression();
+          return result;
+        }
+        const strict = this.strict || this._unicodeMode;
         for (; ; ) {
           const rangeStart = this.index;
           if (!this.consumeClassAtom()) {
@@ -58917,6 +63265,7 @@ var require_regexpp = __commonJS({
           }
           this.onCharacterClassRange(rangeStart, this.index, min, max);
         }
+        return {};
       }
       consumeClassAtom() {
         const start = this.index;
@@ -58936,7 +63285,7 @@ var require_regexpp = __commonJS({
             this.onCharacter(start, this.index, this._lastIntValue);
             return true;
           }
-          if (this.strict || this._uFlag) {
+          if (this.strict || this._unicodeMode) {
             this.raise("Invalid escape");
           }
           this.rewind(start);
@@ -58950,20 +63299,202 @@ var require_regexpp = __commonJS({
           this.onCharacter(start - 1, this.index, this._lastIntValue);
           return true;
         }
-        if (this._uFlag && this.eat(HYPHEN_MINUS)) {
+        if (this._unicodeMode && this.eat(HYPHEN_MINUS)) {
           this._lastIntValue = HYPHEN_MINUS;
           this.onCharacter(start - 1, this.index, this._lastIntValue);
           return true;
         }
         let cp = 0;
-        if (!this.strict && !this._uFlag && this.currentCodePoint === LATIN_SMALL_LETTER_C && (isDecimalDigit(cp = this.nextCodePoint) || cp === LOW_LINE)) {
+        if (!this.strict && !this._unicodeMode && this.currentCodePoint === LATIN_SMALL_LETTER_C && (isDecimalDigit(cp = this.nextCodePoint) || cp === LOW_LINE)) {
           this.advance();
           this.advance();
           this._lastIntValue = cp % 32;
           this.onCharacter(start - 1, this.index, this._lastIntValue);
           return true;
         }
-        return this.consumeCharacterClassEscape() || this.consumeCharacterEscape();
+        return Boolean(this.consumeCharacterClassEscape()) || this.consumeCharacterEscape();
+      }
+      consumeClassSetExpression() {
+        const start = this.index;
+        let mayContainStrings = false;
+        let result = null;
+        if (this.consumeClassSetCharacter()) {
+          if (this.consumeClassSetRangeFromOperator(start)) {
+            this.consumeClassUnionRight({});
+            return {};
+          }
+          mayContainStrings = false;
+        } else if (result = this.consumeClassSetOperand()) {
+          mayContainStrings = result.mayContainStrings;
+        } else {
+          const cp = this.currentCodePoint;
+          if (cp === REVERSE_SOLIDUS) {
+            this.advance();
+            this.raise("Invalid escape");
+          }
+          if (cp === this.nextCodePoint && isClassSetReservedDoublePunctuatorCharacter(cp)) {
+            this.raise("Invalid set operation in character class");
+          }
+          this.raise("Invalid character in character class");
+        }
+        if (this.eat2(AMPERSAND, AMPERSAND)) {
+          while (this.currentCodePoint !== AMPERSAND && (result = this.consumeClassSetOperand())) {
+            this.onClassIntersection(start, this.index);
+            if (!result.mayContainStrings) {
+              mayContainStrings = false;
+            }
+            if (this.eat2(AMPERSAND, AMPERSAND)) {
+              continue;
+            }
+            return { mayContainStrings };
+          }
+          this.raise("Invalid character in character class");
+        }
+        if (this.eat2(HYPHEN_MINUS, HYPHEN_MINUS)) {
+          while (this.consumeClassSetOperand()) {
+            this.onClassSubtraction(start, this.index);
+            if (this.eat2(HYPHEN_MINUS, HYPHEN_MINUS)) {
+              continue;
+            }
+            return { mayContainStrings };
+          }
+          this.raise("Invalid character in character class");
+        }
+        return this.consumeClassUnionRight({ mayContainStrings });
+      }
+      consumeClassUnionRight(leftResult) {
+        let mayContainStrings = leftResult.mayContainStrings;
+        for (; ; ) {
+          const start = this.index;
+          if (this.consumeClassSetCharacter()) {
+            this.consumeClassSetRangeFromOperator(start);
+            continue;
+          }
+          const result = this.consumeClassSetOperand();
+          if (result) {
+            if (result.mayContainStrings) {
+              mayContainStrings = true;
+            }
+            continue;
+          }
+          break;
+        }
+        return { mayContainStrings };
+      }
+      consumeClassSetRangeFromOperator(start) {
+        const currentStart = this.index;
+        const min = this._lastIntValue;
+        if (this.eat(HYPHEN_MINUS)) {
+          if (this.consumeClassSetCharacter()) {
+            const max = this._lastIntValue;
+            if (min === -1 || max === -1) {
+              this.raise("Invalid character class");
+            }
+            if (min > max) {
+              this.raise("Range out of order in character class");
+            }
+            this.onCharacterClassRange(start, this.index, min, max);
+            return true;
+          }
+          this.rewind(currentStart);
+        }
+        return false;
+      }
+      consumeClassSetOperand() {
+        let result = null;
+        if (result = this.consumeNestedClass()) {
+          return result;
+        }
+        if (result = this.consumeClassStringDisjunction()) {
+          return result;
+        }
+        if (this.consumeClassSetCharacter()) {
+          return {};
+        }
+        return null;
+      }
+      consumeNestedClass() {
+        const start = this.index;
+        if (this.eat(LEFT_SQUARE_BRACKET)) {
+          const negate = this.eat(CIRCUMFLEX_ACCENT);
+          this.onCharacterClassEnter(start, negate, true);
+          const result = this.consumeClassContents();
+          if (!this.eat(RIGHT_SQUARE_BRACKET)) {
+            this.raise("Unterminated character class");
+          }
+          if (negate && result.mayContainStrings) {
+            this.raise("Negated character class may contain strings");
+          }
+          this.onCharacterClassLeave(start, this.index, negate);
+          return result;
+        }
+        if (this.eat(REVERSE_SOLIDUS)) {
+          const result = this.consumeCharacterClassEscape();
+          if (result) {
+            return result;
+          }
+          this.rewind(start);
+        }
+        return null;
+      }
+      consumeClassStringDisjunction() {
+        const start = this.index;
+        if (this.eat3(REVERSE_SOLIDUS, LATIN_SMALL_LETTER_Q, LEFT_CURLY_BRACKET)) {
+          this.onClassStringDisjunctionEnter(start);
+          let i = 0;
+          let mayContainStrings = false;
+          do {
+            if (this.consumeClassString(i++).mayContainStrings) {
+              mayContainStrings = true;
+            }
+          } while (this.eat(VERTICAL_LINE));
+          if (this.eat(RIGHT_CURLY_BRACKET)) {
+            this.onClassStringDisjunctionLeave(start, this.index);
+            return { mayContainStrings };
+          }
+          this.raise("Unterminated class string disjunction");
+        }
+        return null;
+      }
+      consumeClassString(i) {
+        const start = this.index;
+        let count = 0;
+        this.onStringAlternativeEnter(start, i);
+        while (this.currentCodePoint !== -1 && this.consumeClassSetCharacter()) {
+          count++;
+        }
+        this.onStringAlternativeLeave(start, this.index, i);
+        return { mayContainStrings: count !== 1 };
+      }
+      consumeClassSetCharacter() {
+        const start = this.index;
+        const cp = this.currentCodePoint;
+        if (cp !== this.nextCodePoint || !isClassSetReservedDoublePunctuatorCharacter(cp)) {
+          if (cp !== -1 && !isClassSetSyntaxCharacter(cp)) {
+            this._lastIntValue = cp;
+            this.advance();
+            this.onCharacter(start, this.index, this._lastIntValue);
+            return true;
+          }
+        }
+        if (this.eat(REVERSE_SOLIDUS)) {
+          if (this.consumeCharacterEscape()) {
+            return true;
+          }
+          if (isClassSetReservedPunctuator(this.currentCodePoint)) {
+            this._lastIntValue = this.currentCodePoint;
+            this.advance();
+            this.onCharacter(start, this.index, this._lastIntValue);
+            return true;
+          }
+          if (this.eat(LATIN_SMALL_LETTER_B)) {
+            this._lastIntValue = BACKSPACE;
+            this.onCharacter(start, this.index, this._lastIntValue);
+            return true;
+          }
+          this.rewind(start);
+        }
+        return false;
       }
       eatGroupName() {
         if (this.eat(LESS_THAN_SIGN)) {
@@ -58986,7 +63517,7 @@ var require_regexpp = __commonJS({
       }
       eatRegExpIdentifierStart() {
         const start = this.index;
-        const forceUFlag = !this._uFlag && this.ecmaVersion >= 2020;
+        const forceUFlag = !this._unicodeMode && this.ecmaVersion >= 2020;
         let cp = this.currentCodePoint;
         this.advance();
         if (cp === REVERSE_SOLIDUS && this.eatRegExpUnicodeEscapeSequence(forceUFlag)) {
@@ -58995,7 +63526,7 @@ var require_regexpp = __commonJS({
           cp = combineSurrogatePair(cp, this.currentCodePoint);
           this.advance();
         }
-        if (isRegExpIdentifierStart(cp)) {
+        if (isIdentifierStartChar(cp)) {
           this._lastIntValue = cp;
           return true;
         }
@@ -59006,7 +63537,7 @@ var require_regexpp = __commonJS({
       }
       eatRegExpIdentifierPart() {
         const start = this.index;
-        const forceUFlag = !this._uFlag && this.ecmaVersion >= 2020;
+        const forceUFlag = !this._unicodeMode && this.ecmaVersion >= 2020;
         let cp = this.currentCodePoint;
         this.advance();
         if (cp === REVERSE_SOLIDUS && this.eatRegExpUnicodeEscapeSequence(forceUFlag)) {
@@ -59015,7 +63546,7 @@ var require_regexpp = __commonJS({
           cp = combineSurrogatePair(cp, this.currentCodePoint);
           this.advance();
         }
-        if (isRegExpIdentifierPart(cp)) {
+        if (isIdentifierPartChar(cp)) {
           this._lastIntValue = cp;
           return true;
         }
@@ -59076,7 +63607,7 @@ var require_regexpp = __commonJS({
       }
       eatRegExpUnicodeEscapeSequence(forceUFlag = false) {
         const start = this.index;
-        const uFlag = forceUFlag || this._uFlag;
+        const uFlag = forceUFlag || this._unicodeMode;
         if (this.eat(LATIN_SMALL_LETTER_U)) {
           if (uFlag && this.eatRegExpUnicodeSurrogatePairEscape() || this.eatFixedHexDigits(4) || uFlag && this.eatRegExpUnicodeCodePointEscape()) {
             return true;
@@ -59124,7 +63655,7 @@ var require_regexpp = __commonJS({
         if (cp === -1) {
           return false;
         }
-        if (this._uFlag) {
+        if (this._unicodeMode) {
           return isSyntaxCharacter(cp) || cp === SOLIDUS;
         }
         if (this.strict) {
@@ -59150,11 +63681,14 @@ var require_regexpp = __commonJS({
       eatUnicodePropertyValueExpression() {
         const start = this.index;
         if (this.eatUnicodePropertyName() && this.eat(EQUALS_SIGN)) {
-          this._lastKeyValue = this._lastStrValue;
+          const key = this._lastStrValue;
           if (this.eatUnicodePropertyValue()) {
-            this._lastValValue = this._lastStrValue;
-            if (isValidUnicodeProperty(this.ecmaVersion, this._lastKeyValue, this._lastValValue)) {
-              return true;
+            const value = this._lastStrValue;
+            if (isValidUnicodeProperty(this.ecmaVersion, key, value)) {
+              return {
+                key,
+                value: value || null
+              };
             }
             this.raise("Invalid property name");
           }
@@ -59163,18 +63697,27 @@ var require_regexpp = __commonJS({
         if (this.eatLoneUnicodePropertyNameOrValue()) {
           const nameOrValue = this._lastStrValue;
           if (isValidUnicodeProperty(this.ecmaVersion, "General_Category", nameOrValue)) {
-            this._lastKeyValue = "General_Category";
-            this._lastValValue = nameOrValue;
-            return true;
+            return {
+              key: "General_Category",
+              value: nameOrValue || null
+            };
           }
           if (isValidLoneUnicodeProperty(this.ecmaVersion, nameOrValue)) {
-            this._lastKeyValue = nameOrValue;
-            this._lastValValue = "";
-            return true;
+            return {
+              key: nameOrValue,
+              value: null
+            };
+          }
+          if (this._unicodeSetsMode && isValidLoneUnicodePropertyOfString(this.ecmaVersion, nameOrValue)) {
+            return {
+              key: nameOrValue,
+              value: null,
+              strings: true
+            };
           }
           this.raise("Invalid property name");
         }
-        return false;
+        return null;
       }
       eatUnicodePropertyName() {
         this._lastStrValue = "";
@@ -59201,7 +63744,7 @@ var require_regexpp = __commonJS({
           if (this.eatFixedHexDigits(2)) {
             return true;
           }
-          if (this._uFlag || this.strict) {
+          if (this._unicodeMode || this.strict) {
             this.raise("Invalid escape");
           }
           this.rewind(start);
@@ -59267,20 +63810,80 @@ var require_regexpp = __commonJS({
         }
         return true;
       }
+      eatModifiers() {
+        let ate = false;
+        while (isRegularExpressionModifier(this.currentCodePoint)) {
+          this.advance();
+          ate = true;
+        }
+        return ate;
+      }
+      parseModifiers(start, end) {
+        const { ignoreCase, multiline, dotAll } = this.parseFlags(this._reader.source, start, end);
+        return { ignoreCase, multiline, dotAll };
+      }
+      parseFlags(source, start, end) {
+        const flags = {
+          global: false,
+          ignoreCase: false,
+          multiline: false,
+          unicode: false,
+          sticky: false,
+          dotAll: false,
+          hasIndices: false,
+          unicodeSets: false
+        };
+        const validFlags = /* @__PURE__ */ new Set();
+        validFlags.add(LATIN_SMALL_LETTER_G);
+        validFlags.add(LATIN_SMALL_LETTER_I);
+        validFlags.add(LATIN_SMALL_LETTER_M);
+        if (this.ecmaVersion >= 2015) {
+          validFlags.add(LATIN_SMALL_LETTER_U);
+          validFlags.add(LATIN_SMALL_LETTER_Y);
+          if (this.ecmaVersion >= 2018) {
+            validFlags.add(LATIN_SMALL_LETTER_S);
+            if (this.ecmaVersion >= 2022) {
+              validFlags.add(LATIN_SMALL_LETTER_D);
+              if (this.ecmaVersion >= 2024) {
+                validFlags.add(LATIN_SMALL_LETTER_V);
+              }
+            }
+          }
+        }
+        for (let i = start; i < end; ++i) {
+          const flag = source.charCodeAt(i);
+          if (validFlags.has(flag)) {
+            const prop = FLAG_CODEPOINT_TO_PROP[flag];
+            if (flags[prop]) {
+              this.raise(`Duplicated flag '${source[i]}'`, {
+                index: start
+              });
+            }
+            flags[prop] = true;
+          } else {
+            this.raise(`Invalid flag '${source[i]}'`, { index: start });
+          }
+        }
+        return flags;
+      }
     };
     var DUMMY_PATTERN = {};
     var DUMMY_FLAGS = {};
     var DUMMY_CAPTURING_GROUP = {};
+    function isClassSetOperand(node) {
+      return node.type === "Character" || node.type === "CharacterSet" || node.type === "CharacterClass" || node.type === "ExpressionCharacterClass" || node.type === "ClassStringDisjunction";
+    }
     var RegExpParserState = class {
       constructor(options) {
         var _a;
         this._node = DUMMY_PATTERN;
+        this._expressionBufferMap = /* @__PURE__ */ new Map();
         this._flags = DUMMY_FLAGS;
         this._backreferences = [];
         this._capturingGroups = [];
         this.source = "";
         this.strict = Boolean(options === null || options === void 0 ? void 0 : options.strict);
-        this.ecmaVersion = (_a = options === null || options === void 0 ? void 0 : options.ecmaVersion) !== null && _a !== void 0 ? _a : 2023;
+        this.ecmaVersion = (_a = options === null || options === void 0 ? void 0 : options.ecmaVersion) !== null && _a !== void 0 ? _a : latestEcmaVersion;
       }
       get pattern() {
         if (this._node.type !== "Pattern") {
@@ -59294,7 +63897,7 @@ var require_regexpp = __commonJS({
         }
         return this._flags;
       }
-      onRegExpFlags(start, end, { global: global2, ignoreCase, multiline, unicode, sticky, dotAll, hasIndices }) {
+      onRegExpFlags(start, end, { global: global2, ignoreCase, multiline, unicode, sticky, dotAll, hasIndices, unicodeSets }) {
         this._flags = {
           type: "Flags",
           parent: null,
@@ -59307,7 +63910,8 @@ var require_regexpp = __commonJS({
           unicode,
           sticky,
           dotAll,
-          hasIndices
+          hasIndices,
+          unicodeSets
         };
       }
       onPatternEnter(start) {
@@ -59327,9 +63931,18 @@ var require_regexpp = __commonJS({
         this._node.raw = this.source.slice(start, end);
         for (const reference of this._backreferences) {
           const ref = reference.ref;
-          const group = typeof ref === "number" ? this._capturingGroups[ref - 1] : this._capturingGroups.find((g) => g.name === ref);
-          reference.resolved = group;
-          group.references.push(reference);
+          const groups = typeof ref === "number" ? [this._capturingGroups[ref - 1]] : this._capturingGroups.filter((g) => g.name === ref);
+          if (groups.length === 1) {
+            const group = groups[0];
+            reference.ambiguous = false;
+            reference.resolved = group;
+          } else {
+            reference.ambiguous = true;
+            reference.resolved = groups;
+          }
+          for (const group of groups) {
+            group.references.push(reference);
+          }
         }
       }
       onAlternativeEnter(start) {
@@ -59361,14 +63974,16 @@ var require_regexpp = __commonJS({
         if (parent.type !== "Alternative") {
           throw new Error("UnknownError");
         }
-        this._node = {
+        const group = {
           type: "Group",
           parent,
           start,
           end: start,
           raw: "",
+          modifiers: null,
           alternatives: []
         };
+        this._node = group;
         parent.elements.push(this._node);
       }
       onGroupLeave(start, end) {
@@ -59379,6 +63994,63 @@ var require_regexpp = __commonJS({
         node.end = end;
         node.raw = this.source.slice(start, end);
         this._node = node.parent;
+      }
+      onModifiersEnter(start) {
+        const parent = this._node;
+        if (parent.type !== "Group") {
+          throw new Error("UnknownError");
+        }
+        this._node = {
+          type: "Modifiers",
+          parent,
+          start,
+          end: start,
+          raw: "",
+          add: null,
+          remove: null
+        };
+        parent.modifiers = this._node;
+      }
+      onModifiersLeave(start, end) {
+        const node = this._node;
+        if (node.type !== "Modifiers" || node.parent.type !== "Group") {
+          throw new Error("UnknownError");
+        }
+        node.end = end;
+        node.raw = this.source.slice(start, end);
+        this._node = node.parent;
+      }
+      onAddModifiers(start, end, { ignoreCase, multiline, dotAll }) {
+        const parent = this._node;
+        if (parent.type !== "Modifiers") {
+          throw new Error("UnknownError");
+        }
+        parent.add = {
+          type: "ModifierFlags",
+          parent,
+          start,
+          end,
+          raw: this.source.slice(start, end),
+          ignoreCase,
+          multiline,
+          dotAll
+        };
+      }
+      onRemoveModifiers(start, end, { ignoreCase, multiline, dotAll }) {
+        const parent = this._node;
+        if (parent.type !== "Modifiers") {
+          throw new Error("UnknownError");
+        }
+        parent.remove = {
+          type: "ModifierFlags",
+          parent,
+          start,
+          end,
+          raw: this.source.slice(start, end),
+          ignoreCase,
+          multiline,
+          dotAll
+        };
       }
       onCapturingGroupEnter(start, name) {
         const parent = this._node;
@@ -59514,26 +64186,33 @@ var require_regexpp = __commonJS({
           negate
         });
       }
-      onUnicodePropertyCharacterSet(start, end, kind, key, value, negate) {
+      onUnicodePropertyCharacterSet(start, end, kind, key, value, negate, strings) {
         const parent = this._node;
         if (parent.type !== "Alternative" && parent.type !== "CharacterClass") {
           throw new Error("UnknownError");
         }
-        parent.elements.push({
+        const base = {
           type: "CharacterSet",
-          parent,
+          parent: null,
           start,
           end,
           raw: this.source.slice(start, end),
           kind,
-          key,
-          value,
-          negate
-        });
+          strings: null,
+          key
+        };
+        if (strings) {
+          if (parent.type === "CharacterClass" && !parent.unicodeSets || negate || value !== null) {
+            throw new Error("UnknownError");
+          }
+          parent.elements.push(Object.assign(Object.assign({}, base), { parent, strings, value, negate }));
+        } else {
+          parent.elements.push(Object.assign(Object.assign({}, base), { parent, strings, value, negate }));
+        }
       }
       onCharacter(start, end, value) {
         const parent = this._node;
-        if (parent.type !== "Alternative" && parent.type !== "CharacterClass") {
+        if (parent.type !== "Alternative" && parent.type !== "CharacterClass" && parent.type !== "StringAlternative") {
           throw new Error("UnknownError");
         }
         parent.elements.push({
@@ -59557,35 +64236,70 @@ var require_regexpp = __commonJS({
           end,
           raw: this.source.slice(start, end),
           ref,
+          ambiguous: false,
           resolved: DUMMY_CAPTURING_GROUP
         };
         parent.elements.push(node);
         this._backreferences.push(node);
       }
-      onCharacterClassEnter(start, negate) {
+      onCharacterClassEnter(start, negate, unicodeSets) {
         const parent = this._node;
-        if (parent.type !== "Alternative") {
-          throw new Error("UnknownError");
-        }
-        this._node = {
+        const base = {
           type: "CharacterClass",
           parent,
           start,
           end: start,
           raw: "",
+          unicodeSets,
           negate,
           elements: []
         };
-        parent.elements.push(this._node);
+        if (parent.type === "Alternative") {
+          const node = Object.assign(Object.assign({}, base), { parent });
+          this._node = node;
+          parent.elements.push(node);
+        } else if (parent.type === "CharacterClass" && parent.unicodeSets && unicodeSets) {
+          const node = Object.assign(Object.assign({}, base), {
+            parent,
+            unicodeSets
+          });
+          this._node = node;
+          parent.elements.push(node);
+        } else {
+          throw new Error("UnknownError");
+        }
       }
       onCharacterClassLeave(start, end) {
         const node = this._node;
-        if (node.type !== "CharacterClass" || node.parent.type !== "Alternative") {
+        if (node.type !== "CharacterClass" || node.parent.type !== "Alternative" && node.parent.type !== "CharacterClass") {
           throw new Error("UnknownError");
         }
+        const parent = node.parent;
         node.end = end;
         node.raw = this.source.slice(start, end);
-        this._node = node.parent;
+        this._node = parent;
+        const expression = this._expressionBufferMap.get(node);
+        if (!expression) {
+          return;
+        }
+        if (node.elements.length > 0) {
+          throw new Error("UnknownError");
+        }
+        this._expressionBufferMap.delete(node);
+        const newNode = {
+          type: "ExpressionCharacterClass",
+          parent,
+          start: node.start,
+          end: node.end,
+          raw: node.raw,
+          negate: node.negate,
+          expression
+        };
+        expression.parent = newNode;
+        if (node !== parent.elements.pop()) {
+          throw new Error("UnknownError");
+        }
+        parent.elements.push(newNode);
       }
       onCharacterClassRange(start, end) {
         const parent = this._node;
@@ -59594,9 +64308,17 @@ var require_regexpp = __commonJS({
         }
         const elements = parent.elements;
         const max = elements.pop();
-        const hyphen = elements.pop();
+        if (!max || max.type !== "Character") {
+          throw new Error("UnknownError");
+        }
+        if (!parent.unicodeSets) {
+          const hyphen = elements.pop();
+          if (!hyphen || hyphen.type !== "Character" || hyphen.value !== HYPHEN_MINUS) {
+            throw new Error("UnknownError");
+          }
+        }
         const min = elements.pop();
-        if (!min || !max || !hyphen || min.type !== "Character" || max.type !== "Character" || hyphen.type !== "Character" || hyphen.value !== HYPHEN_MINUS) {
+        if (!min || min.type !== "Character") {
           throw new Error("UnknownError");
         }
         const node = {
@@ -59611,6 +64333,102 @@ var require_regexpp = __commonJS({
         min.parent = node;
         max.parent = node;
         elements.push(node);
+      }
+      onClassIntersection(start, end) {
+        var _a;
+        const parent = this._node;
+        if (parent.type !== "CharacterClass" || !parent.unicodeSets) {
+          throw new Error("UnknownError");
+        }
+        const right = parent.elements.pop();
+        const left = (_a = this._expressionBufferMap.get(parent)) !== null && _a !== void 0 ? _a : parent.elements.pop();
+        if (!left || !right || left.type === "ClassSubtraction" || left.type !== "ClassIntersection" && !isClassSetOperand(left) || !isClassSetOperand(right)) {
+          throw new Error("UnknownError");
+        }
+        const node = {
+          type: "ClassIntersection",
+          parent,
+          start,
+          end,
+          raw: this.source.slice(start, end),
+          left,
+          right
+        };
+        left.parent = node;
+        right.parent = node;
+        this._expressionBufferMap.set(parent, node);
+      }
+      onClassSubtraction(start, end) {
+        var _a;
+        const parent = this._node;
+        if (parent.type !== "CharacterClass" || !parent.unicodeSets) {
+          throw new Error("UnknownError");
+        }
+        const right = parent.elements.pop();
+        const left = (_a = this._expressionBufferMap.get(parent)) !== null && _a !== void 0 ? _a : parent.elements.pop();
+        if (!left || !right || left.type === "ClassIntersection" || left.type !== "ClassSubtraction" && !isClassSetOperand(left) || !isClassSetOperand(right)) {
+          throw new Error("UnknownError");
+        }
+        const node = {
+          type: "ClassSubtraction",
+          parent,
+          start,
+          end,
+          raw: this.source.slice(start, end),
+          left,
+          right
+        };
+        left.parent = node;
+        right.parent = node;
+        this._expressionBufferMap.set(parent, node);
+      }
+      onClassStringDisjunctionEnter(start) {
+        const parent = this._node;
+        if (parent.type !== "CharacterClass" || !parent.unicodeSets) {
+          throw new Error("UnknownError");
+        }
+        this._node = {
+          type: "ClassStringDisjunction",
+          parent,
+          start,
+          end: start,
+          raw: "",
+          alternatives: []
+        };
+        parent.elements.push(this._node);
+      }
+      onClassStringDisjunctionLeave(start, end) {
+        const node = this._node;
+        if (node.type !== "ClassStringDisjunction" || node.parent.type !== "CharacterClass") {
+          throw new Error("UnknownError");
+        }
+        node.end = end;
+        node.raw = this.source.slice(start, end);
+        this._node = node.parent;
+      }
+      onStringAlternativeEnter(start) {
+        const parent = this._node;
+        if (parent.type !== "ClassStringDisjunction") {
+          throw new Error("UnknownError");
+        }
+        this._node = {
+          type: "StringAlternative",
+          parent,
+          start,
+          end: start,
+          raw: "",
+          elements: []
+        };
+        parent.alternatives.push(this._node);
+      }
+      onStringAlternativeLeave(start, end) {
+        const node = this._node;
+        if (node.type !== "StringAlternative") {
+          throw new Error("UnknownError");
+        }
+        node.end = end;
+        node.raw = this.source.slice(start, end);
+        this._node = node.parent;
       }
     };
     var RegExpParser = class {
@@ -59641,9 +64459,9 @@ var require_regexpp = __commonJS({
         this._validator.validateFlags(source, start, end);
         return this._state.flags;
       }
-      parsePattern(source, start = 0, end = source.length, uFlag = false) {
+      parsePattern(source, start = 0, end = source.length, uFlagOrFlags = void 0) {
         this._state.source = source;
-        this._validator.validatePattern(source, start, end, uFlag);
+        this._validator.validatePattern(source, start, end, uFlagOrFlags);
         return this._state.pattern;
       }
     };
@@ -59677,11 +64495,29 @@ var require_regexpp = __commonJS({
           case "CharacterSet":
             this.visitCharacterSet(node);
             break;
+          case "ClassIntersection":
+            this.visitClassIntersection(node);
+            break;
+          case "ClassStringDisjunction":
+            this.visitClassStringDisjunction(node);
+            break;
+          case "ClassSubtraction":
+            this.visitClassSubtraction(node);
+            break;
+          case "ExpressionCharacterClass":
+            this.visitExpressionCharacterClass(node);
+            break;
           case "Flags":
             this.visitFlags(node);
             break;
           case "Group":
             this.visitGroup(node);
+            break;
+          case "Modifiers":
+            this.visitModifiers(node);
+            break;
+          case "ModifierFlags":
+            this.visitModifierFlags(node);
             break;
           case "Pattern":
             this.visitPattern(node);
@@ -59691,6 +64527,9 @@ var require_regexpp = __commonJS({
             break;
           case "RegExpLiteral":
             this.visitRegExpLiteral(node);
+            break;
+          case "StringAlternative":
+            this.visitStringAlternative(node);
             break;
           default:
             throw new Error(`Unknown type: ${node.type}`);
@@ -59768,6 +64607,44 @@ var require_regexpp = __commonJS({
           this._handlers.onCharacterSetLeave(node);
         }
       }
+      visitClassIntersection(node) {
+        if (this._handlers.onClassIntersectionEnter) {
+          this._handlers.onClassIntersectionEnter(node);
+        }
+        this.visit(node.left);
+        this.visit(node.right);
+        if (this._handlers.onClassIntersectionLeave) {
+          this._handlers.onClassIntersectionLeave(node);
+        }
+      }
+      visitClassStringDisjunction(node) {
+        if (this._handlers.onClassStringDisjunctionEnter) {
+          this._handlers.onClassStringDisjunctionEnter(node);
+        }
+        node.alternatives.forEach(this.visit, this);
+        if (this._handlers.onClassStringDisjunctionLeave) {
+          this._handlers.onClassStringDisjunctionLeave(node);
+        }
+      }
+      visitClassSubtraction(node) {
+        if (this._handlers.onClassSubtractionEnter) {
+          this._handlers.onClassSubtractionEnter(node);
+        }
+        this.visit(node.left);
+        this.visit(node.right);
+        if (this._handlers.onClassSubtractionLeave) {
+          this._handlers.onClassSubtractionLeave(node);
+        }
+      }
+      visitExpressionCharacterClass(node) {
+        if (this._handlers.onExpressionCharacterClassEnter) {
+          this._handlers.onExpressionCharacterClassEnter(node);
+        }
+        this.visit(node.expression);
+        if (this._handlers.onExpressionCharacterClassLeave) {
+          this._handlers.onExpressionCharacterClassLeave(node);
+        }
+      }
       visitFlags(node) {
         if (this._handlers.onFlagsEnter) {
           this._handlers.onFlagsEnter(node);
@@ -59780,9 +64657,34 @@ var require_regexpp = __commonJS({
         if (this._handlers.onGroupEnter) {
           this._handlers.onGroupEnter(node);
         }
+        if (node.modifiers) {
+          this.visit(node.modifiers);
+        }
         node.alternatives.forEach(this.visit, this);
         if (this._handlers.onGroupLeave) {
           this._handlers.onGroupLeave(node);
+        }
+      }
+      visitModifiers(node) {
+        if (this._handlers.onModifiersEnter) {
+          this._handlers.onModifiersEnter(node);
+        }
+        if (node.add) {
+          this.visit(node.add);
+        }
+        if (node.remove) {
+          this.visit(node.remove);
+        }
+        if (this._handlers.onModifiersLeave) {
+          this._handlers.onModifiersLeave(node);
+        }
+      }
+      visitModifierFlags(node) {
+        if (this._handlers.onModifierFlagsEnter) {
+          this._handlers.onModifierFlagsEnter(node);
+        }
+        if (this._handlers.onModifierFlagsLeave) {
+          this._handlers.onModifierFlagsLeave(node);
         }
       }
       visitPattern(node) {
@@ -59813,6 +64715,15 @@ var require_regexpp = __commonJS({
           this._handlers.onRegExpLiteralLeave(node);
         }
       }
+      visitStringAlternative(node) {
+        if (this._handlers.onStringAlternativeEnter) {
+          this._handlers.onStringAlternativeEnter(node);
+        }
+        node.elements.forEach(this.visit, this);
+        if (this._handlers.onStringAlternativeLeave) {
+          this._handlers.onStringAlternativeLeave(node);
+        }
+      }
     };
     function parseRegExpLiteral(source, options) {
       return new RegExpParser(options).parseLiteral(String(source));
@@ -59825,6 +64736,7 @@ var require_regexpp = __commonJS({
     }
     exports.AST = ast;
     exports.RegExpParser = RegExpParser;
+    exports.RegExpSyntaxError = RegExpSyntaxError;
     exports.RegExpValidator = RegExpValidator;
     exports.parseRegExpLiteral = parseRegExpLiteral;
     exports.validateRegExpLiteral = validateRegExpLiteral;
@@ -59853,9 +64765,11 @@ var require_no_control_regex = __commonJS({
       }
       collectControlChars(regexpStr, flags) {
         const uFlag = typeof flags === "string" && flags.includes("u");
+        const vFlag = typeof flags === "string" && flags.includes("v");
+        this._controlChars = [];
+        this._source = regexpStr;
         try {
-          this._source = regexpStr;
-          this._validator.validatePattern(regexpStr, void 0, void 0, uFlag);
+          this._validator.validatePattern(regexpStr, void 0, void 0, { unicode: uFlag, unicodeSets: vFlag });
         } catch {
         }
         return this._controlChars;
@@ -60857,7 +65771,9 @@ var require_no_empty = __commonJS({
 var require_no_empty_character_class = __commonJS({
   "../../node_modules/eslint/lib/rules/no-empty-character-class.js"(exports, module) {
     "use strict";
-    var regex = /^([^\\[]|\\.|\[([^\\\]]|\\.)+\])*$/u;
+    var { RegExpParser, visitRegExpAST } = require_regexpp();
+    var parser = new RegExpParser();
+    var QUICK_TEST_REGEX = /\[\]/u;
     module.exports = {
       meta: {
         type: "problem",
@@ -60874,9 +65790,26 @@ var require_no_empty_character_class = __commonJS({
       create(context) {
         return {
           "Literal[regex]"(node) {
-            if (!regex.test(node.regex.pattern)) {
-              context.report({ node, messageId: "unexpected" });
+            const { pattern, flags } = node.regex;
+            if (!QUICK_TEST_REGEX.test(pattern)) {
+              return;
             }
+            let regExpAST;
+            try {
+              regExpAST = parser.parsePattern(pattern, 0, pattern.length, {
+                unicode: flags.includes("u"),
+                unicodeSets: flags.includes("v")
+              });
+            } catch {
+              return;
+            }
+            visitRegExpAST(regExpAST, {
+              onCharacterClassEnter(characterClass) {
+                if (!characterClass.negate && characterClass.elements.length === 0) {
+                  context.report({ node, messageId: "unexpected" });
+                }
+              }
+            });
           }
         };
       }
@@ -60998,6 +65931,7 @@ var require_no_empty_function = __commonJS({
 var require_no_empty_pattern = __commonJS({
   "../../node_modules/eslint/lib/rules/no-empty-pattern.js"(exports, module) {
     "use strict";
+    var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
         type: "problem",
@@ -61006,17 +65940,33 @@ var require_no_empty_pattern = __commonJS({
           recommended: true,
           url: "https://eslint.org/docs/latest/rules/no-empty-pattern"
         },
-        schema: [],
+        schema: [
+          {
+            type: "object",
+            properties: {
+              allowObjectPatternsAsParameters: {
+                type: "boolean",
+                default: false
+              }
+            },
+            additionalProperties: false
+          }
+        ],
         messages: {
           unexpected: "Unexpected empty {{type}} pattern."
         }
       },
       create(context) {
+        const options = context.options[0] || {}, allowObjectPatternsAsParameters = options.allowObjectPatternsAsParameters || false;
         return {
           ObjectPattern(node) {
-            if (node.properties.length === 0) {
-              context.report({ node, messageId: "unexpected", data: { type: "object" } });
+            if (node.properties.length > 0) {
+              return;
             }
+            if (allowObjectPatternsAsParameters && (astUtils.isFunction(node.parent) || node.parent.type === "AssignmentPattern" && astUtils.isFunction(node.parent.parent) && node.parent.right.type === "ObjectExpression" && node.parent.right.properties.length === 0)) {
+              return;
+            }
+            context.report({ node, messageId: "unexpected", data: { type: "object" } });
           },
           ArrayPattern(node) {
             if (node.elements.length === 0) {
@@ -61298,7 +66248,7 @@ var require_no_extend_native = __commonJS({
   "../../node_modules/eslint/lib/rules/no-extend-native.js"(exports, module) {
     "use strict";
     var astUtils = require_ast_utils2();
-    var globals = require_globals2();
+    var globals = require_globals5();
     module.exports = {
       meta: {
         type: "suggestion",
@@ -61764,6 +66714,8 @@ var require_no_extra_parens = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow unnecessary parentheses",
@@ -62468,6 +67420,8 @@ var require_no_extra_semi = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Disallow unnecessary semicolons",
@@ -62560,6 +67514,14 @@ var require_no_fallthrough = __commonJS({
     "use strict";
     var { directivesPattern } = require_directives();
     var DEFAULT_FALLTHROUGH_COMMENT = /falls?\s?through/iu;
+    function isAnySegmentReachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return true;
+        }
+      }
+      return false;
+    }
     function isFallThroughComment(comment, fallthroughCommentPattern) {
       return fallthroughCommentPattern.test(comment) && !directivesPattern.test(comment.trim());
     }
@@ -62574,9 +67536,6 @@ var require_no_fallthrough = __commonJS({
       }
       const comment = sourceCode.getCommentsBefore(subsequentCase).pop();
       return Boolean(comment && isFallThroughComment(comment.value, fallthroughCommentPattern));
-    }
-    function isReachable(segment) {
-      return segment.reachable;
     }
     function hasBlankLinesBetween(node, token) {
       return token.loc.start.line > node.loc.end.line + 1;
@@ -62612,7 +67571,8 @@ var require_no_fallthrough = __commonJS({
       },
       create(context) {
         const options = context.options[0] || {};
-        let currentCodePath = null;
+        const codePathSegments = [];
+        let currentCodePathSegments = /* @__PURE__ */ new Set();
         const sourceCode = context.sourceCode;
         const allowEmptyCase = options.allowEmptyCase || false;
         let fallthroughCase = null;
@@ -62623,11 +67583,24 @@ var require_no_fallthrough = __commonJS({
           fallthroughCommentPattern = DEFAULT_FALLTHROUGH_COMMENT;
         }
         return {
-          onCodePathStart(codePath) {
-            currentCodePath = codePath;
+          onCodePathStart() {
+            codePathSegments.push(currentCodePathSegments);
+            currentCodePathSegments = /* @__PURE__ */ new Set();
           },
           onCodePathEnd() {
-            currentCodePath = currentCodePath.upper;
+            currentCodePathSegments = codePathSegments.pop();
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            currentCodePathSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            currentCodePathSegments.delete(segment);
+          },
+          onCodePathSegmentStart(segment) {
+            currentCodePathSegments.add(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            currentCodePathSegments.delete(segment);
           },
           SwitchCase(node) {
             if (fallthroughCase && !hasFallthroughComment(fallthroughCase, node, context, fallthroughCommentPattern)) {
@@ -62640,7 +67613,7 @@ var require_no_fallthrough = __commonJS({
           },
           "SwitchCase:exit"(node) {
             const nextToken = sourceCode.getTokenAfter(node);
-            if (currentCodePath.currentSegments.some(isReachable) && (node.consequent.length > 0 || !allowEmptyCase && hasBlankLinesBetween(node, nextToken)) && node.parent.cases[node.parent.cases.length - 1] !== node) {
+            if (isAnySegmentReachable(currentCodePathSegments) && (node.consequent.length > 0 || !allowEmptyCase && hasBlankLinesBetween(node, nextToken)) && node.parent.cases[node.parent.cases.length - 1] !== node) {
               fallthroughCase = node;
             }
           }
@@ -62657,6 +67630,8 @@ var require_no_floating_decimal = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Disallow leading or trailing decimal points in numeric literals",
@@ -63433,7 +68408,7 @@ var require_no_invalid_regexp = __commonJS({
     "use strict";
     var RegExpValidator = require_regexpp().RegExpValidator;
     var validator = new RegExpValidator();
-    var validFlags = /[dgimsuy]/gu;
+    var validFlags = /[dgimsuvy]/gu;
     var undefined1 = void 0;
     module.exports = {
       meta: {
@@ -63487,9 +68462,9 @@ var require_no_invalid_regexp = __commonJS({
           }
           return null;
         }
-        function validateRegExpPattern(pattern, uFlag) {
+        function validateRegExpPattern(pattern, flags) {
           try {
-            validator.validatePattern(pattern, undefined1, undefined1, uFlag);
+            validator.validatePattern(pattern, undefined1, undefined1, flags);
             return null;
           } catch (err) {
             return err.message;
@@ -63501,10 +68476,13 @@ var require_no_invalid_regexp = __commonJS({
           }
           try {
             validator.validateFlags(flags);
-            return null;
           } catch {
             return `Invalid flags supplied to RegExp constructor '${flags}'`;
           }
+          if (flags.includes("u") && flags.includes("v")) {
+            return "Regex 'u' and 'v' flags cannot be used together";
+          }
+          return null;
         }
         return {
           "CallExpression, NewExpression"(node) {
@@ -63525,7 +68503,7 @@ var require_no_invalid_regexp = __commonJS({
             }
             const pattern = node.arguments[0].value;
             message = // If flags are unknown, report the regex only if its pattern is invalid both with and without the "u" flag
-            flags === null ? validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false) : validateRegExpPattern(pattern, flags.includes("u"));
+            flags === null ? validateRegExpPattern(pattern, { unicode: true, unicodeSets: false }) && validateRegExpPattern(pattern, { unicode: false, unicodeSets: true }) && validateRegExpPattern(pattern, { unicode: false, unicodeSets: false }) : validateRegExpPattern(pattern, { unicode: flags.includes("u"), unicodeSets: flags.includes("v") });
             if (message) {
               report(node, message);
             }
@@ -63591,7 +68569,7 @@ var require_no_invalid_this = __commonJS({
             }
             if (codePath.origin === "program") {
               const scope = sourceCode.getScope(node);
-              const features = context.parserOptions.ecmaFeatures || {};
+              const features = context.languageOptions.parserOptions.ecmaFeatures || {};
               stack.push({
                 init: true,
                 node,
@@ -64193,7 +69171,7 @@ var require_no_loop_func = __commonJS({
             return;
           }
           const references = sourceCode.getScope(node).through;
-          const unsafeRefs = references.filter((r) => !isSafe(loopNode, r)).map((r) => r.identifier.name);
+          const unsafeRefs = references.filter((r) => r.resolved && !isSafe(loopNode, r)).map((r) => r.identifier.name);
           if (unsafeRefs.length > 0) {
             context.report({
               node,
@@ -64517,7 +69495,7 @@ var require_regular_expressions = __commonJS({
   "../../node_modules/eslint/lib/rules/utils/regular-expressions.js"(exports, module) {
     "use strict";
     var { RegExpValidator } = require_regexpp();
-    var REGEXPP_LATEST_ECMA_VERSION = 2022;
+    var REGEXPP_LATEST_ECMA_VERSION = 2024;
     function isValidWithUnicodeFlag(ecmaVersion, pattern) {
       if (ecmaVersion <= 5) {
         return false;
@@ -64526,13 +69504,10 @@ var require_regular_expressions = __commonJS({
         ecmaVersion: Math.min(ecmaVersion, REGEXPP_LATEST_ECMA_VERSION)
       });
       try {
-        validator.validatePattern(
-          pattern,
-          void 0,
-          void 0,
+        validator.validatePattern(pattern, void 0, void 0, { unicode: (
           /* uFlag = */
           true
-        );
+        ) });
       } catch {
         return false;
       }
@@ -64559,14 +69534,17 @@ var require_no_misleading_character_class = __commonJS({
       for (const node of nodes) {
         switch (node.type) {
           case "Character":
-            seq.push(node.value);
+            seq.push(node);
             break;
           case "CharacterClassRange":
-            seq.push(node.min.value);
+            seq.push(node.min);
             yield seq;
-            seq = [node.max.value];
+            seq = [node.max];
             break;
           case "CharacterSet":
+          case "CharacterClass":
+          case "ClassStringDisjunction":
+          case "ExpressionCharacterClass":
             if (seq.length > 0) {
               yield seq;
               seq = [];
@@ -64578,22 +69556,40 @@ var require_no_misleading_character_class = __commonJS({
         yield seq;
       }
     }
+    function isUnicodeCodePointEscape(char) {
+      return /^\\u\{[\da-f]+\}$/iu.test(char.raw);
+    }
     var hasCharacterSequence = {
       surrogatePairWithoutUFlag(chars) {
-        return chars.some((c, i) => i !== 0 && isSurrogatePair(chars[i - 1], c));
+        return chars.some((c, i) => {
+          if (i === 0) {
+            return false;
+          }
+          const c1 = chars[i - 1];
+          return isSurrogatePair(c1.value, c.value) && !isUnicodeCodePointEscape(c1) && !isUnicodeCodePointEscape(c);
+        });
+      },
+      surrogatePair(chars) {
+        return chars.some((c, i) => {
+          if (i === 0) {
+            return false;
+          }
+          const c1 = chars[i - 1];
+          return isSurrogatePair(c1.value, c.value) && (isUnicodeCodePointEscape(c1) || isUnicodeCodePointEscape(c));
+        });
       },
       combiningClass(chars) {
-        return chars.some((c, i) => i !== 0 && isCombiningCharacter(c) && !isCombiningCharacter(chars[i - 1]));
+        return chars.some((c, i) => i !== 0 && isCombiningCharacter(c.value) && !isCombiningCharacter(chars[i - 1].value));
       },
       emojiModifier(chars) {
-        return chars.some((c, i) => i !== 0 && isEmojiModifier(c) && !isEmojiModifier(chars[i - 1]));
+        return chars.some((c, i) => i !== 0 && isEmojiModifier(c.value) && !isEmojiModifier(chars[i - 1].value));
       },
       regionalIndicatorSymbol(chars) {
-        return chars.some((c, i) => i !== 0 && isRegionalIndicatorSymbol(c) && isRegionalIndicatorSymbol(chars[i - 1]));
+        return chars.some((c, i) => i !== 0 && isRegionalIndicatorSymbol(c.value) && isRegionalIndicatorSymbol(chars[i - 1].value));
       },
       zwj(chars) {
         const lastIndex = chars.length - 1;
-        return chars.some((c, i) => i !== 0 && i !== lastIndex && c === 8205 && chars[i - 1] !== 8205 && chars[i + 1] !== 8205);
+        return chars.some((c, i) => i !== 0 && i !== lastIndex && c.value === 8205 && chars[i - 1].value !== 8205 && chars[i + 1].value !== 8205);
       }
     };
     var kinds = Object.keys(hasCharacterSequence);
@@ -64609,6 +69605,7 @@ var require_no_misleading_character_class = __commonJS({
         schema: [],
         messages: {
           surrogatePairWithoutUFlag: "Unexpected surrogate pair in character class. Use 'u' flag.",
+          surrogatePair: "Unexpected surrogate pair in character class.",
           combiningClass: "Unexpected combined character in character class.",
           emojiModifier: "Unexpected modified Emoji in character class.",
           regionalIndicatorSymbol: "Unexpected national flag in character class.",
@@ -64626,7 +69623,10 @@ var require_no_misleading_character_class = __commonJS({
               pattern,
               0,
               pattern.length,
-              flags.includes("u")
+              {
+                unicode: flags.includes("u"),
+                unicodeSets: flags.includes("v")
+              }
             );
           } catch {
             return;
@@ -64749,6 +69749,8 @@ var require_no_mixed_operators = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Disallow mixed binary operators",
@@ -64992,6 +69994,8 @@ var require_no_mixed_spaces_and_tabs = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow mixed spaces and tabs for indentation",
@@ -65120,6 +70124,8 @@ var require_no_multi_spaces = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow multiple spaces",
@@ -65249,6 +70255,8 @@ var require_no_multiple_empty_lines = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow multiple empty lines",
@@ -65679,6 +70687,10 @@ var require_no_new_object = __commonJS({
           recommended: false,
           url: "https://eslint.org/docs/latest/rules/no-new-object"
         },
+        deprecated: true,
+        replacedBy: [
+          "no-object-constructor"
+        ],
         schema: [],
         messages: {
           preferLiteral: "The object literal notation {} is preferable."
@@ -65789,6 +70801,7 @@ var require_no_new_symbol = __commonJS({
 var require_no_new_wrappers = __commonJS({
   "../../node_modules/eslint/lib/rules/no-new-wrappers.js"(exports, module) {
     "use strict";
+    var { getVariableByName } = require_ast_utils2();
     module.exports = {
       meta: {
         type: "suggestion",
@@ -65803,15 +70816,20 @@ var require_no_new_wrappers = __commonJS({
         }
       },
       create(context) {
+        const { sourceCode } = context;
         return {
           NewExpression(node) {
             const wrapperObjects = ["String", "Number", "Boolean"];
-            if (wrapperObjects.includes(node.callee.name)) {
-              context.report({
-                node,
-                messageId: "noConstructor",
-                data: { fn: node.callee.name }
-              });
+            const { name } = node.callee;
+            if (wrapperObjects.includes(name)) {
+              const variable = getVariableByName(sourceCode.getScope(node), name);
+              if (variable && variable.identifiers.length === 0) {
+                context.report({
+                  node,
+                  messageId: "noConstructor",
+                  data: { fn: name }
+                });
+              }
             }
           }
         };
@@ -65978,6 +70996,86 @@ var require_no_obj_calls = __commonJS({
               context.report({ node: refNode, messageId, data: { name, ref } });
             }
           }
+        };
+      }
+    };
+  }
+});
+
+// ../../node_modules/eslint/lib/rules/no-object-constructor.js
+var require_no_object_constructor = __commonJS({
+  "../../node_modules/eslint/lib/rules/no-object-constructor.js"(exports, module) {
+    "use strict";
+    var {
+      getVariableByName,
+      isArrowToken,
+      isStartOfExpressionStatement,
+      needsPrecedingSemicolon
+    } = require_ast_utils2();
+    module.exports = {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description: "Disallow calls to the `Object` constructor without an argument",
+          recommended: false,
+          url: "https://eslint.org/docs/latest/rules/no-object-constructor"
+        },
+        hasSuggestions: true,
+        schema: [],
+        messages: {
+          preferLiteral: "The object literal notation {} is preferable.",
+          useLiteral: "Replace with '{{replacement}}'.",
+          useLiteralAfterSemicolon: "Replace with '{{replacement}}', add preceding semicolon."
+        }
+      },
+      create(context) {
+        const sourceCode = context.sourceCode;
+        function needsParentheses(node) {
+          if (isStartOfExpressionStatement(node)) {
+            return true;
+          }
+          const prevToken = sourceCode.getTokenBefore(node);
+          if (prevToken && isArrowToken(prevToken)) {
+            return true;
+          }
+          return false;
+        }
+        function check(node) {
+          if (node.callee.type !== "Identifier" || node.callee.name !== "Object" || node.arguments.length) {
+            return;
+          }
+          const variable = getVariableByName(sourceCode.getScope(node), "Object");
+          if (variable && variable.identifiers.length === 0) {
+            let replacement;
+            let fixText;
+            let messageId = "useLiteral";
+            if (needsParentheses(node)) {
+              replacement = "({})";
+              if (needsPrecedingSemicolon(sourceCode, node)) {
+                fixText = ";({})";
+                messageId = "useLiteralAfterSemicolon";
+              } else {
+                fixText = "({})";
+              }
+            } else {
+              replacement = fixText = "{}";
+            }
+            context.report({
+              node,
+              messageId: "preferLiteral",
+              suggest: [
+                {
+                  messageId,
+                  data: { replacement },
+                  fix: (fixer) => fixer.replaceText(node, fixText)
+                }
+              ]
+            });
+          }
+        }
+        return {
+          CallExpression: check,
+          NewExpression: check
         };
       }
     };
@@ -66377,6 +71475,7 @@ var require_no_promise_executor_return = __commonJS({
   "../../node_modules/eslint/lib/rules/no-promise-executor-return.js"(exports, module) {
     "use strict";
     var { findVariable } = require_eslint_utils();
+    var astUtils = require_ast_utils2();
     var functionTypesToCheck = /* @__PURE__ */ new Set(["ArrowFunctionExpression", "FunctionExpression"]);
     function isGlobalReference(node, scope) {
       const variable = findVariable(scope, node);
@@ -66393,6 +71492,39 @@ var require_no_promise_executor_return = __commonJS({
       const parent = node.parent;
       return parent.type === "NewExpression" && parent.arguments[0] === node && parent.callee.type === "Identifier" && parent.callee.name === "Promise" && isGlobalReference(parent.callee, getOuterScope(scope));
     }
+    function expressionIsVoid(node) {
+      return node.type === "UnaryExpression" && node.operator === "void";
+    }
+    function voidPrependFixer(sourceCode, node, fixer) {
+      const requiresParens = (
+        // prepending `void ` will fail if the node has a lower precedence than void
+        astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression", operator: "void" }) && // check if there are parentheses around the node to avoid redundant parentheses
+        !astUtils.isParenthesised(sourceCode, node)
+      );
+      const returnOrArrowToken = sourceCode.getTokenBefore(
+        node,
+        node.parent.type === "ArrowFunctionExpression" ? astUtils.isArrowToken : (token) => token.type === "Keyword" && token.value === "return"
+      );
+      const firstToken = sourceCode.getTokenAfter(returnOrArrowToken);
+      const prependSpace = (
+        // is return token, as => allows void to be adjacent
+        returnOrArrowToken.value === "return" && // If two tokens (return and "(") are adjacent
+        returnOrArrowToken.range[1] === firstToken.range[0]
+      );
+      return [
+        fixer.insertTextBefore(firstToken, `${prependSpace ? " " : ""}void ${requiresParens ? "(" : ""}`),
+        fixer.insertTextAfter(node, requiresParens ? ")" : "")
+      ];
+    }
+    function curlyWrapFixer(sourceCode, node, fixer) {
+      const arrowToken = sourceCode.getTokenBefore(node.body, astUtils.isArrowToken);
+      const firstToken = sourceCode.getTokenAfter(arrowToken);
+      const lastToken = sourceCode.getLastToken(node);
+      return [
+        fixer.insertTextBefore(firstToken, "{"),
+        fixer.insertTextAfter(lastToken, "}")
+      ];
+    }
     module.exports = {
       meta: {
         type: "problem",
@@ -66401,34 +71533,90 @@ var require_no_promise_executor_return = __commonJS({
           recommended: false,
           url: "https://eslint.org/docs/latest/rules/no-promise-executor-return"
         },
-        schema: [],
+        hasSuggestions: true,
+        schema: [{
+          type: "object",
+          properties: {
+            allowVoid: {
+              type: "boolean",
+              default: false
+            }
+          },
+          additionalProperties: false
+        }],
         messages: {
-          returnsValue: "Return values from promise executor functions cannot be read."
+          returnsValue: "Return values from promise executor functions cannot be read.",
+          // arrow and function suggestions
+          prependVoid: "Prepend `void` to the expression.",
+          // only arrow suggestions
+          wrapBraces: "Wrap the expression in `{}`."
         }
       },
       create(context) {
         let funcInfo = null;
         const sourceCode = context.sourceCode;
-        function report(node) {
-          context.report({ node, messageId: "returnsValue" });
-        }
+        const {
+          allowVoid = false
+        } = context.options[0] || {};
         return {
           onCodePathStart(_, node) {
             funcInfo = {
               upper: funcInfo,
               shouldCheck: functionTypesToCheck.has(node.type) && isPromiseExecutor(node, sourceCode.getScope(node))
             };
-            if (funcInfo.shouldCheck && node.type === "ArrowFunctionExpression" && node.expression) {
-              report(node.body);
+            if (
+              // Is a Promise executor
+              funcInfo.shouldCheck && node.type === "ArrowFunctionExpression" && node.expression && // Except void
+              !(allowVoid && expressionIsVoid(node.body))
+            ) {
+              const suggest = [];
+              if (allowVoid) {
+                suggest.push({
+                  messageId: "prependVoid",
+                  fix(fixer) {
+                    return voidPrependFixer(sourceCode, node.body, fixer);
+                  }
+                });
+              }
+              if (!(node.body.type === "FunctionExpression" && !node.body.id)) {
+                suggest.push({
+                  messageId: "wrapBraces",
+                  fix(fixer) {
+                    return curlyWrapFixer(sourceCode, node, fixer);
+                  }
+                });
+              }
+              context.report({
+                node: node.body,
+                messageId: "returnsValue",
+                suggest
+              });
             }
           },
           onCodePathEnd() {
             funcInfo = funcInfo.upper;
           },
           ReturnStatement(node) {
-            if (funcInfo.shouldCheck && node.argument) {
-              report(node);
+            if (!(funcInfo.shouldCheck && node.argument)) {
+              return;
             }
+            if (!allowVoid) {
+              context.report({ node, messageId: "returnsValue" });
+              return;
+            }
+            if (expressionIsVoid(node.argument)) {
+              return;
+            }
+            context.report({
+              node,
+              messageId: "returnsValue",
+              suggest: [{
+                messageId: "prependVoid",
+                fix(fixer) {
+                  return voidPrependFixer(sourceCode, node.argument, fixer);
+                }
+              }]
+            });
           }
         };
       }
@@ -66472,6 +71660,20 @@ var require_no_prototype_builtins = __commonJS({
   "../../node_modules/eslint/lib/rules/no-prototype-builtins.js"(exports, module) {
     "use strict";
     var astUtils = require_ast_utils2();
+    function isAfterOptional(node) {
+      let leftNode;
+      if (node.type === "MemberExpression") {
+        leftNode = node.object;
+      } else if (node.type === "CallExpression") {
+        leftNode = node.callee;
+      } else {
+        return false;
+      }
+      if (node.optional) {
+        return true;
+      }
+      return isAfterOptional(leftNode);
+    }
     module.exports = {
       meta: {
         type: "problem",
@@ -66480,9 +71682,11 @@ var require_no_prototype_builtins = __commonJS({
           recommended: true,
           url: "https://eslint.org/docs/latest/rules/no-prototype-builtins"
         },
+        hasSuggestions: true,
         schema: [],
         messages: {
-          prototypeBuildIn: "Do not access Object.prototype method '{{prop}}' from target object."
+          prototypeBuildIn: "Do not access Object.prototype method '{{prop}}' from target object.",
+          callObjectPrototype: "Call Object.prototype.{{prop}} explicitly."
         }
       },
       create(context) {
@@ -66502,7 +71706,41 @@ var require_no_prototype_builtins = __commonJS({
               messageId: "prototypeBuildIn",
               loc: callee.property.loc,
               data: { prop: propName },
-              node
+              node,
+              suggest: [
+                {
+                  messageId: "callObjectPrototype",
+                  data: { prop: propName },
+                  fix(fixer) {
+                    const sourceCode = context.sourceCode;
+                    if (isAfterOptional(node)) {
+                      return null;
+                    }
+                    if (node.callee.type === "ChainExpression") {
+                      return null;
+                    }
+                    const objectVariable = astUtils.getVariableByName(sourceCode.getScope(node), "Object");
+                    if (!objectVariable || objectVariable.scope.type !== "global" || objectVariable.defs.length > 0) {
+                      return null;
+                    }
+                    let objectText = sourceCode.getText(callee.object);
+                    if (astUtils.getPrecedence(callee.object) <= astUtils.getPrecedence({ type: "SequenceExpression" })) {
+                      objectText = `(${objectText})`;
+                    }
+                    const openParenToken = sourceCode.getTokenAfter(
+                      node.callee,
+                      astUtils.isOpeningParenToken
+                    );
+                    const isEmptyParameters = node.arguments.length === 0;
+                    const delim = isEmptyParameters ? "" : ", ";
+                    const fixes = [
+                      fixer.replaceText(callee, `Object.prototype.${propName}.call`),
+                      fixer.insertTextAfter(openParenToken, objectText + delim)
+                    ];
+                    return fixes;
+                  }
+                }
+              ]
             });
           }
         }
@@ -66651,7 +71889,7 @@ var require_no_regex_spaces = __commonJS({
           const characterClassNodes = [];
           let regExpAST;
           try {
-            regExpAST = regExpParser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
+            regExpAST = regExpParser.parsePattern(pattern, 0, pattern.length, { unicode: flags.includes("u"), unicodeSets: flags.includes("v") });
           } catch {
             return;
           }
@@ -66703,12 +71941,21 @@ var require_no_regex_spaces = __commonJS({
           const regExpVar = astUtils.getVariableByName(scope, "RegExp");
           const shadowed = regExpVar && regExpVar.defs.length > 0;
           const patternNode = node.arguments[0];
-          const flagsNode = node.arguments[1];
           if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(patternNode) && !shadowed) {
             const pattern = patternNode.value;
             const rawPattern = patternNode.raw.slice(1, -1);
             const rawPatternStartRange = patternNode.range[0] + 1;
-            const flags = isString(flagsNode) ? flagsNode.value : "";
+            let flags;
+            if (node.arguments.length < 2) {
+              flags = "";
+            } else {
+              const flagsNode = node.arguments[1];
+              if (isString(flagsNode)) {
+                flags = flagsNode.value;
+              } else {
+                return;
+              }
+            }
             checkRegex(
               node,
               pattern,
@@ -66997,18 +72244,32 @@ var require_ignore = __commonJS({
       return slashes.slice(0, length - length % 2);
     };
     var REPLACERS = [
+      [
+        // remove BOM
+        // TODO:
+        // Other similar zero-width characters?
+        /^\uFEFF/,
+        () => EMPTY
+      ],
       // > Trailing spaces are ignored unless they are quoted with backslash ("\")
       [
         // (a\ ) -> (a )
         // (a  ) -> (a)
+        // (a ) -> (a)
         // (a \ ) -> (a  )
-        /\\?\s+$/,
-        (match) => match.indexOf("\\") === 0 ? SPACE : EMPTY
+        /((?:\\\\)*?)(\\?\s+)$/,
+        (_, m1, m2) => m1 + (m2.indexOf("\\") === 0 ? SPACE : EMPTY)
       ],
       // replace (\ ) with ' '
+      // (\ ) -> ' '
+      // (\\ ) -> '\\ '
+      // (\\\ ) -> '\\ '
       [
-        /\\\s/g,
-        () => SPACE
+        /(\\+?)\s/g,
+        (_, m1) => {
+          const { length } = m1;
+          return m1.slice(0, length - length % 2) + SPACE;
+        }
       ],
       // Escape metacharacters
       // which is written down by users but means special for regular expressions.
@@ -67143,7 +72404,7 @@ var require_ignore = __commonJS({
       let source = regexCache[pattern];
       if (!source) {
         source = REPLACERS.reduce(
-          (prev, current) => prev.replace(current[0], current[1].bind(pattern)),
+          (prev, [matcher, replacer]) => prev.replace(matcher, replacer.bind(pattern)),
           pattern
         );
         regexCache[pattern] = source;
@@ -67400,6 +72661,9 @@ var require_no_restricted_imports = __commonJS({
                 minItems: 1,
                 uniqueItems: true
               },
+              importNamePattern: {
+                type: "string"
+              },
               message: {
                 type: "string",
                 minLength: 1
@@ -67434,8 +72698,11 @@ var require_no_restricted_imports = __commonJS({
           // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
           patternAndImportNameWithCustomMessage: "'{{importName}}' import from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
           patternAndEverything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern.",
+          patternAndEverythingWithRegexImportName: "* import is invalid because import name matching '{{importNames}}' pattern from '{{importSource}}' is restricted from being used.",
           // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
           patternAndEverythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
+          // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
+          patternAndEverythingWithRegexImportNameAndCustomMessage: "* import is invalid because import name matching '{{importNames}}' pattern from '{{importSource}}' is restricted from being used. {{customMessage}}",
           everything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted.",
           // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
           everythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted. {{customMessage}}",
@@ -67481,10 +72748,11 @@ var require_no_restricted_imports = __commonJS({
         if (restrictedPatterns.length > 0 && typeof restrictedPatterns[0] === "string") {
           restrictedPatterns = [{ group: restrictedPatterns }];
         }
-        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames }) => ({
+        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames, importNamePattern }) => ({
           matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
           customMessage: message,
-          importNames
+          importNames,
+          importNamePattern
         }));
         if (Object.keys(restrictedPaths).length === 0 && restrictedPatternGroups.length === 0) {
           return {};
@@ -67541,7 +72809,8 @@ var require_no_restricted_imports = __commonJS({
           const importSource = node.source.value.trim();
           const customMessage = group.customMessage;
           const restrictedImportNames = group.importNames;
-          if (!restrictedImportNames) {
+          const restrictedImportNamePattern = group.importNamePattern ? new RegExp(group.importNamePattern, "u") : null;
+          if (!restrictedImportNames && !restrictedImportNamePattern) {
             context.report({
               node,
               messageId: customMessage ? "patternWithCustomMessage" : "patterns",
@@ -67552,36 +72821,48 @@ var require_no_restricted_imports = __commonJS({
             });
             return;
           }
-          if (importNames.has("*")) {
-            const specifierData = importNames.get("*")[0];
-            context.report({
-              node,
-              messageId: customMessage ? "patternAndEverythingWithCustomMessage" : "patternAndEverything",
-              loc: specifierData.loc,
-              data: {
-                importSource,
-                importNames: restrictedImportNames,
-                customMessage
+          importNames.forEach((specifiers, importName) => {
+            if (importName === "*") {
+              const [specifier] = specifiers;
+              if (restrictedImportNames) {
+                context.report({
+                  node,
+                  messageId: customMessage ? "patternAndEverythingWithCustomMessage" : "patternAndEverything",
+                  loc: specifier.loc,
+                  data: {
+                    importSource,
+                    importNames: restrictedImportNames,
+                    customMessage
+                  }
+                });
+              } else {
+                context.report({
+                  node,
+                  messageId: customMessage ? "patternAndEverythingWithRegexImportNameAndCustomMessage" : "patternAndEverythingWithRegexImportName",
+                  loc: specifier.loc,
+                  data: {
+                    importSource,
+                    importNames: restrictedImportNamePattern,
+                    customMessage
+                  }
+                });
               }
-            });
-          }
-          restrictedImportNames.forEach((importName) => {
-            if (!importNames.has(importName)) {
               return;
             }
-            const specifiers = importNames.get(importName);
-            specifiers.forEach((specifier) => {
-              context.report({
-                node,
-                messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
-                loc: specifier.loc,
-                data: {
-                  importSource,
-                  customMessage,
-                  importName
-                }
+            if (restrictedImportNames && restrictedImportNames.includes(importName) || restrictedImportNamePattern && restrictedImportNamePattern.test(importName)) {
+              specifiers.forEach((specifier) => {
+                context.report({
+                  node,
+                  messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
+                  loc: specifier.loc,
+                  data: {
+                    importSource,
+                    customMessage,
+                    importName
+                  }
+                });
               });
-            });
+            }
           });
         }
         function isRestrictedPattern(importSource, group) {
@@ -67890,32 +73171,25 @@ var require_no_restricted_properties = __commonJS({
             });
           }
         }
-        function checkDestructuringAssignment(node) {
-          if (node.right.type === "Identifier") {
-            const objectName = node.right.name;
-            if (node.left.type === "ObjectPattern") {
-              node.left.properties.forEach((property) => {
-                checkPropertyAccess(node.left, objectName, astUtils.getStaticPropertyName(property));
-              });
-            }
-          }
-        }
         return {
           MemberExpression(node) {
             checkPropertyAccess(node, node.object && node.object.name, astUtils.getStaticPropertyName(node));
           },
-          VariableDeclarator(node) {
-            if (node.init && node.init.type === "Identifier") {
-              const objectName = node.init.name;
-              if (node.id.type === "ObjectPattern") {
-                node.id.properties.forEach((property) => {
-                  checkPropertyAccess(node.id, objectName, astUtils.getStaticPropertyName(property));
-                });
+          ObjectPattern(node) {
+            let objectName = null;
+            if (node.parent.type === "VariableDeclarator") {
+              if (node.parent.init && node.parent.init.type === "Identifier") {
+                objectName = node.parent.init.name;
+              }
+            } else if (node.parent.type === "AssignmentExpression" || node.parent.type === "AssignmentPattern") {
+              if (node.parent.right.type === "Identifier") {
+                objectName = node.parent.right.name;
               }
             }
-          },
-          AssignmentExpression: checkDestructuringAssignment,
-          AssignmentPattern: checkDestructuringAssignment
+            node.properties.forEach((property) => {
+              checkPropertyAccess(node, objectName, astUtils.getStaticPropertyName(property));
+            });
+          }
         };
       }
     };
@@ -68052,6 +73326,8 @@ var require_no_return_await = __commonJS({
           url: "https://eslint.org/docs/latest/rules/no-return-await"
         },
         fixable: null,
+        deprecated: true,
+        replacedBy: [],
         schema: [],
         messages: {
           removeAwait: "Remove redundant `await`.",
@@ -68854,6 +74130,8 @@ var require_no_tabs = __commonJS({
     var anyNonWhitespaceRegex = /\S/u;
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow all tabs",
@@ -69000,22 +74278,28 @@ var require_no_this_before_super = __commonJS({
         function isInConstructorOfDerivedClass() {
           return Boolean(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends);
         }
+        function isEverySegmentCalled(segments) {
+          for (const segment of segments) {
+            if (!isCalled(segment)) {
+              return false;
+            }
+          }
+          return true;
+        }
         function isBeforeCallOfSuper() {
-          return isInConstructorOfDerivedClass() && !funcInfo.codePath.currentSegments.every(isCalled);
+          return isInConstructorOfDerivedClass() && !isEverySegmentCalled(funcInfo.currentSegments);
         }
         function setInvalid(node) {
-          const segments = funcInfo.codePath.currentSegments;
-          for (let i = 0; i < segments.length; ++i) {
-            const segment = segments[i];
+          const segments = funcInfo.currentSegments;
+          for (const segment of segments) {
             if (segment.reachable) {
               segInfoMap[segment.id].invalidNodes.push(node);
             }
           }
         }
         function setSuperCalled() {
-          const segments = funcInfo.codePath.currentSegments;
-          for (let i = 0; i < segments.length; ++i) {
-            const segment = segments[i];
+          const segments = funcInfo.currentSegments;
+          for (const segment of segments) {
             if (segment.reachable) {
               segInfoMap[segment.id].superCalled = true;
             }
@@ -69037,14 +74321,16 @@ var require_no_this_before_super = __commonJS({
                 hasExtends: Boolean(
                   classNode.superClass && !astUtils.isNullOrUndefined(classNode.superClass)
                 ),
-                codePath
+                codePath,
+                currentSegments: /* @__PURE__ */ new Set()
               };
             } else {
               funcInfo = {
                 upper: funcInfo,
                 isConstructor: false,
                 hasExtends: false,
-                codePath
+                codePath,
+                currentSegments: /* @__PURE__ */ new Set()
               };
             }
           },
@@ -69085,6 +74371,7 @@ var require_no_this_before_super = __commonJS({
            * @returns {void}
            */
           onCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
             if (!isInConstructorOfDerivedClass()) {
               return;
             }
@@ -69092,6 +74379,15 @@ var require_no_this_before_super = __commonJS({
               superCalled: segment.prevSegments.length > 0 && segment.prevSegments.every(isCalled),
               invalidNodes: []
             };
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            funcInfo.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            funcInfo.currentSegments.delete(segment);
           },
           /**
            * Update information of the code path segment when a code path was
@@ -69206,6 +74502,8 @@ var require_no_trailing_spaces = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow trailing whitespace at the end of lines",
@@ -70034,8 +75332,13 @@ var require_no_unreachable = __commonJS({
     function isInitialized(node) {
       return Boolean(node.init);
     }
-    function isUnreachable(segment) {
-      return !segment.reachable;
+    function areAllSegmentsUnreachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return false;
+        }
+      }
+      return true;
     }
     var ConsecutiveRange = class {
       constructor(sourceCode) {
@@ -70107,12 +75410,13 @@ var require_no_unreachable = __commonJS({
         }
       },
       create(context) {
-        let currentCodePath = null;
         let constructorInfo = null;
         const range = new ConsecutiveRange(context.sourceCode);
+        const codePathSegments = [];
+        let currentCodePathSegments = /* @__PURE__ */ new Set();
         function reportIfUnreachable(node) {
           let nextNode = null;
-          if (node && (node.type === "PropertyDefinition" || currentCodePath.currentSegments.every(isUnreachable))) {
+          if (node && (node.type === "PropertyDefinition" || areAllSegmentsUnreachable(currentCodePathSegments))) {
             if (range.isEmpty) {
               range.reset(node);
               return;
@@ -70137,11 +75441,24 @@ var require_no_unreachable = __commonJS({
         }
         return {
           // Manages the current code path.
-          onCodePathStart(codePath) {
-            currentCodePath = codePath;
+          onCodePathStart() {
+            codePathSegments.push(currentCodePathSegments);
+            currentCodePathSegments = /* @__PURE__ */ new Set();
           },
           onCodePathEnd() {
-            currentCodePath = currentCodePath.upper;
+            currentCodePathSegments = codePathSegments.pop();
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            currentCodePathSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            currentCodePathSegments.delete(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            currentCodePathSegments.delete(segment);
+          },
+          onCodePathSegmentStart(segment) {
+            currentCodePathSegments.add(segment);
           },
           // Registers for all statement nodes (excludes FunctionDeclaration).
           BlockStatement: reportIfUnreachable,
@@ -70215,6 +75532,14 @@ var require_no_unreachable_loop = __commonJS({
   "../../node_modules/eslint/lib/rules/no-unreachable-loop.js"(exports, module) {
     "use strict";
     var allLoopTypes = ["WhileStatement", "DoWhileStatement", "ForStatement", "ForInStatement", "ForOfStatement"];
+    function isAnySegmentReachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return true;
+        }
+      }
+      return false;
+    }
     function isLoopingTarget(node) {
       const parent = node.parent;
       if (parent) {
@@ -70262,20 +75587,27 @@ var require_no_unreachable_loop = __commonJS({
       },
       create(context) {
         const ignoredLoopTypes = context.options[0] && context.options[0].ignore || [], loopTypesToCheck = getDifference(allLoopTypes, ignoredLoopTypes), loopSelector = loopTypesToCheck.join(","), loopsByTargetSegments = /* @__PURE__ */ new Map(), loopsToReport = /* @__PURE__ */ new Set();
-        let currentCodePath = null;
+        const codePathSegments = [];
+        let currentCodePathSegments = /* @__PURE__ */ new Set();
         return {
-          onCodePathStart(codePath) {
-            currentCodePath = codePath;
+          onCodePathStart() {
+            codePathSegments.push(currentCodePathSegments);
+            currentCodePathSegments = /* @__PURE__ */ new Set();
           },
           onCodePathEnd() {
-            currentCodePath = currentCodePath.upper;
+            currentCodePathSegments = codePathSegments.pop();
           },
-          [loopSelector](node) {
-            if (currentCodePath.currentSegments.some((segment) => segment.reachable)) {
-              loopsToReport.add(node);
-            }
+          onUnreachableCodePathSegmentStart(segment) {
+            currentCodePathSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            currentCodePathSegments.delete(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            currentCodePathSegments.delete(segment);
           },
           onCodePathSegmentStart(segment, node) {
+            currentCodePathSegments.add(segment);
             if (isLoopingTarget(node)) {
               const loop = node.parent;
               loopsByTargetSegments.set(segment, loop);
@@ -70285,6 +75617,11 @@ var require_no_unreachable_loop = __commonJS({
             const loop = loopsByTargetSegments.get(toSegment);
             if (node === loop || node.type === "ContinueStatement") {
               loopsToReport.delete(loop);
+            }
+          },
+          [loopSelector](node) {
+            if (isAnySegmentReachable(currentCodePathSegments)) {
+              loopsToReport.add(node);
             }
           },
           "Program:exit"() {
@@ -71505,7 +76842,7 @@ var require_no_useless_backreference = __commonJS({
         function checkRegex(node, pattern, flags) {
           let regExpAST;
           try {
-            regExpAST = parser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
+            regExpAST = parser.parsePattern(pattern, 0, pattern.length, { unicode: flags.includes("u"), unicodeSets: flags.includes("v") });
           } catch {
             return;
           }
@@ -71895,6 +77232,7 @@ var require_no_useless_escape = __commonJS({
   "../../node_modules/eslint/lib/rules/no-useless-escape.js"(exports, module) {
     "use strict";
     var astUtils = require_ast_utils2();
+    var { RegExpParser, visitRegExpAST } = require_regexpp();
     function union(setA, setB) {
       return new Set(function* () {
         yield* setA;
@@ -71904,35 +77242,8 @@ var require_no_useless_escape = __commonJS({
     var VALID_STRING_ESCAPES = union(new Set("\\nrvtbfux"), astUtils.LINEBREAKS);
     var REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnpPrsStvwWxu0123456789]");
     var REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[{}|()Bk"));
-    function parseRegExp(regExpText) {
-      const charList = [];
-      regExpText.split("").reduce((state, char, index) => {
-        if (!state.escapeNextChar) {
-          if (char === "\\") {
-            return Object.assign(state, { escapeNextChar: true });
-          }
-          if (char === "[" && !state.inCharClass) {
-            return Object.assign(state, { inCharClass: true, startingCharClass: true });
-          }
-          if (char === "]" && state.inCharClass) {
-            if (charList.length && charList[charList.length - 1].inCharClass) {
-              charList[charList.length - 1].endsCharClass = true;
-            }
-            return Object.assign(state, { inCharClass: false, startingCharClass: false });
-          }
-        }
-        charList.push({
-          text: char,
-          index,
-          escaped: state.escapeNextChar,
-          inCharClass: state.inCharClass,
-          startsCharClass: state.startingCharClass,
-          endsCharClass: false
-        });
-        return Object.assign(state, { escapeNextChar: false, startingCharClass: false });
-      }, { escapeNextChar: false, inCharClass: false, startingCharClass: false });
-      return charList;
-    }
+    var REGEX_CLASSSET_CHARACTER_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("q/[{}|()-"));
+    var REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR = new Set("!#$%&*+,.:;<=>?@^`~");
     module.exports = {
       meta: {
         type: "suggestion",
@@ -71952,7 +77263,8 @@ var require_no_useless_escape = __commonJS({
       },
       create(context) {
         const sourceCode = context.sourceCode;
-        function report(node, startOffset, character) {
+        const parser = new RegExpParser();
+        function report(node, startOffset, character, disableEscapeBackslashSuggest) {
           const rangeStart = node.range[0] + startOffset;
           const range = [rangeStart, rangeStart + 1];
           const start = sourceCode.getLocFromIndex(rangeStart);
@@ -71972,12 +77284,14 @@ var require_no_useless_escape = __commonJS({
                   return fixer.removeRange(range);
                 }
               },
-              {
-                messageId: "escapeBackslash",
-                fix(fixer) {
-                  return fixer.insertTextBeforeRange(range, "\\");
+              ...disableEscapeBackslashSuggest ? [] : [
+                {
+                  messageId: "escapeBackslash",
+                  fix(fixer) {
+                    return fixer.insertTextBeforeRange(range, "\\");
+                  }
                 }
-              }
+              ]
             ]
           });
         }
@@ -72000,6 +77314,86 @@ var require_no_useless_escape = __commonJS({
             report(node, match.index, match[0].slice(1));
           }
         }
+        function validateRegExp(node) {
+          const { pattern, flags } = node.regex;
+          let patternNode;
+          const unicode = flags.includes("u");
+          const unicodeSets = flags.includes("v");
+          try {
+            patternNode = parser.parsePattern(pattern, 0, pattern.length, { unicode, unicodeSets });
+          } catch {
+            return;
+          }
+          const characterClassStack = [];
+          visitRegExpAST(patternNode, {
+            onCharacterClassEnter: (characterClassNode) => characterClassStack.unshift(characterClassNode),
+            onCharacterClassLeave: () => characterClassStack.shift(),
+            onExpressionCharacterClassEnter: (characterClassNode) => characterClassStack.unshift(characterClassNode),
+            onExpressionCharacterClassLeave: () => characterClassStack.shift(),
+            onCharacterEnter(characterNode) {
+              if (!characterNode.raw.startsWith("\\")) {
+                return;
+              }
+              const escapedChar = characterNode.raw.slice(1);
+              if (escapedChar !== String.fromCodePoint(characterNode.value)) {
+                return;
+              }
+              let allowedEscapes;
+              if (characterClassStack.length) {
+                allowedEscapes = unicodeSets ? REGEX_CLASSSET_CHARACTER_ESCAPES : REGEX_GENERAL_ESCAPES;
+              } else {
+                allowedEscapes = REGEX_NON_CHARCLASS_ESCAPES;
+              }
+              if (allowedEscapes.has(escapedChar)) {
+                return;
+              }
+              const reportedIndex = characterNode.start + 1;
+              let disableEscapeBackslashSuggest = false;
+              if (characterClassStack.length) {
+                const characterClassNode = characterClassStack[0];
+                if (escapedChar === "^") {
+                  if (characterClassNode.start + 1 === characterNode.start) {
+                    return;
+                  }
+                }
+                if (!unicodeSets) {
+                  if (escapedChar === "-") {
+                    if (characterClassNode.start + 1 !== characterNode.start && characterNode.end !== characterClassNode.end - 1) {
+                      return;
+                    }
+                  }
+                } else {
+                  if (REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(escapedChar)) {
+                    if (pattern[characterNode.end] === escapedChar) {
+                      return;
+                    }
+                    if (pattern[characterNode.start - 1] === escapedChar) {
+                      if (escapedChar !== "^") {
+                        return;
+                      }
+                      if (!characterClassNode.negate) {
+                        return;
+                      }
+                      const negateCaretIndex = characterClassNode.start + 1;
+                      if (negateCaretIndex < characterNode.start - 1) {
+                        return;
+                      }
+                    }
+                  }
+                  if (characterNode.parent.type === "ClassIntersection" || characterNode.parent.type === "ClassSubtraction") {
+                    disableEscapeBackslashSuggest = true;
+                  }
+                }
+              }
+              report(
+                node,
+                reportedIndex,
+                escapedChar,
+                disableEscapeBackslashSuggest
+              );
+            }
+          });
+        }
         function check(node) {
           const isTemplateElement = node.type === "TemplateElement";
           if (isTemplateElement && node.parent && node.parent.parent && node.parent.parent.type === "TaggedTemplateExpression" && node.parent === node.parent.parent.quasi) {
@@ -72016,7 +77410,7 @@ var require_no_useless_escape = __commonJS({
               validateString(node, match);
             }
           } else if (node.regex) {
-            parseRegExp(node.regex.pattern).filter((charInfo) => !(charInfo.text === "-" && charInfo.inCharClass && !charInfo.startsCharClass && !charInfo.endsCharClass)).filter((charInfo) => !(charInfo.text === "^" && charInfo.startsCharClass)).filter((charInfo) => charInfo.escaped).filter((charInfo) => !(charInfo.inCharClass ? REGEX_GENERAL_ESCAPES : REGEX_NON_CHARCLASS_ESCAPES).has(charInfo.text)).forEach((charInfo) => report(node, charInfo.index, charInfo.text));
+            validateRegExp(node);
           }
         }
         return {
@@ -72144,6 +77538,14 @@ var require_no_useless_return = __commonJS({
       }
       return false;
     }
+    function isAnySegmentReachable(segments) {
+      for (const segment of segments) {
+        if (segment.reachable) {
+          return true;
+        }
+      }
+      return false;
+    }
     module.exports = {
       meta: {
         type: "suggestion",
@@ -72209,7 +77611,7 @@ var require_no_useless_return = __commonJS({
           });
         }
         function markReturnStatementsOnCurrentSegmentsAsUsed() {
-          scopeInfo.codePath.currentSegments.forEach((segment) => markReturnStatementsOnSegmentAsUsed(segment, /* @__PURE__ */ new Set()));
+          scopeInfo.currentSegments.forEach((segment) => markReturnStatementsOnSegmentAsUsed(segment, /* @__PURE__ */ new Set()));
         }
         return {
           // Makes and pushes a new scope information.
@@ -72218,7 +77620,8 @@ var require_no_useless_return = __commonJS({
               upper: scopeInfo,
               uselessReturns: [],
               traversedTryBlockStatements: [],
-              codePath
+              codePath,
+              currentSegments: /* @__PURE__ */ new Set()
             };
           },
           // Reports useless return statements if exist.
@@ -72243,11 +77646,21 @@ var require_no_useless_return = __commonJS({
            * NOTE: This event is notified for only reachable segments.
            */
           onCodePathSegmentStart(segment) {
+            scopeInfo.currentSegments.add(segment);
             const info = {
               uselessReturns: getUselessReturns([], segment.allPrevSegments),
               returned: false
             };
             segmentInfoMap.set(segment, info);
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            scopeInfo.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            scopeInfo.currentSegments.delete(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            scopeInfo.currentSegments.delete(segment);
           },
           // Adds ReturnStatement node to check whether it's useless or not.
           ReturnStatement(node) {
@@ -72255,10 +77668,10 @@ var require_no_useless_return = __commonJS({
               markReturnStatementsOnCurrentSegmentsAsUsed();
             }
             if (node.argument || astUtils.isInLoop(node) || isInFinally(node) || // Ignore `return` statements in unreachable places (https://github.com/eslint/eslint/issues/11647).
-            !scopeInfo.codePath.currentSegments.some((s) => s.reachable)) {
+            !isAnySegmentReachable(scopeInfo.currentSegments)) {
               return;
             }
-            for (const segment of scopeInfo.codePath.currentSegments) {
+            for (const segment of scopeInfo.currentSegments) {
               const info = segmentInfoMap.get(segment);
               if (info) {
                 info.uselessReturns.push(node);
@@ -72597,6 +78010,8 @@ var require_no_whitespace_before_property = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Disallow whitespace before properties",
@@ -72694,6 +78109,8 @@ var require_nonblock_statement_body_position = __commonJS({
     var POSITION_SCHEMA = { enum: ["beside", "below", "any"] };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce the location of single-line statements",
@@ -72849,6 +78266,8 @@ var require_object_curly_newline = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent line breaks after opening and before closing braces",
@@ -72986,6 +78405,8 @@ var require_object_curly_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing inside braces",
@@ -73158,6 +78579,8 @@ var require_object_property_newline = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce placing object properties on separate lines",
@@ -73952,6 +79375,8 @@ var require_one_var_declaration_per_line = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Require or disallow newlines around variable declarations",
@@ -74124,6 +79549,8 @@ var require_operator_linebreak = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent linebreak style for operators",
@@ -74280,6 +79707,8 @@ var require_padded_blocks = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow padding within blocks",
@@ -74686,6 +80115,8 @@ var require_padding_line_between_statements = __commonJS({
     };
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow padding lines between statements",
@@ -75606,10 +81037,13 @@ var require_prefer_named_capture_group = __commonJS({
       },
       create(context) {
         const sourceCode = context.sourceCode;
-        function checkRegex(pattern, node, regexNode, uFlag) {
+        function checkRegex(pattern, node, regexNode, flags) {
           let ast;
           try {
-            ast = parser.parsePattern(pattern, 0, pattern.length, uFlag);
+            ast = parser.parsePattern(pattern, 0, pattern.length, {
+              unicode: Boolean(flags && flags.includes("u")),
+              unicodeSets: Boolean(flags && flags.includes("v"))
+            });
           } catch {
             return;
           }
@@ -75633,7 +81067,7 @@ var require_prefer_named_capture_group = __commonJS({
         return {
           Literal(node) {
             if (node.regex) {
-              checkRegex(node.regex.pattern, node, node, node.regex.flags.includes("u"));
+              checkRegex(node.regex.pattern, node, node, node.regex.flags);
             }
           },
           Program(node) {
@@ -75649,7 +81083,7 @@ var require_prefer_named_capture_group = __commonJS({
               const regex = getStringIfConstant(refNode.arguments[0]);
               const flags = getStringIfConstant(refNode.arguments[1]);
               if (regex) {
-                checkRegex(regex, refNode, refNode.arguments[0], flags && flags.includes("u"));
+                checkRegex(regex, refNode, refNode.arguments[0], flags);
               }
             }
           }
@@ -76311,7 +81745,10 @@ var require_prefer_regex_literals = __commonJS({
         function isValidRegexForEcmaVersion(pattern, flags) {
           const validator = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
           try {
-            validator.validatePattern(pattern, 0, pattern.length, flags ? flags.includes("u") : false);
+            validator.validatePattern(pattern, 0, pattern.length, {
+              unicode: flags ? flags.includes("u") : false,
+              unicodeSets: flags ? flags.includes("v") : false
+            });
             if (flags) {
               validator.validateFlags(flags);
             }
@@ -76418,7 +81855,10 @@ var require_prefer_regex_literals = __commonJS({
                 }
                 if (regexContent && !noFix) {
                   let charIncrease = 0;
-                  const ast = new RegExpParser({ ecmaVersion: regexppEcmaVersion }).parsePattern(regexContent, 0, regexContent.length, flags ? flags.includes("u") : false);
+                  const ast = new RegExpParser({ ecmaVersion: regexppEcmaVersion }).parsePattern(regexContent, 0, regexContent.length, {
+                    unicode: flags ? flags.includes("u") : false,
+                    unicodeSets: flags ? flags.includes("v") : false
+                  });
                   visitRegExpAST(ast, {
                     onCharacterEnter(characterNode) {
                       const escaped = resolveEscapes(characterNode.raw);
@@ -76707,6 +82147,8 @@ var require_quote_props = __commonJS({
     var keywords = require_keywords();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Require quotes around object literal property names",
@@ -76958,6 +82400,8 @@ var require_quotes = __commonJS({
     var AVOID_ESCAPE = "avoid-escape";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce the consistent use of either backticks, double, or single quotes",
@@ -77375,7 +82819,8 @@ var require_require_atomic_updates = __commonJS({
             stack = {
               upper: stack,
               codePath,
-              referenceMap: shouldVerify ? createReferenceMap(scope) : null
+              referenceMap: shouldVerify ? createReferenceMap(scope) : null,
+              currentSegments: /* @__PURE__ */ new Set()
             };
           },
           onCodePathEnd() {
@@ -77384,10 +82829,20 @@ var require_require_atomic_updates = __commonJS({
           // Initialize the segment information.
           onCodePathSegmentStart(segment) {
             segmentInfo.initialize(segment);
+            stack.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentStart(segment) {
+            stack.currentSegments.add(segment);
+          },
+          onUnreachableCodePathSegmentEnd(segment) {
+            stack.currentSegments.delete(segment);
+          },
+          onCodePathSegmentEnd(segment) {
+            stack.currentSegments.delete(segment);
           },
           // Handle references to prepare verification.
           Identifier(node) {
-            const { codePath, referenceMap } = stack;
+            const { referenceMap } = stack;
             const reference = referenceMap && referenceMap.get(node);
             if (!reference) {
               return;
@@ -77396,7 +82851,7 @@ var require_require_atomic_updates = __commonJS({
             const writeExpr = getWriteExpr(reference);
             const isMemberAccess = reference.identifier.parent.type === "MemberExpression";
             if (reference.isRead() && !(writeExpr && writeExpr.parent.operator === "=")) {
-              segmentInfo.markAsRead(codePath.currentSegments, variable);
+              segmentInfo.markAsRead(stack.currentSegments, variable);
             }
             if (writeExpr && writeExpr.parent.right === writeExpr && // ← exclude variable declarations.
             !isLocalVariableWithoutEscape(variable, isMemberAccess)) {
@@ -77413,19 +82868,18 @@ var require_require_atomic_updates = __commonJS({
            * If the reference exists in `outdatedReadVariables` list, report it.
            */
           ":expression:exit"(node) {
-            const { codePath, referenceMap } = stack;
-            if (!referenceMap) {
+            if (!stack.referenceMap) {
               return;
             }
             if (node.type === "AwaitExpression" || node.type === "YieldExpression") {
-              segmentInfo.makeOutdated(codePath.currentSegments);
+              segmentInfo.makeOutdated(stack.currentSegments);
             }
             const references = assignmentReferences.get(node);
             if (references) {
               assignmentReferences.delete(node);
               for (const reference of references) {
                 const variable = reference.resolved;
-                if (segmentInfo.isOutdated(codePath.currentSegments, variable)) {
+                if (segmentInfo.isOutdated(stack.currentSegments, variable)) {
                   if (node.parent.left === reference.identifier) {
                     context.report({
                       node: node.parent,
@@ -77641,7 +83095,7 @@ var require_require_unicode_regexp = __commonJS({
       meta: {
         type: "suggestion",
         docs: {
-          description: "Enforce the use of `u` flag on RegExp",
+          description: "Enforce the use of `u` or `v` flag on RegExp",
           recommended: false,
           url: "https://eslint.org/docs/latest/rules/require-unicode-regexp"
         },
@@ -77657,7 +83111,7 @@ var require_require_unicode_regexp = __commonJS({
         return {
           "Literal[regex]"(node) {
             const flags = node.regex.flags || "";
-            if (!flags.includes("u")) {
+            if (!flags.includes("u") && !flags.includes("v")) {
               context.report({
                 messageId: "requireUFlag",
                 node,
@@ -77685,7 +83139,7 @@ var require_require_unicode_regexp = __commonJS({
               }
               const pattern = getStringIfConstant(patternNode, scope);
               const flags = getStringIfConstant(flagsNode, scope);
-              if (!flagsNode || typeof flags === "string" && !flags.includes("u")) {
+              if (!flagsNode || typeof flags === "string" && !flags.includes("u") && !flags.includes("v")) {
                 context.report({
                   messageId: "requireUFlag",
                   node: refNode,
@@ -77777,6 +83231,8 @@ var require_rest_spread_spacing = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce spacing between rest and spread operators and their expressions",
@@ -77869,6 +83325,8 @@ var require_semi = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow semicolons instead of ASI",
@@ -78111,6 +83569,8 @@ var require_semi_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before and after semicolons",
@@ -78307,6 +83767,8 @@ var require_semi_style = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce location of semicolons",
@@ -78802,6 +84264,8 @@ var require_space_before_blocks = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before blocks",
@@ -78921,6 +84385,8 @@ var require_space_before_function_paren = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before `function` definition opening parenthesis",
@@ -79033,6 +84499,8 @@ var require_space_in_parens = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing inside parentheses",
@@ -79220,6 +84688,8 @@ var require_space_infix_ops = __commonJS({
     var { isEqToken } = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require spacing around infix operators",
@@ -79340,6 +84810,8 @@ var require_space_unary_ops = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce consistent spacing before or after unary operators",
@@ -79595,6 +85067,8 @@ var require_spaced_comment = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "suggestion",
         docs: {
           description: "Enforce consistent spacing after the `//` or `/*` in a comment",
@@ -79930,6 +85404,8 @@ var require_switch_colon_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Enforce spacing around colons of switch statements",
@@ -80064,6 +85540,8 @@ var require_template_curly_spacing = __commonJS({
     var astUtils = require_ast_utils2();
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow spacing around embedded expressions of template strings",
@@ -80166,6 +85644,8 @@ var require_template_tag_spacing = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow spacing between template tags and their literals",
@@ -82677,6 +88157,8 @@ var require_wrap_iife = __commonJS({
     }
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require parentheses around immediate `function` invocations",
@@ -82782,6 +88264,8 @@ var require_wrap_regex = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require parenthesis around regex literals",
@@ -82824,6 +88308,8 @@ var require_yield_star_spacing = __commonJS({
     "use strict";
     module.exports = {
       meta: {
+        deprecated: true,
+        replacedBy: [],
         type: "layout",
         docs: {
           description: "Require or disallow spacing around the `*` in `yield*` expressions",
@@ -83267,6 +88753,7 @@ var require_rules2 = __commonJS({
       "no-new-wrappers": () => require_no_new_wrappers(),
       "no-nonoctal-decimal-escape": () => require_no_nonoctal_decimal_escape(),
       "no-obj-calls": () => require_no_obj_calls(),
+      "no-object-constructor": () => require_no_object_constructor(),
       "no-octal": () => require_no_octal(),
       "no-octal-escape": () => require_no_octal_escape(),
       "no-param-reassign": () => require_no_param_reassign(),
@@ -84702,6 +90189,49 @@ var require_object_schema = __commonJS({
         throw new TypeError(`Definition for key "${name}" must have a validate() method.`);
       }
     }
+    var UnexpectedKeyError = class extends Error {
+      /**
+       * Creates a new instance.
+       * @param {string} key The key that was unexpected. 
+       */
+      constructor(key) {
+        super(`Unexpected key "${key}" found.`);
+      }
+    };
+    var MissingKeyError = class extends Error {
+      /**
+       * Creates a new instance.
+       * @param {string} key The key that was missing. 
+       */
+      constructor(key) {
+        super(`Missing required key "${key}".`);
+      }
+    };
+    var MissingDependentKeysError = class extends Error {
+      /**
+       * Creates a new instance.
+       * @param {string} key The key that was unexpected.
+       * @param {Array<string>} requiredKeys The keys that are required.
+       */
+      constructor(key, requiredKeys2) {
+        super(`Key "${key}" requires keys "${requiredKeys2.join('", "')}".`);
+      }
+    };
+    var WrapperError = class extends Error {
+      /**
+       * Creates a new instance.
+       * @param {string} key The object key causing the error. 
+       * @param {Error} source The source error. 
+       */
+      constructor(key, source) {
+        super(`Key "${key}": ${source.message}`, { cause: source });
+        for (const key2 of Object.keys(source)) {
+          if (!(key2 in this)) {
+            this[key2] = source[key2];
+          }
+        }
+      }
+    };
     var ObjectSchema = class _ObjectSchema {
       /**
        * Creates a new instance.
@@ -84765,10 +90295,10 @@ var require_object_schema = __commonJS({
        */
       merge(...objects) {
         if (objects.length < 2) {
-          throw new Error("merge() requires at least two arguments.");
+          throw new TypeError("merge() requires at least two arguments.");
         }
         if (objects.some((object) => object == null || typeof object !== "object")) {
-          throw new Error("All arguments must be objects.");
+          throw new TypeError("All arguments must be objects.");
         }
         return objects.reduce((result, object) => {
           this.validate(object);
@@ -84781,8 +90311,7 @@ var require_object_schema = __commonJS({
                 }
               }
             } catch (ex) {
-              ex.message = `Key "${key}": ` + ex.message;
-              throw ex;
+              throw new WrapperError(key, ex);
             }
           }
           return result;
@@ -84797,24 +90326,23 @@ var require_object_schema = __commonJS({
       validate(object) {
         for (const key of Object.keys(object)) {
           if (!this.hasKey(key)) {
-            throw new Error(`Unexpected key "${key}" found.`);
+            throw new UnexpectedKeyError(key);
           }
           const strategy = this[strategies].get(key);
           if (Array.isArray(strategy.requires)) {
             if (!strategy.requires.every((otherKey) => otherKey in object)) {
-              throw new Error(`Key "${key}" requires keys "${strategy.requires.join('", "')}".`);
+              throw new MissingDependentKeysError(key, strategy.requires);
             }
           }
           try {
             strategy.validate.call(strategy, object[key]);
           } catch (ex) {
-            ex.message = `Key "${key}": ` + ex.message;
-            throw ex;
+            throw new WrapperError(key, ex);
           }
         }
         for (const [key] of this[requiredKeys]) {
           if (!(key in object)) {
-            throw new Error(`Missing required key "${key}".`);
+            throw new MissingKeyError(key);
           }
         }
       }
@@ -84840,17 +90368,14 @@ var require_api = __commonJS({
     var minimatch = require_minimatch();
     var createDebug = require_browser();
     var objectSchema = require_src();
-    function assertIsArray(value) {
-      if (!Array.isArray(value)) {
-        throw new TypeError("Expected value to be an array.");
+    var NOOP_STRATEGY = {
+      required: false,
+      merge() {
+        return void 0;
+      },
+      validate() {
       }
-    }
-    function assertIsArrayOfStringsAndFunctions(value, name) {
-      assertIsArray(value);
-      if (value.some((item) => typeof item !== "string" && typeof item !== "function")) {
-        throw new TypeError("Expected array to only contain strings.");
-      }
-    }
+    };
     var baseSchema = Object.freeze({
       name: {
         required: false,
@@ -84863,13 +90388,33 @@ var require_api = __commonJS({
           }
         }
       },
+      files: NOOP_STRATEGY,
+      ignores: NOOP_STRATEGY
+    });
+    function assertIsArray(value) {
+      if (!Array.isArray(value)) {
+        throw new TypeError("Expected value to be an array.");
+      }
+    }
+    function assertIsArrayOfStringsAndFunctions(value, name) {
+      assertIsArray(value);
+      if (value.some((item) => typeof item !== "string" && typeof item !== "function")) {
+        throw new TypeError("Expected array to only contain strings and functions.");
+      }
+    }
+    function assertIsNonEmptyArray(value) {
+      if (!Array.isArray(value) || value.length === 0) {
+        throw new TypeError("Expected value to be a non-empty array.");
+      }
+    }
+    var filesAndIgnoresSchema = Object.freeze({
       files: {
         required: false,
         merge() {
           return void 0;
         },
         validate(value) {
-          assertIsArray(value);
+          assertIsNonEmptyArray(value);
           value.forEach((item) => {
             if (Array.isArray(item)) {
               assertIsArrayOfStringsAndFunctions(item);
@@ -84896,12 +90441,63 @@ var require_api = __commonJS({
       dot: true
     };
     var CONFIG_TYPES = /* @__PURE__ */ new Set(["array", "function"]);
+    var META_FIELDS = /* @__PURE__ */ new Set(["name"]);
+    var FILES_AND_IGNORES_SCHEMA = new objectSchema.ObjectSchema(filesAndIgnoresSchema);
+    var ConfigError = class extends Error {
+      /**
+       * Creates a new instance.
+       * @param {string} name The config object name causing the error.
+       * @param {number} index The index of the config object in the array.
+       * @param {Error} source The source error. 
+       */
+      constructor(name, index, { cause, message }) {
+        const finalMessage = message || cause.message;
+        super(`Config ${name}: ${finalMessage}`, { cause });
+        if (cause) {
+          for (const key of Object.keys(cause)) {
+            if (!(key in this)) {
+              this[key] = cause[key];
+            }
+          }
+        }
+        this.name = "ConfigError";
+        this.index = index;
+      }
+    };
+    function getConfigName(config) {
+      if (config && typeof config.name === "string" && config.name) {
+        return `"${config.name}"`;
+      }
+      return "(unnamed)";
+    }
+    function rethrowConfigError(config, index, error) {
+      const configName = getConfigName(config);
+      throw new ConfigError(configName, index, error);
+    }
     function isString(value) {
       return typeof value === "string";
     }
-    function assertNonEmptyFilesArray(config) {
-      if (!Array.isArray(config.files) || config.files.length === 0) {
-        throw new TypeError("The files key must be a non-empty array.");
+    function assertValidBaseConfig(config, index) {
+      if (config === null) {
+        throw new ConfigError(getConfigName(config), index, { message: "Unexpected null config." });
+      }
+      if (config === void 0) {
+        throw new ConfigError(getConfigName(config), index, { message: "Unexpected undefined config." });
+      }
+      if (typeof config !== "object") {
+        throw new ConfigError(getConfigName(config), index, { message: "Unexpected non-object config." });
+      }
+      const validateConfig = {};
+      if ("files" in config) {
+        validateConfig.files = config.files;
+      }
+      if ("ignores" in config) {
+        validateConfig.ignores = config.ignores;
+      }
+      try {
+        FILES_AND_IGNORES_SCHEMA.validate(validateConfig);
+      } catch (validationError) {
+        rethrowConfigError(config, index, { cause: validationError });
       }
     }
     function doMatch(filepath, pattern, options = {}) {
@@ -85001,11 +90597,10 @@ var require_api = __commonJS({
     }
     function pathMatchesIgnores(filePath, basePath, config) {
       const relativeFilePath = path.relative(basePath, filePath);
-      return Object.keys(config).length > 1 && !shouldIgnorePath(config.ignores, filePath, relativeFilePath);
+      return Object.keys(config).filter((key) => !META_FIELDS.has(key)).length > 1 && !shouldIgnorePath(config.ignores, filePath, relativeFilePath);
     }
     function pathMatches(filePath, basePath, config) {
       const relativeFilePath = path.relative(basePath, filePath);
-      assertNonEmptyFilesArray(config);
       const match = (pattern) => {
         if (isString(pattern)) {
           return doMatch(relativeFilePath, pattern);
@@ -85138,25 +90733,8 @@ var require_api = __commonJS({
         }
         const result = [];
         for (const config of this) {
-          if (config.ignores && Object.keys(config).length === 1) {
-            config.ignores.forEach((ignore) => {
-              result.push(ignore);
-              if (typeof ignore === "string") {
-                if (ignore.startsWith("!")) {
-                  if (ignore.endsWith("/**")) {
-                    result.push(ignore.slice(0, ignore.length - 3));
-                  } else if (ignore.endsWith("/*")) {
-                    result.push(ignore.slice(0, ignore.length - 2));
-                  }
-                }
-                if (ignore.endsWith("/")) {
-                  result.push(ignore.slice(0, ignore.length - 1));
-                  result.push(ignore + "**");
-                } else if (!ignore.endsWith("*")) {
-                  result.push(ignore + "/**");
-                }
-              }
-            });
+          if (config.ignores && Object.keys(config).filter((key) => !META_FIELDS.has(key)).length === 1) {
+            result.push(...config.ignores);
           }
         }
         cache.ignores = result;
@@ -85181,6 +90759,7 @@ var require_api = __commonJS({
           const normalizedConfigs = await normalize(this, context, this.extraConfigTypes);
           this.length = 0;
           this.push(...normalizedConfigs.map(this[ConfigArraySymbol.preprocessConfig].bind(this)));
+          this.forEach(assertValidBaseConfig);
           this[ConfigArraySymbol.isNormalized] = true;
           Object.freeze(this);
         }
@@ -85197,6 +90776,7 @@ var require_api = __commonJS({
           const normalizedConfigs = normalizeSync(this, context, this.extraConfigTypes);
           this.length = 0;
           this.push(...normalizedConfigs.map(this[ConfigArraySymbol.preprocessConfig].bind(this)));
+          this.forEach(assertValidBaseConfig);
           this[ConfigArraySymbol.isNormalized] = true;
           Object.freeze(this);
         }
@@ -85264,10 +90844,10 @@ var require_api = __commonJS({
       getConfig(filePath) {
         assertNormalized(this);
         const cache = this[ConfigArraySymbol.configCache];
-        let finalConfig = cache.get(filePath);
-        if (finalConfig) {
-          return finalConfig;
+        if (cache.has(filePath)) {
+          return cache.get(filePath);
         }
+        let finalConfig;
         if (this.isDirectoryIgnored(path.dirname(filePath))) {
           debug(`Ignoring ${filePath} based on directory pattern`);
           cache.set(filePath, finalConfig);
@@ -85297,7 +90877,6 @@ var require_api = __commonJS({
             debug(`Skipped config found for ${filePath} (based on ignores: ${config.ignores})`);
             return;
           }
-          assertNonEmptyFilesArray(config);
           const universalFiles = config.files.filter(
             (pattern) => universalPattern.test(pattern)
           );
@@ -85345,7 +90924,11 @@ var require_api = __commonJS({
           return finalConfig;
         }
         finalConfig = matchingConfigIndices.reduce((result, index) => {
-          return this[ConfigArraySymbol.schema].merge(result, this[index]);
+          try {
+            return this[ConfigArraySymbol.schema].merge(result, this[index]);
+          } catch (validationError) {
+            rethrowConfigError(this[index], index, { cause: validationError });
+          }
         }, {}, this);
         finalConfig = this[ConfigArraySymbol.finalizeConfig](finalConfig);
         cache.set(filePath, finalConfig);
@@ -85411,10 +90994,324 @@ var require_api = __commonJS({
   }
 });
 
+// ../../node_modules/@ungap/structured-clone/cjs/types.js
+var require_types2 = __commonJS({
+  "../../node_modules/@ungap/structured-clone/cjs/types.js"(exports) {
+    "use strict";
+    var VOID = -1;
+    exports.VOID = VOID;
+    var PRIMITIVE = 0;
+    exports.PRIMITIVE = PRIMITIVE;
+    var ARRAY = 1;
+    exports.ARRAY = ARRAY;
+    var OBJECT = 2;
+    exports.OBJECT = OBJECT;
+    var DATE = 3;
+    exports.DATE = DATE;
+    var REGEXP = 4;
+    exports.REGEXP = REGEXP;
+    var MAP = 5;
+    exports.MAP = MAP;
+    var SET = 6;
+    exports.SET = SET;
+    var ERROR = 7;
+    exports.ERROR = ERROR;
+    var BIGINT = 8;
+    exports.BIGINT = BIGINT;
+  }
+});
+
+// ../../node_modules/@ungap/structured-clone/cjs/deserialize.js
+var require_deserialize = __commonJS({
+  "../../node_modules/@ungap/structured-clone/cjs/deserialize.js"(exports) {
+    "use strict";
+    var {
+      VOID,
+      PRIMITIVE,
+      ARRAY,
+      OBJECT,
+      DATE,
+      REGEXP,
+      MAP,
+      SET,
+      ERROR,
+      BIGINT
+    } = require_types2();
+    var env = typeof self === "object" ? self : globalThis;
+    var deserializer = ($, _) => {
+      const as = (out, index) => {
+        $.set(index, out);
+        return out;
+      };
+      const unpair = (index) => {
+        if ($.has(index))
+          return $.get(index);
+        const [type, value] = _[index];
+        switch (type) {
+          case PRIMITIVE:
+          case VOID:
+            return as(value, index);
+          case ARRAY: {
+            const arr = as([], index);
+            for (const index2 of value)
+              arr.push(unpair(index2));
+            return arr;
+          }
+          case OBJECT: {
+            const object = as({}, index);
+            for (const [key, index2] of value)
+              object[unpair(key)] = unpair(index2);
+            return object;
+          }
+          case DATE:
+            return as(new Date(value), index);
+          case REGEXP: {
+            const { source, flags } = value;
+            return as(new RegExp(source, flags), index);
+          }
+          case MAP: {
+            const map = as(/* @__PURE__ */ new Map(), index);
+            for (const [key, index2] of value)
+              map.set(unpair(key), unpair(index2));
+            return map;
+          }
+          case SET: {
+            const set = as(/* @__PURE__ */ new Set(), index);
+            for (const index2 of value)
+              set.add(unpair(index2));
+            return set;
+          }
+          case ERROR: {
+            const { name, message } = value;
+            return as(new env[name](message), index);
+          }
+          case BIGINT:
+            return as(BigInt(value), index);
+          case "BigInt":
+            return as(Object(BigInt(value)), index);
+          case "ArrayBuffer":
+            return as(new Uint8Array(value).buffer, value);
+          case "DataView": {
+            const { buffer } = new Uint8Array(value);
+            return as(new DataView(buffer), value);
+          }
+        }
+        return as(new env[type](value), index);
+      };
+      return unpair;
+    };
+    var deserialize = (serialized) => deserializer(/* @__PURE__ */ new Map(), serialized)(0);
+    exports.deserialize = deserialize;
+  }
+});
+
+// ../../node_modules/@ungap/structured-clone/cjs/serialize.js
+var require_serialize = __commonJS({
+  "../../node_modules/@ungap/structured-clone/cjs/serialize.js"(exports) {
+    "use strict";
+    var {
+      VOID,
+      PRIMITIVE,
+      ARRAY,
+      OBJECT,
+      DATE,
+      REGEXP,
+      MAP,
+      SET,
+      ERROR,
+      BIGINT
+    } = require_types2();
+    var EMPTY = "";
+    var { toString } = {};
+    var { keys } = Object;
+    var typeOf = (value) => {
+      const type = typeof value;
+      if (type !== "object" || !value)
+        return [PRIMITIVE, type];
+      const asString = toString.call(value).slice(8, -1);
+      switch (asString) {
+        case "Array":
+          return [ARRAY, EMPTY];
+        case "Object":
+          return [OBJECT, EMPTY];
+        case "Date":
+          return [DATE, EMPTY];
+        case "RegExp":
+          return [REGEXP, EMPTY];
+        case "Map":
+          return [MAP, EMPTY];
+        case "Set":
+          return [SET, EMPTY];
+        case "DataView":
+          return [ARRAY, asString];
+      }
+      if (asString.includes("Array"))
+        return [ARRAY, asString];
+      if (asString.includes("Error"))
+        return [ERROR, asString];
+      return [OBJECT, asString];
+    };
+    var shouldSkip = ([TYPE, type]) => TYPE === PRIMITIVE && (type === "function" || type === "symbol");
+    var serializer = (strict, json, $, _) => {
+      const as = (out, value) => {
+        const index = _.push(out) - 1;
+        $.set(value, index);
+        return index;
+      };
+      const pair = (value) => {
+        if ($.has(value))
+          return $.get(value);
+        let [TYPE, type] = typeOf(value);
+        switch (TYPE) {
+          case PRIMITIVE: {
+            let entry = value;
+            switch (type) {
+              case "bigint":
+                TYPE = BIGINT;
+                entry = value.toString();
+                break;
+              case "function":
+              case "symbol":
+                if (strict)
+                  throw new TypeError("unable to serialize " + type);
+                entry = null;
+                break;
+              case "undefined":
+                return as([VOID], value);
+            }
+            return as([TYPE, entry], value);
+          }
+          case ARRAY: {
+            if (type) {
+              let spread = value;
+              if (type === "DataView") {
+                spread = new Uint8Array(value.buffer);
+              } else if (type === "ArrayBuffer") {
+                spread = new Uint8Array(value);
+              }
+              return as([type, [...spread]], value);
+            }
+            const arr = [];
+            const index = as([TYPE, arr], value);
+            for (const entry of value)
+              arr.push(pair(entry));
+            return index;
+          }
+          case OBJECT: {
+            if (type) {
+              switch (type) {
+                case "BigInt":
+                  return as([type, value.toString()], value);
+                case "Boolean":
+                case "Number":
+                case "String":
+                  return as([type, value.valueOf()], value);
+              }
+            }
+            if (json && "toJSON" in value)
+              return pair(value.toJSON());
+            const entries = [];
+            const index = as([TYPE, entries], value);
+            for (const key of keys(value)) {
+              if (strict || !shouldSkip(typeOf(value[key])))
+                entries.push([pair(key), pair(value[key])]);
+            }
+            return index;
+          }
+          case DATE:
+            return as([TYPE, value.toISOString()], value);
+          case REGEXP: {
+            const { source, flags } = value;
+            return as([TYPE, { source, flags }], value);
+          }
+          case MAP: {
+            const entries = [];
+            const index = as([TYPE, entries], value);
+            for (const [key, entry] of value) {
+              if (strict || !(shouldSkip(typeOf(key)) || shouldSkip(typeOf(entry))))
+                entries.push([pair(key), pair(entry)]);
+            }
+            return index;
+          }
+          case SET: {
+            const entries = [];
+            const index = as([TYPE, entries], value);
+            for (const entry of value) {
+              if (strict || !shouldSkip(typeOf(entry)))
+                entries.push(pair(entry));
+            }
+            return index;
+          }
+        }
+        const { message } = value;
+        return as([TYPE, { name: type, message }], value);
+      };
+      return pair;
+    };
+    var serialize = (value, { json, lossy } = {}) => {
+      const _ = [];
+      return serializer(!(json || lossy), !!json, /* @__PURE__ */ new Map(), _)(value), _;
+    };
+    exports.serialize = serialize;
+  }
+});
+
+// ../../node_modules/@ungap/structured-clone/cjs/index.js
+var require_cjs = __commonJS({
+  "../../node_modules/@ungap/structured-clone/cjs/index.js"(exports) {
+    "use strict";
+    var { deserialize } = require_deserialize();
+    var { serialize } = require_serialize();
+    Object.defineProperty(exports, "__esModule", { value: true }).default = typeof structuredClone === "function" ? (
+      /* c8 ignore start */
+      (any, options) => options && ("json" in options || "lossy" in options) ? deserialize(serialize(any, options)) : structuredClone(any)
+    ) : (any, options) => deserialize(serialize(any, options));
+    exports.deserialize = deserialize;
+    exports.serialize = serialize;
+  }
+});
+
+// ../../node_modules/eslint/lib/shared/severity.js
+var require_severity = __commonJS({
+  "../../node_modules/eslint/lib/shared/severity.js"(exports, module) {
+    "use strict";
+    function normalizeSeverityToString(severity) {
+      if ([2, "2", "error"].includes(severity)) {
+        return "error";
+      }
+      if ([1, "1", "warn"].includes(severity)) {
+        return "warn";
+      }
+      if ([0, "0", "off"].includes(severity)) {
+        return "off";
+      }
+      throw new Error(`Invalid severity value: ${severity}`);
+    }
+    function normalizeSeverityToNumber(severity) {
+      if ([2, "2", "error"].includes(severity)) {
+        return 2;
+      }
+      if ([1, "1", "warn"].includes(severity)) {
+        return 1;
+      }
+      if ([0, "0", "off"].includes(severity)) {
+        return 0;
+      }
+      throw new Error(`Invalid severity value: ${severity}`);
+    }
+    module.exports = {
+      normalizeSeverityToString,
+      normalizeSeverityToNumber
+    };
+  }
+});
+
 // ../../node_modules/eslint/lib/config/flat-config-schema.js
 var require_flat_config_schema = __commonJS({
-  "../../node_modules/eslint/lib/config/flat-config-schema.js"(exports) {
+  "../../node_modules/eslint/lib/config/flat-config-schema.js"(exports, module) {
     "use strict";
+    var structuredClone2 = require_cjs().default;
+    var { normalizeSeverityToNumber } = require_severity();
     var ruleSeverities = /* @__PURE__ */ new Map([
       [0, 0],
       ["off", 0],
@@ -85438,34 +91335,39 @@ var require_flat_config_schema = __commonJS({
     function isNonNullObject(value) {
       return typeof value === "object" && value !== null;
     }
+    function isNonArrayObject(value) {
+      return isNonNullObject(value) && !Array.isArray(value);
+    }
     function isUndefined(value) {
       return typeof value === "undefined";
     }
-    function deepMerge(first = {}, second = {}) {
-      if (Array.isArray(second)) {
-        return second;
+    function deepMerge(first, second, mergeMap = /* @__PURE__ */ new Map()) {
+      let secondMergeMap = mergeMap.get(first);
+      if (secondMergeMap) {
+        const result2 = secondMergeMap.get(second);
+        if (result2) {
+          return result2;
+        }
+      } else {
+        secondMergeMap = /* @__PURE__ */ new Map();
+        mergeMap.set(first, secondMergeMap);
       }
       const result = {
         ...first,
         ...second
       };
+      delete result.__proto__;
+      secondMergeMap.set(second, result);
       for (const key of Object.keys(second)) {
-        if (key === "__proto__") {
+        if (key === "__proto__" || !Object.prototype.propertyIsEnumerable.call(first, key)) {
           continue;
         }
         const firstValue = first[key];
         const secondValue = second[key];
-        if (isNonNullObject(firstValue)) {
-          result[key] = deepMerge(firstValue, secondValue);
-        } else if (isUndefined(firstValue)) {
-          if (isNonNullObject(secondValue)) {
-            result[key] = deepMerge(
-              Array.isArray(secondValue) ? [] : {},
-              secondValue
-            );
-          } else if (!isUndefined(secondValue)) {
-            result[key] = secondValue;
-          }
+        if (isNonArrayObject(firstValue) && isNonArrayObject(secondValue)) {
+          result[key] = deepMerge(firstValue, secondValue, mergeMap);
+        } else if (isUndefined(secondValue)) {
+          result[key] = firstValue;
         }
       }
       return result;
@@ -85473,7 +91375,7 @@ var require_flat_config_schema = __commonJS({
     function normalizeRuleOptions(ruleOptions) {
       const finalOptions = Array.isArray(ruleOptions) ? ruleOptions.slice(0) : [ruleOptions];
       finalOptions[0] = ruleSeverities.get(finalOptions[0]);
-      return finalOptions;
+      return structuredClone2(finalOptions);
     }
     var InvalidRuleOptionsError = class extends Error {
       /**
@@ -85503,7 +91405,7 @@ var require_flat_config_schema = __commonJS({
       }
     };
     function assertIsRuleSeverity(ruleId, value) {
-      const severity = typeof value === "string" ? ruleSeverities.get(value.toLowerCase()) : ruleSeverities.get(value);
+      const severity = ruleSeverities.get(value);
       if (typeof severity === "undefined") {
         throw new InvalidRuleSeverityError(ruleId, value);
       }
@@ -85518,9 +91420,45 @@ var require_flat_config_schema = __commonJS({
         throw new TypeError("Expected an object.");
       }
     }
+    var IncompatibleKeyError = class extends Error {
+      /**
+       * @param {string} key The invalid key.
+       */
+      constructor(key) {
+        super("This appears to be in eslintrc format rather than flat config format.");
+        this.messageTemplate = "eslintrc-incompat";
+        this.messageData = { key };
+      }
+    };
+    var IncompatiblePluginsError = class extends Error {
+      /**
+       * Creates a new instance.
+       * @param {Array<string>} plugins The plugins array.
+       */
+      constructor(plugins) {
+        super("This appears to be in eslintrc format (array of strings) rather than flat config format (object).");
+        this.messageTemplate = "eslintrc-plugins";
+        this.messageData = { plugins };
+      }
+    };
     var booleanSchema = {
       merge: "replace",
       validate: "boolean"
+    };
+    var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warn", "off", 2, 1, 0]);
+    var disableDirectiveSeveritySchema = {
+      merge(first, second) {
+        const value = second === void 0 ? first : second;
+        if (typeof value === "boolean") {
+          return value ? "warn" : "off";
+        }
+        return normalizeSeverityToNumber(value);
+      },
+      validate(value) {
+        if (!(ALLOWED_SEVERITIES.has(value) || typeof value === "boolean")) {
+          throw new TypeError('Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean.');
+        }
+      }
     };
     var deepObjectAssignSchema = {
       merge(first = {}, second = {}) {
@@ -85572,6 +91510,9 @@ var require_flat_config_schema = __commonJS({
         if (value === null || typeof value !== "object") {
           throw new TypeError("Expected an object.");
         }
+        if (Array.isArray(value)) {
+          throw new IncompatiblePluginsError(value);
+        }
         for (const key of Object.keys(value)) {
           if (key === "__proto__") {
             continue;
@@ -85603,19 +91544,23 @@ var require_flat_config_schema = __commonJS({
           ...second
         };
         for (const ruleId of Object.keys(result)) {
-          if (ruleId === "__proto__") {
-            delete result.__proto__;
-            continue;
-          }
-          result[ruleId] = normalizeRuleOptions(result[ruleId]);
-          if (!(ruleId in first) || !(ruleId in second)) {
-            continue;
-          }
-          const firstRuleOptions = normalizeRuleOptions(first[ruleId]);
-          const secondRuleOptions = normalizeRuleOptions(second[ruleId]);
-          if (secondRuleOptions.length === 1) {
-            result[ruleId] = [secondRuleOptions[0], ...firstRuleOptions.slice(1)];
-            continue;
+          try {
+            if (ruleId === "__proto__") {
+              delete result.__proto__;
+              continue;
+            }
+            result[ruleId] = normalizeRuleOptions(result[ruleId]);
+            if (!(ruleId in first) || !(ruleId in second)) {
+              continue;
+            }
+            const firstRuleOptions = normalizeRuleOptions(first[ruleId]);
+            const secondRuleOptions = normalizeRuleOptions(second[ruleId]);
+            if (secondRuleOptions.length === 1) {
+              result[ruleId] = [secondRuleOptions[0], ...firstRuleOptions.slice(1)];
+              continue;
+            }
+          } catch (ex) {
+            throw new Error(`Key "${ruleId}": ${ex.message}`, { cause: ex });
           }
         }
         return result;
@@ -85653,12 +91598,35 @@ var require_flat_config_schema = __commonJS({
         }
       }
     };
-    exports.flatConfigSchema = {
+    function createEslintrcErrorSchema(key) {
+      return {
+        merge: "replace",
+        validate() {
+          throw new IncompatibleKeyError(key);
+        }
+      };
+    }
+    var eslintrcKeys = [
+      "env",
+      "extends",
+      "globals",
+      "ignorePatterns",
+      "noInlineConfig",
+      "overrides",
+      "parser",
+      "parserOptions",
+      "reportUnusedDisableDirectives",
+      "root"
+    ];
+    var flatConfigSchema = {
+      // eslintrc-style keys that should always error
+      ...Object.fromEntries(eslintrcKeys.map((key) => [key, createEslintrcErrorSchema(key)])),
+      // flat config keys
       settings: deepObjectAssignSchema,
       linterOptions: {
         schema: {
           noInlineConfig: booleanSchema,
-          reportUnusedDisableDirectives: booleanSchema
+          reportUnusedDisableDirectives: disableDirectiveSeveritySchema
         }
       },
       languageOptions: {
@@ -85673,6 +91641,11 @@ var require_flat_config_schema = __commonJS({
       processor: processorSchema,
       plugins: pluginsSchema,
       rules: rulesSchema
+    };
+    module.exports = {
+      flatConfigSchema,
+      assertIsRuleSeverity,
+      assertIsRuleOptions
     };
   }
 });
@@ -85859,7 +91832,8 @@ var require_ajv2 = __commonJS({
 var require_rule_validator = __commonJS({
   "../../node_modules/eslint/lib/config/rule-validator.js"(exports) {
     "use strict";
-    var ajv = require_ajv2()();
+    var ajvImport = require_ajv2();
+    var ajv = ajvImport();
     var {
       parseRuleId,
       getRuleFromConfig,
@@ -86000,24 +91974,13 @@ var require_eslint_all = __commonJS({
     module.exports = Object.freeze({
       "rules": {
         "accessor-pairs": "error",
-        "array-bracket-newline": "error",
-        "array-bracket-spacing": "error",
         "array-callback-return": "error",
-        "array-element-newline": "error",
         "arrow-body-style": "error",
-        "arrow-parens": "error",
-        "arrow-spacing": "error",
         "block-scoped-var": "error",
-        "block-spacing": "error",
-        "brace-style": "error",
         "camelcase": "error",
         "capitalized-comments": "error",
         "class-methods-use-this": "error",
-        "comma-dangle": "error",
-        "comma-spacing": "error",
-        "comma-style": "error",
         "complexity": "error",
-        "computed-property-spacing": "error",
         "consistent-return": "error",
         "consistent-this": "error",
         "constructor-super": "error",
@@ -86025,49 +91988,30 @@ var require_eslint_all = __commonJS({
         "default-case": "error",
         "default-case-last": "error",
         "default-param-last": "error",
-        "dot-location": "error",
         "dot-notation": "error",
-        "eol-last": "error",
         "eqeqeq": "error",
         "for-direction": "error",
-        "func-call-spacing": "error",
         "func-name-matching": "error",
         "func-names": "error",
         "func-style": "error",
-        "function-call-argument-newline": "error",
-        "function-paren-newline": "error",
-        "generator-star-spacing": "error",
         "getter-return": "error",
         "grouped-accessor-pairs": "error",
         "guard-for-in": "error",
         "id-denylist": "error",
         "id-length": "error",
         "id-match": "error",
-        "implicit-arrow-linebreak": "error",
-        "indent": "error",
         "init-declarations": "error",
-        "jsx-quotes": "error",
-        "key-spacing": "error",
-        "keyword-spacing": "error",
         "line-comment-position": "error",
-        "linebreak-style": "error",
-        "lines-around-comment": "error",
-        "lines-between-class-members": "error",
         "logical-assignment-operators": "error",
         "max-classes-per-file": "error",
         "max-depth": "error",
-        "max-len": "error",
         "max-lines": "error",
         "max-lines-per-function": "error",
         "max-nested-callbacks": "error",
         "max-params": "error",
         "max-statements": "error",
-        "max-statements-per-line": "error",
         "multiline-comment-style": "error",
-        "multiline-ternary": "error",
         "new-cap": "error",
-        "new-parens": "error",
-        "newline-per-chained-call": "error",
         "no-alert": "error",
         "no-array-constructor": "error",
         "no-async-promise-executor": "error",
@@ -86078,7 +92022,6 @@ var require_eslint_all = __commonJS({
         "no-class-assign": "error",
         "no-compare-neg-zero": "error",
         "no-cond-assign": "error",
-        "no-confusing-arrow": "error",
         "no-console": "error",
         "no-const-assign": "error",
         "no-constant-binary-expression": "error",
@@ -86108,10 +92051,7 @@ var require_eslint_all = __commonJS({
         "no-extra-bind": "error",
         "no-extra-boolean-cast": "error",
         "no-extra-label": "error",
-        "no-extra-parens": "error",
-        "no-extra-semi": "error",
         "no-fallthrough": "error",
-        "no-floating-decimal": "error",
         "no-func-assign": "error",
         "no-global-assign": "error",
         "no-implicit-coercion": "error",
@@ -86132,22 +92072,18 @@ var require_eslint_all = __commonJS({
         "no-loss-of-precision": "error",
         "no-magic-numbers": "error",
         "no-misleading-character-class": "error",
-        "no-mixed-operators": "error",
-        "no-mixed-spaces-and-tabs": "error",
         "no-multi-assign": "error",
-        "no-multi-spaces": "error",
         "no-multi-str": "error",
-        "no-multiple-empty-lines": "error",
         "no-negated-condition": "error",
         "no-nested-ternary": "error",
         "no-new": "error",
         "no-new-func": "error",
         "no-new-native-nonconstructor": "error",
-        "no-new-object": "error",
         "no-new-symbol": "error",
         "no-new-wrappers": "error",
         "no-nonoctal-decimal-escape": "error",
         "no-obj-calls": "error",
+        "no-object-constructor": "error",
         "no-octal": "error",
         "no-octal-escape": "error",
         "no-param-reassign": "error",
@@ -86163,7 +92099,6 @@ var require_eslint_all = __commonJS({
         "no-restricted-properties": "error",
         "no-restricted-syntax": "error",
         "no-return-assign": "error",
-        "no-return-await": "error",
         "no-script-url": "error",
         "no-self-assign": "error",
         "no-self-compare": "error",
@@ -86172,12 +92107,10 @@ var require_eslint_all = __commonJS({
         "no-shadow": "error",
         "no-shadow-restricted-names": "error",
         "no-sparse-arrays": "error",
-        "no-tabs": "error",
         "no-template-curly-in-string": "error",
         "no-ternary": "error",
         "no-this-before-super": "error",
         "no-throw-literal": "error",
-        "no-trailing-spaces": "error",
         "no-undef": "error",
         "no-undef-init": "error",
         "no-undefined": "error",
@@ -86207,19 +92140,10 @@ var require_eslint_all = __commonJS({
         "no-var": "error",
         "no-void": "error",
         "no-warning-comments": "error",
-        "no-whitespace-before-property": "error",
         "no-with": "error",
-        "nonblock-statement-body-position": "error",
-        "object-curly-newline": "error",
-        "object-curly-spacing": "error",
-        "object-property-newline": "error",
         "object-shorthand": "error",
         "one-var": "error",
-        "one-var-declaration-per-line": "error",
         "operator-assignment": "error",
-        "operator-linebreak": "error",
-        "padded-blocks": "error",
-        "padding-line-between-statements": "error",
         "prefer-arrow-callback": "error",
         "prefer-const": "error",
         "prefer-destructuring": "error",
@@ -86233,38 +92157,20 @@ var require_eslint_all = __commonJS({
         "prefer-rest-params": "error",
         "prefer-spread": "error",
         "prefer-template": "error",
-        "quote-props": "error",
-        "quotes": "error",
         "radix": "error",
         "require-atomic-updates": "error",
         "require-await": "error",
         "require-unicode-regexp": "error",
         "require-yield": "error",
-        "rest-spread-spacing": "error",
-        "semi": "error",
-        "semi-spacing": "error",
-        "semi-style": "error",
         "sort-imports": "error",
         "sort-keys": "error",
         "sort-vars": "error",
-        "space-before-blocks": "error",
-        "space-before-function-paren": "error",
-        "space-in-parens": "error",
-        "space-infix-ops": "error",
-        "space-unary-ops": "error",
-        "spaced-comment": "error",
         "strict": "error",
-        "switch-colon-spacing": "error",
         "symbol-description": "error",
-        "template-curly-spacing": "error",
-        "template-tag-spacing": "error",
         "unicode-bom": "error",
         "use-isnan": "error",
         "valid-typeof": "error",
         "vars-on-top": "error",
-        "wrap-iife": "error",
-        "wrap-regex": "error",
-        "yield-star-spacing": "error",
         "yoda": "error"
       }
     });
@@ -86365,6 +92271,7 @@ var require_flat_config_array = __commonJS({
     var { RuleValidator } = require_rule_validator();
     var { defaultConfig } = require_default_config();
     var jsPlugin = require_src2();
+    var META_FIELDS = /* @__PURE__ */ new Set(["name"]);
     var ruleValidator = new RuleValidator();
     function splitPluginIdentifier(identifier) {
       const parts = identifier.split("/");
@@ -86393,7 +92300,25 @@ var require_flat_config_array = __commonJS({
       }
       return name;
     }
+    function wrapConfigErrorWithDetails(error, originalLength2, baseLength2) {
+      let location = "user-defined";
+      let configIndex = error.index;
+      if (error.index < baseLength2) {
+        location = "base";
+      } else if (error.index < originalLength2 + baseLength2) {
+        location = "original";
+        configIndex = error.index - baseLength2;
+      } else {
+        configIndex = error.index - originalLength2 - baseLength2;
+      }
+      return new TypeError(
+        `${error.message.slice(0, -1)} at ${location} index ${configIndex}.`,
+        { cause: error }
+      );
+    }
     var originalBaseConfig = Symbol("originalBaseConfig");
+    var originalLength = Symbol("originalLength");
+    var baseLength = Symbol("baseLength");
     var FlatConfigArray = class extends ConfigArray {
       /**
        * Creates a new instance.
@@ -86410,15 +92335,48 @@ var require_flat_config_array = __commonJS({
           basePath,
           schema: flatConfigSchema
         });
+        this[originalLength] = this.length;
         if (baseConfig[Symbol.iterator]) {
           this.unshift(...baseConfig);
         } else {
           this.unshift(baseConfig);
         }
+        this[baseLength] = this.length - this[originalLength];
         this[originalBaseConfig] = baseConfig;
         Object.defineProperty(this, originalBaseConfig, { writable: false });
         this.shouldIgnore = shouldIgnore;
         Object.defineProperty(this, "shouldIgnore", { writable: false });
+      }
+      /**
+       * Normalizes the array by calling the superclass method and catching/rethrowing
+       * any ConfigError exceptions with additional details.
+       * @param {any} [context] The context to use to normalize the array.
+       * @returns {Promise<FlatConfigArray>} A promise that resolves when the array is normalized.
+       */
+      normalize(context) {
+        return super.normalize(context).catch((error) => {
+          if (error.name === "ConfigError") {
+            throw wrapConfigErrorWithDetails(error, this[originalLength], this[baseLength]);
+          }
+          throw error;
+        });
+      }
+      /**
+       * Normalizes the array by calling the superclass method and catching/rethrowing
+       * any ConfigError exceptions with additional details.
+       * @param {any} [context] The context to use to normalize the array.
+       * @returns {FlatConfigArray} The current instance.
+       * @throws {TypeError} If the config is invalid.
+       */
+      normalizeSync(context) {
+        try {
+          return super.normalizeSync(context);
+        } catch (error) {
+          if (error.name === "ConfigError") {
+            throw wrapConfigErrorWithDetails(error, this[originalLength], this[baseLength]);
+          }
+          throw error;
+        }
       }
       /* eslint-disable class-methods-use-this -- Desired as instance method */
       /**
@@ -86441,7 +92399,7 @@ var require_flat_config_array = __commonJS({
           }
           return jsPlugin.configs.all;
         }
-        if (!this.shouldIgnore && !this[originalBaseConfig].includes(config) && config.ignores && !config.files) {
+        if (!this.shouldIgnore && !this[originalBaseConfig].includes(config) && config.ignores && Object.keys(config).filter((key) => !META_FIELDS.has(key)).length === 1) {
           const { ignores, ...otherKeys } = config;
           return otherKeys;
         }
@@ -86520,135 +92478,6 @@ var require_flat_config_array = __commonJS({
   }
 });
 
-// ../../node_modules/eslint/conf/globals.js
-var require_globals3 = __commonJS({
-  "../../node_modules/eslint/conf/globals.js"(exports, module) {
-    "use strict";
-    var commonjs = {
-      exports: true,
-      global: false,
-      module: false,
-      require: false
-    };
-    var es3 = {
-      Array: false,
-      Boolean: false,
-      constructor: false,
-      Date: false,
-      decodeURI: false,
-      decodeURIComponent: false,
-      encodeURI: false,
-      encodeURIComponent: false,
-      Error: false,
-      escape: false,
-      eval: false,
-      EvalError: false,
-      Function: false,
-      hasOwnProperty: false,
-      Infinity: false,
-      isFinite: false,
-      isNaN: false,
-      isPrototypeOf: false,
-      Math: false,
-      NaN: false,
-      Number: false,
-      Object: false,
-      parseFloat: false,
-      parseInt: false,
-      propertyIsEnumerable: false,
-      RangeError: false,
-      ReferenceError: false,
-      RegExp: false,
-      String: false,
-      SyntaxError: false,
-      toLocaleString: false,
-      toString: false,
-      TypeError: false,
-      undefined: false,
-      unescape: false,
-      URIError: false,
-      valueOf: false
-    };
-    var es5 = {
-      ...es3,
-      JSON: false
-    };
-    var es2015 = {
-      ...es5,
-      ArrayBuffer: false,
-      DataView: false,
-      Float32Array: false,
-      Float64Array: false,
-      Int16Array: false,
-      Int32Array: false,
-      Int8Array: false,
-      Map: false,
-      Promise: false,
-      Proxy: false,
-      Reflect: false,
-      Set: false,
-      Symbol: false,
-      Uint16Array: false,
-      Uint32Array: false,
-      Uint8Array: false,
-      Uint8ClampedArray: false,
-      WeakMap: false,
-      WeakSet: false
-    };
-    var es2016 = {
-      ...es2015
-    };
-    var es2017 = {
-      ...es2016,
-      Atomics: false,
-      SharedArrayBuffer: false
-    };
-    var es2018 = {
-      ...es2017
-    };
-    var es2019 = {
-      ...es2018
-    };
-    var es2020 = {
-      ...es2019,
-      BigInt: false,
-      BigInt64Array: false,
-      BigUint64Array: false,
-      globalThis: false
-    };
-    var es2021 = {
-      ...es2020,
-      AggregateError: false,
-      FinalizationRegistry: false,
-      WeakRef: false
-    };
-    var es2022 = {
-      ...es2021
-    };
-    var es2023 = {
-      ...es2022
-    };
-    var es2024 = {
-      ...es2023
-    };
-    module.exports = {
-      commonjs,
-      es3,
-      es5,
-      es2015,
-      es2016,
-      es2017,
-      es2018,
-      es2019,
-      es2020,
-      es2021,
-      es2022,
-      es2023,
-      es2024
-    };
-  }
-});
-
 // ../../node_modules/eslint/lib/linter/linter.js
 var require_linter = __commonJS({
   "../../node_modules/eslint/lib/linter/linter.js"(exports, module) {
@@ -86684,6 +92513,9 @@ var require_linter = __commonJS({
     var ruleReplacements = require_replacements();
     var { getRuleFromConfig } = require_flat_config_helpers();
     var { FlatConfigArray } = require_flat_config_array();
+    var { RuleValidator } = require_rule_validator();
+    var { assertIsRuleOptions, assertIsRuleSeverity } = require_flat_config_schema();
+    var { normalizeSeverityToString } = require_severity();
     var debug = require_browser()("eslint:linter");
     var MAX_AUTOFIX_PASSES = 10;
     var DEFAULT_PARSER_NAME = "espree";
@@ -86691,22 +92523,8 @@ var require_linter = __commonJS({
     var commentParser = new ConfigCommentParser();
     var DEFAULT_ERROR_LOC = { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } };
     var parserSymbol = Symbol.for("eslint.RuleTester.parser");
-    var globals = require_globals3();
     function isEspree(parser) {
       return !!(parser === espree || parser[parserSymbol] === espree);
-    }
-    function getGlobalsForEcmaVersion(ecmaVersion) {
-      switch (ecmaVersion) {
-        case 3:
-          return globals.es3;
-        case 5:
-          return globals.es5;
-        default:
-          if (ecmaVersion < 2015) {
-            return globals[`es${ecmaVersion + 2009}`];
-          }
-          return globals[`es${ecmaVersion}`];
-      }
     }
     function addDeclaredGlobals(globalScope, configGlobals, { exportedVariables, enabledGlobals }) {
       for (const id of /* @__PURE__ */ new Set([...Object.keys(configGlobals), ...Object.keys(enabledGlobals)])) {
@@ -86805,16 +92623,7 @@ var require_linter = __commonJS({
       }
       return result;
     }
-    function extractDirectiveComment(value) {
-      const match = /\s-{2,}\s/u.exec(value);
-      if (!match) {
-        return { directivePart: value.trim(), justificationPart: "" };
-      }
-      const directive = value.slice(0, match.index).trim();
-      const justification = value.slice(match.index + match[0].length).trim();
-      return { directivePart: directive, justificationPart: justification };
-    }
-    function getDirectiveComments(ast, ruleMapper, warnInlineConfig) {
+    function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig) {
       const configuredRules = {};
       const enabledGlobals = /* @__PURE__ */ Object.create(null);
       const exportedVariables = {};
@@ -86823,8 +92632,8 @@ var require_linter = __commonJS({
       const validator = new ConfigValidator({
         builtInRules: Rules
       });
-      ast.comments.filter((token) => token.type !== "Shebang").forEach((comment) => {
-        const { directivePart, justificationPart } = extractDirectiveComment(comment.value);
+      sourceCode.getInlineConfigNodes().filter((token) => token.type !== "Shebang").forEach((comment) => {
+        const { directivePart, justificationPart } = commentParser.extractDirectiveComment(comment.value);
         const match = directivesPattern.exec(directivePart);
         if (!match) {
           return;
@@ -86931,6 +92740,49 @@ var require_linter = __commonJS({
         disableDirectives
       };
     }
+    function getDirectiveCommentsForFlatConfig(sourceCode, ruleMapper) {
+      const problems = [];
+      const disableDirectives = [];
+      sourceCode.getInlineConfigNodes().filter((token) => token.type !== "Shebang").forEach((comment) => {
+        const { directivePart, justificationPart } = commentParser.extractDirectiveComment(comment.value);
+        const match = directivesPattern.exec(directivePart);
+        if (!match) {
+          return;
+        }
+        const directiveText = match[1];
+        const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(directiveText);
+        if (comment.type === "Line" && !lineCommentSupported) {
+          return;
+        }
+        if (directiveText === "eslint-disable-line" && comment.loc.start.line !== comment.loc.end.line) {
+          const message = `${directiveText} comment should not span multiple lines.`;
+          problems.push(createLintingProblem({
+            ruleId: null,
+            message,
+            loc: comment.loc
+          }));
+          return;
+        }
+        const directiveValue = directivePart.slice(match.index + directiveText.length);
+        switch (directiveText) {
+          case "eslint-disable":
+          case "eslint-enable":
+          case "eslint-disable-next-line":
+          case "eslint-disable-line": {
+            const directiveType = directiveText.slice("eslint-".length);
+            const options = { commentToken: comment, type: directiveType, value: directiveValue, justification: justificationPart, ruleMapper };
+            const { directives, directiveProblems } = createDisableDirectives(options);
+            disableDirectives.push(...directives);
+            problems.push(...directiveProblems);
+            break;
+          }
+        }
+      });
+      return {
+        problems,
+        disableDirectives
+      };
+    }
     function normalizeEcmaVersion(parser, ecmaVersion) {
       if (isEspree(parser)) {
         if (ecmaVersion === "latest") {
@@ -86961,7 +92813,7 @@ var require_linter = __commonJS({
         if (match[0].endsWith("*/")) {
           retv = Object.assign(
             retv || {},
-            commentParser.parseListConfig(extractDirectiveComment(match[1]).directivePart)
+            commentParser.parseListConfig(commentParser.extractDirectiveComment(match[1]).directivePart)
           );
         }
       }
@@ -86982,7 +92834,11 @@ var require_linter = __commonJS({
         reportUnusedDisableDirectives = reportUnusedDisableDirectives ? "error" : "off";
       }
       if (typeof reportUnusedDisableDirectives !== "string") {
-        reportUnusedDisableDirectives = linterOptions.reportUnusedDisableDirectives ? "warn" : "off";
+        if (typeof linterOptions.reportUnusedDisableDirectives === "boolean") {
+          reportUnusedDisableDirectives = linterOptions.reportUnusedDisableDirectives ? "warn" : "off";
+        } else {
+          reportUnusedDisableDirectives = linterOptions.reportUnusedDisableDirectives === void 0 ? "off" : normalizeSeverityToString(linterOptions.reportUnusedDisableDirectives);
+        }
       }
       return {
         filename: normalizeFilename(providedOptions.filename || "<input>"),
@@ -87017,7 +92873,7 @@ var require_linter = __commonJS({
     }
     function resolveGlobals(providedGlobals, enabledEnvironments) {
       return Object.assign(
-        {},
+        /* @__PURE__ */ Object.create(null),
         ...enabledEnvironments.filter((env) => env.globals).map((env) => env.globals),
         providedGlobals
       );
@@ -87401,7 +93257,7 @@ var require_linter = __commonJS({
           }
         }
         const sourceCode = slots.lastSourceCode;
-        const commentDirectives = options.allowInlineConfig ? getDirectiveComments(sourceCode.ast, (ruleId) => getRule(slots, ruleId), options.warnInlineConfig) : { configuredRules: {}, enabledGlobals: {}, exportedVariables: {}, problems: [], disableDirectives: [] };
+        const commentDirectives = options.allowInlineConfig ? getDirectiveComments(sourceCode, (ruleId) => getRule(slots, ruleId), options.warnInlineConfig) : { configuredRules: {}, enabledGlobals: {}, exportedVariables: {}, problems: [], disableDirectives: [] };
         addDeclaredGlobals(
           sourceCode.scopeManager.scopes[0],
           configuredGlobals,
@@ -87459,13 +93315,13 @@ Rule: "${err.ruleId}"`;
        */
       verify(textOrSourceCode, config, filenameOrOptions) {
         debug("Verify");
-        const { configType } = internalSlotsMap.get(this);
+        const { configType, cwd } = internalSlotsMap.get(this);
         const options = typeof filenameOrOptions === "string" ? { filename: filenameOrOptions } : filenameOrOptions || {};
         if (config) {
           if (configType === "flat") {
             let configArray = config;
             if (!Array.isArray(config) || typeof config.getConfig !== "function") {
-              configArray = new FlatConfigArray(config);
+              configArray = new FlatConfigArray(config, { basePath: cwd });
               configArray.normalizeSync();
             }
             return this._distinguishSuppressedMessages(this._verifyWithFlatConfigArray(textOrSourceCode, configArray, options, true));
@@ -87565,12 +93421,6 @@ Rule: "${err.ruleId}"`;
         languageOptions.ecmaVersion = normalizeEcmaVersionForLanguageOptions(
           languageOptions.ecmaVersion
         );
-        const configuredGlobals = Object.assign(
-          {},
-          getGlobalsForEcmaVersion(languageOptions.ecmaVersion),
-          languageOptions.sourceType === "commonjs" ? globals.commonjs : void 0,
-          languageOptions.globals
-        );
         if (!languageOptions.parser) {
           throw new TypeError(`No parser specified for ${options.filename}`);
         }
@@ -87606,18 +93456,75 @@ Rule: "${err.ruleId}"`;
           }
         }
         const sourceCode = slots.lastSourceCode;
-        const commentDirectives = options.allowInlineConfig ? getDirectiveComments(
-          sourceCode.ast,
-          (ruleId) => getRuleFromConfig(ruleId, config),
-          options.warnInlineConfig
-        ) : { configuredRules: {}, enabledGlobals: {}, exportedVariables: {}, problems: [], disableDirectives: [] };
-        addDeclaredGlobals(
-          sourceCode.scopeManager.scopes[0],
-          configuredGlobals,
-          { exportedVariables: commentDirectives.exportedVariables, enabledGlobals: commentDirectives.enabledGlobals }
-        );
-        const configuredRules = Object.assign({}, config.rules, commentDirectives.configuredRules);
+        sourceCode.applyLanguageOptions(languageOptions);
+        const mergedInlineConfig = {
+          rules: {}
+        };
+        const inlineConfigProblems = [];
+        if (options.allowInlineConfig) {
+          if (options.warnInlineConfig) {
+            sourceCode.getInlineConfigNodes().forEach((node) => {
+              inlineConfigProblems.push(createLintingProblem({
+                ruleId: null,
+                message: `'${sourceCode.text.slice(node.range[0], node.range[1])}' has no effect because you have 'noInlineConfig' setting in ${options.warnInlineConfig}.`,
+                loc: node.loc,
+                severity: 1
+              }));
+            });
+          } else {
+            const inlineConfigResult = sourceCode.applyInlineConfig();
+            inlineConfigProblems.push(
+              ...inlineConfigResult.problems.map(createLintingProblem).map((problem) => {
+                problem.fatal = true;
+                return problem;
+              })
+            );
+            const ruleValidator = new RuleValidator();
+            for (const { config: inlineConfig, node } of inlineConfigResult.configs) {
+              Object.keys(inlineConfig.rules).forEach((ruleId) => {
+                const rule = getRuleFromConfig(ruleId, config);
+                const ruleValue = inlineConfig.rules[ruleId];
+                if (!rule) {
+                  inlineConfigProblems.push(createLintingProblem({ ruleId, loc: node.loc }));
+                  return;
+                }
+                try {
+                  const ruleOptions = Array.isArray(ruleValue) ? ruleValue : [ruleValue];
+                  assertIsRuleOptions(ruleId, ruleValue);
+                  assertIsRuleSeverity(ruleId, ruleOptions[0]);
+                  ruleValidator.validate({
+                    plugins: config.plugins,
+                    rules: {
+                      [ruleId]: ruleOptions
+                    }
+                  });
+                  mergedInlineConfig.rules[ruleId] = ruleValue;
+                } catch (err) {
+                  let baseMessage = err.message.slice(
+                    err.message.startsWith('Key "rules":') ? err.message.indexOf(":", 12) + 1 : err.message.indexOf(":") + 1
+                  ).trim();
+                  if (err.messageTemplate) {
+                    baseMessage += ` You passed "${ruleValue}".`;
+                  }
+                  inlineConfigProblems.push(createLintingProblem({
+                    ruleId,
+                    message: `Inline configuration for rule "${ruleId}" is invalid:
+	${baseMessage}
+`,
+                    loc: node.loc
+                  }));
+                }
+              });
+            }
+          }
+        }
+        const commentDirectives = options.allowInlineConfig && !options.warnInlineConfig ? getDirectiveCommentsForFlatConfig(
+          sourceCode,
+          (ruleId) => getRuleFromConfig(ruleId, config)
+        ) : { problems: [], disableDirectives: [] };
+        const configuredRules = Object.assign({}, config.rules, mergedInlineConfig.rules);
         let lintingProblems;
+        sourceCode.finalize();
         try {
           lintingProblems = runRules(
             sourceCode,
@@ -87652,7 +93559,7 @@ Rule: "${err.ruleId}"`;
         return applyDisableDirectives({
           directives: commentDirectives.disableDirectives,
           disableFixes: options.disableFixes,
-          problems: lintingProblems.concat(commentDirectives.problems).sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
+          problems: lintingProblems.concat(commentDirectives.problems).concat(inlineConfigProblems).sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
           reportUnusedDisableDirectives: options.reportUnusedDisableDirectives
         });
       }

--- a/packages/ace-linters/src/services/service-manager.ts
+++ b/packages/ace-linters/src/services/service-manager.ts
@@ -87,196 +87,196 @@ export class ServiceManager {
                 uri: documentUri,
                 version: version
             };
-			function handleError (error: Error)
-			{
-				// We shall ignore content modified errors: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#implementationConsiderations: "If clients receive a ContentModified error, it generally should not show it in the UI for the end-user."
-				if (error.message != "Content modified.")
-				{
-					throw (error);
-				}
-			}
+            function handleError (error: Error)
+            {
+                // We shall ignore content modified errors: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#implementationConsiderations: "If clients receive a ContentModified error, it generally should not show it in the UI for the end-user."
+                if (error.message != "Content modified.")
+                {
+                    throw (error);
+                }
+            }
             switch (message.type) {
                 case MessageType.format:
-					try {
-						serviceInstances = this.filterByFeature(serviceInstances, "format");
-						if (serviceInstances.length > 0) {
-							//we will use only first service to format
-							postMessage["value"] = await serviceInstances[0].format(documentIdentifier, message.value, message.format);
-						}
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        serviceInstances = this.filterByFeature(serviceInstances, "format");
+                        if (serviceInstances.length > 0) {
+                            //we will use only first service to format
+                            postMessage["value"] = await serviceInstances[0].format(documentIdentifier, message.value, message.format);
+                        }
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.complete:
-					try {
-						postMessage["value"] = (await Promise.all(this.filterByFeature(serviceInstances, "completion").map(async (service) => {
-							return {
-								completions: await service.doComplete(documentIdentifier, message["value"]),
-								service: service.serviceData.className
-							};
-						}))).filter(notEmpty);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        postMessage["value"] = (await Promise.all(this.filterByFeature(serviceInstances, "completion").map(async (service) => {
+                            return {
+                                completions: await service.doComplete(documentIdentifier, message["value"]),
+                                service: service.serviceData.className
+                            };
+                        }))).filter(notEmpty);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.resolveCompletion:
-					try {
-						let serviceName = message.value["service"];
-						postMessage["value"] = await this.filterByFeature(serviceInstances, "completionResolve").find((service) => {
-							if (service.serviceData.className === serviceName) {
-								return service;
-							}
-						})?.doResolve(message.value);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        let serviceName = message.value["service"];
+                        postMessage["value"] = await this.filterByFeature(serviceInstances, "completionResolve").find((service) => {
+                            if (service.serviceData.className === serviceName) {
+                                return service;
+                            }
+                        })?.doResolve(message.value);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.change:
-					try {
-						serviceInstances.forEach((service) => {
-							service.setValue(documentIdentifier, message["value"]);
-						});
-						await doValidation(documentIdentifier, serviceInstances);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        serviceInstances.forEach((service) => {
+                            service.setValue(documentIdentifier, message["value"]);
+                        });
+                        await doValidation(documentIdentifier, serviceInstances);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.applyDelta:
-					try {
-						serviceInstances.forEach((service) => {
-							service.applyDeltas(documentIdentifier, message["value"]);
-						});
-						await doValidation(documentIdentifier, serviceInstances);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        serviceInstances.forEach((service) => {
+                            service.applyDeltas(documentIdentifier, message["value"]);
+                        });
+                        await doValidation(documentIdentifier, serviceInstances);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.hover:
-					try {
-						postMessage["value"] = await this.aggregateFeatureResponses(serviceInstances, "hover", "doHover", documentIdentifier, message.value);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        postMessage["value"] = await this.aggregateFeatureResponses(serviceInstances, "hover", "doHover", documentIdentifier, message.value);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.validate:
-					try {
-						postMessage["value"] = await doValidation(documentIdentifier, serviceInstances);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        postMessage["value"] = await doValidation(documentIdentifier, serviceInstances);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.init: //this should be first message
-					try {
-						postMessage["value"] = await this.getServicesCapabilitiesAfterCallback(documentIdentifier, message, this.addDocument.bind(this))
-						await doValidation(documentIdentifier);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        postMessage["value"] = await this.getServicesCapabilitiesAfterCallback(documentIdentifier, message, this.addDocument.bind(this))
+                        await doValidation(documentIdentifier);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.changeMode:
-					try {
-						postMessage["value"] = await this.getServicesCapabilitiesAfterCallback(documentIdentifier, message, this.changeDocumentMode.bind(this))
-						await doValidation(documentIdentifier);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        postMessage["value"] = await this.getServicesCapabilitiesAfterCallback(documentIdentifier, message, this.changeDocumentMode.bind(this))
+                        await doValidation(documentIdentifier);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.changeOptions:
-					try {
-						this.applyOptionsToServices(serviceInstances, documentUri, message.options);
-						await doValidation(documentIdentifier, serviceInstances);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        this.applyOptionsToServices(serviceInstances, documentUri, message.options);
+                        await doValidation(documentIdentifier, serviceInstances);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.closeDocument:
-					try {
-						this.removeDocument(documentIdentifier);
-						await doValidation(documentIdentifier, serviceInstances);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        this.removeDocument(documentIdentifier);
+                        await doValidation(documentIdentifier, serviceInstances);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.closeConnection:
-					try {
-						await this.closeAllConnections();
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        await this.closeAllConnections();
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.globalOptions:
-					try {
-						this.setGlobalOptions(message.serviceName, message.options, message.merge);
-						await provideValidationForServiceInstance(message.serviceName);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        this.setGlobalOptions(message.serviceName, message.options, message.merge);
+                        await provideValidationForServiceInstance(message.serviceName);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.configureFeatures:
-					try {
-						this.configureFeatures(message.serviceName, message.options);
-						await provideValidationForServiceInstance(message.serviceName);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        this.configureFeatures(message.serviceName, message.options);
+                        await provideValidationForServiceInstance(message.serviceName);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.signatureHelp:
-					try {
-						postMessage["value"] = await this.aggregateFeatureResponses(serviceInstances, "signatureHelp", "provideSignatureHelp", documentIdentifier, message.value);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        postMessage["value"] = await this.aggregateFeatureResponses(serviceInstances, "signatureHelp", "provideSignatureHelp", documentIdentifier, message.value);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.documentHighlight:
-					try {
-						let highlights = await this.aggregateFeatureResponses(serviceInstances, "documentHighlight", "findDocumentHighlights", documentIdentifier, message.value);
-						postMessage["value"] = highlights.flat();
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        let highlights = await this.aggregateFeatureResponses(serviceInstances, "documentHighlight", "findDocumentHighlights", documentIdentifier, message.value);
+                        postMessage["value"] = highlights.flat();
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.getSemanticTokens:
-					try {
-						serviceInstances = this.filterByFeature(serviceInstances, "semanticTokens");
-						if (serviceInstances.length > 0) {
-							//we will use only first service
-							postMessage["value"] = await serviceInstances[0].getSemanticTokens(documentIdentifier, message.value);
-						}
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        serviceInstances = this.filterByFeature(serviceInstances, "semanticTokens");
+                        if (serviceInstances.length > 0) {
+                            //we will use only first service
+                            postMessage["value"] = await serviceInstances[0].getSemanticTokens(documentIdentifier, message.value);
+                        }
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.getCodeActions:
-					try {
-						let value = message.value;
-						let context = message.context;
-						postMessage["value"] = (await Promise.all(this.filterByFeature(serviceInstances, "codeAction").map(async (service) => {
-							return {
-								codeActions: await service.getCodeActions(documentIdentifier, value, context),
-								service: service.serviceName
-							};
-						}))).filter(notEmpty);
-					}
-					catch (error) {
-						handleError(error);
-					}
+                    try {
+                        let value = message.value;
+                        let context = message.context;
+                        postMessage["value"] = (await Promise.all(this.filterByFeature(serviceInstances, "codeAction").map(async (service) => {
+                            return {
+                                codeActions: await service.getCodeActions(documentIdentifier, value, context),
+                                service: service.serviceName
+                            };
+                        }))).filter(notEmpty);
+                    }
+                    catch (error) {
+                        handleError(error);
+                    }
                     break;
                 case MessageType.executeCommand:
                     postMessage["value"] = this.$services[message.serviceName]?.serviceInstance?.executeCommand(message.value, message.args);

--- a/packages/ace-linters/src/services/yaml/lib/index.js
+++ b/packages/ace-linters/src/services/yaml/lib/index.js
@@ -8332,1648 +8332,6 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/dynamicAnchor.js
-var require_dynamicAnchor = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/dynamicAnchor.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.dynamicAnchor = void 0;
-    var codegen_1 = require_codegen();
-    var names_1 = require_names();
-    var compile_1 = require_compile();
-    var ref_1 = require_ref();
-    var def = {
-      keyword: "$dynamicAnchor",
-      schemaType: "string",
-      code: (cxt) => dynamicAnchor(cxt, cxt.schema)
-    };
-    function dynamicAnchor(cxt, anchor) {
-      const { gen, it } = cxt;
-      it.schemaEnv.root.dynamicAnchors[anchor] = true;
-      const v = (0, codegen_1._)`${names_1.default.dynamicAnchors}${(0, codegen_1.getProperty)(anchor)}`;
-      const validate3 = it.errSchemaPath === "#" ? it.validateName : _getValidate(cxt);
-      gen.if((0, codegen_1._)`!${v}`, () => gen.assign(v, validate3));
-    }
-    exports.dynamicAnchor = dynamicAnchor;
-    function _getValidate(cxt) {
-      const { schemaEnv, schema: schema4, self: self2 } = cxt.it;
-      const { root, baseId, localRefs, meta } = schemaEnv.root;
-      const { schemaId } = self2.opts;
-      const sch = new compile_1.SchemaEnv({ schema: schema4, schemaId, root, baseId, localRefs, meta });
-      compile_1.compileSchema.call(self2, sch);
-      return (0, ref_1.getValidate)(cxt, sch);
-    }
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/dynamicRef.js
-var require_dynamicRef = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/dynamicRef.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.dynamicRef = void 0;
-    var codegen_1 = require_codegen();
-    var names_1 = require_names();
-    var ref_1 = require_ref();
-    var def = {
-      keyword: "$dynamicRef",
-      schemaType: "string",
-      code: (cxt) => dynamicRef(cxt, cxt.schema)
-    };
-    function dynamicRef(cxt, ref) {
-      const { gen, keyword, it } = cxt;
-      if (ref[0] !== "#")
-        throw new Error(`"${keyword}" only supports hash fragment reference`);
-      const anchor = ref.slice(1);
-      if (it.allErrors) {
-        _dynamicRef();
-      } else {
-        const valid = gen.let("valid", false);
-        _dynamicRef(valid);
-        cxt.ok(valid);
-      }
-      function _dynamicRef(valid) {
-        if (it.schemaEnv.root.dynamicAnchors[anchor]) {
-          const v = gen.let("_v", (0, codegen_1._)`${names_1.default.dynamicAnchors}${(0, codegen_1.getProperty)(anchor)}`);
-          gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid));
-        } else {
-          _callRef(it.validateName, valid)();
-        }
-      }
-      function _callRef(validate3, valid) {
-        return valid ? () => gen.block(() => {
-          (0, ref_1.callRef)(cxt, validate3);
-          gen.let(valid, true);
-        }) : () => (0, ref_1.callRef)(cxt, validate3);
-      }
-    }
-    exports.dynamicRef = dynamicRef;
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/recursiveAnchor.js
-var require_recursiveAnchor = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/recursiveAnchor.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var dynamicAnchor_1 = require_dynamicAnchor();
-    var util_1 = require_util();
-    var def = {
-      keyword: "$recursiveAnchor",
-      schemaType: "boolean",
-      code(cxt) {
-        if (cxt.schema)
-          (0, dynamicAnchor_1.dynamicAnchor)(cxt, "");
-        else
-          (0, util_1.checkStrictMode)(cxt.it, "$recursiveAnchor: false is ignored");
-      }
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/recursiveRef.js
-var require_recursiveRef = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/recursiveRef.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var dynamicRef_1 = require_dynamicRef();
-    var def = {
-      keyword: "$recursiveRef",
-      schemaType: "string",
-      code: (cxt) => (0, dynamicRef_1.dynamicRef)(cxt, cxt.schema)
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/index.js
-var require_dynamic = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/dynamic/index.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var dynamicAnchor_1 = require_dynamicAnchor();
-    var dynamicRef_1 = require_dynamicRef();
-    var recursiveAnchor_1 = require_recursiveAnchor();
-    var recursiveRef_1 = require_recursiveRef();
-    var dynamic = [dynamicAnchor_1.default, dynamicRef_1.default, recursiveAnchor_1.default, recursiveRef_1.default];
-    exports.default = dynamic;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/validation/dependentRequired.js
-var require_dependentRequired = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/validation/dependentRequired.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var dependencies_1 = require_dependencies();
-    var def = {
-      keyword: "dependentRequired",
-      type: "object",
-      schemaType: "object",
-      error: dependencies_1.error,
-      code: (cxt) => (0, dependencies_1.validatePropertyDeps)(cxt)
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/applicator/dependentSchemas.js
-var require_dependentSchemas = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/applicator/dependentSchemas.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var dependencies_1 = require_dependencies();
-    var def = {
-      keyword: "dependentSchemas",
-      type: "object",
-      schemaType: "object",
-      code: (cxt) => (0, dependencies_1.validateSchemaDeps)(cxt)
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/validation/limitContains.js
-var require_limitContains = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/validation/limitContains.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var util_1 = require_util();
-    var def = {
-      keyword: ["maxContains", "minContains"],
-      type: "array",
-      schemaType: "number",
-      code({ keyword, parentSchema, it }) {
-        if (parentSchema.contains === void 0) {
-          (0, util_1.checkStrictMode)(it, `"${keyword}" without "contains" is ignored`);
-        }
-      }
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/next.js
-var require_next = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/next.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var dependentRequired_1 = require_dependentRequired();
-    var dependentSchemas_1 = require_dependentSchemas();
-    var limitContains_1 = require_limitContains();
-    var next = [dependentRequired_1.default, dependentSchemas_1.default, limitContains_1.default];
-    exports.default = next;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/unevaluated/unevaluatedProperties.js
-var require_unevaluatedProperties = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/unevaluated/unevaluatedProperties.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var codegen_1 = require_codegen();
-    var util_1 = require_util();
-    var names_1 = require_names();
-    var error = {
-      message: "must NOT have unevaluated properties",
-      params: ({ params }) => (0, codegen_1._)`{unevaluatedProperty: ${params.unevaluatedProperty}}`
-    };
-    var def = {
-      keyword: "unevaluatedProperties",
-      type: "object",
-      schemaType: ["boolean", "object"],
-      trackErrors: true,
-      error,
-      code(cxt) {
-        const { gen, schema: schema4, data, errsCount, it } = cxt;
-        if (!errsCount)
-          throw new Error("ajv implementation error");
-        const { allErrors, props } = it;
-        if (props instanceof codegen_1.Name) {
-          gen.if((0, codegen_1._)`${props} !== true`, () => gen.forIn("key", data, (key) => gen.if(unevaluatedDynamic(props, key), () => unevaluatedPropCode(key))));
-        } else if (props !== true) {
-          gen.forIn("key", data, (key) => props === void 0 ? unevaluatedPropCode(key) : gen.if(unevaluatedStatic(props, key), () => unevaluatedPropCode(key)));
-        }
-        it.props = true;
-        cxt.ok((0, codegen_1._)`${errsCount} === ${names_1.default.errors}`);
-        function unevaluatedPropCode(key) {
-          if (schema4 === false) {
-            cxt.setParams({ unevaluatedProperty: key });
-            cxt.error();
-            if (!allErrors)
-              gen.break();
-            return;
-          }
-          if (!(0, util_1.alwaysValidSchema)(it, schema4)) {
-            const valid = gen.name("valid");
-            cxt.subschema({
-              keyword: "unevaluatedProperties",
-              dataProp: key,
-              dataPropType: util_1.Type.Str
-            }, valid);
-            if (!allErrors)
-              gen.if((0, codegen_1.not)(valid), () => gen.break());
-          }
-        }
-        function unevaluatedDynamic(evaluatedProps, key) {
-          return (0, codegen_1._)`!${evaluatedProps} || !${evaluatedProps}[${key}]`;
-        }
-        function unevaluatedStatic(evaluatedProps, key) {
-          const ps = [];
-          for (const p in evaluatedProps) {
-            if (evaluatedProps[p] === true)
-              ps.push((0, codegen_1._)`${key} !== ${p}`);
-          }
-          return (0, codegen_1.and)(...ps);
-        }
-      }
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/unevaluated/unevaluatedItems.js
-var require_unevaluatedItems = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/unevaluated/unevaluatedItems.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var codegen_1 = require_codegen();
-    var util_1 = require_util();
-    var error = {
-      message: ({ params: { len } }) => (0, codegen_1.str)`must NOT have more than ${len} items`,
-      params: ({ params: { len } }) => (0, codegen_1._)`{limit: ${len}}`
-    };
-    var def = {
-      keyword: "unevaluatedItems",
-      type: "array",
-      schemaType: ["boolean", "object"],
-      error,
-      code(cxt) {
-        const { gen, schema: schema4, data, it } = cxt;
-        const items = it.items || 0;
-        if (items === true)
-          return;
-        const len = gen.const("len", (0, codegen_1._)`${data}.length`);
-        if (schema4 === false) {
-          cxt.setParams({ len: items });
-          cxt.fail((0, codegen_1._)`${len} > ${items}`);
-        } else if (typeof schema4 == "object" && !(0, util_1.alwaysValidSchema)(it, schema4)) {
-          const valid = gen.var("valid", (0, codegen_1._)`${len} <= ${items}`);
-          gen.if((0, codegen_1.not)(valid), () => validateItems(valid, items));
-          cxt.ok(valid);
-        }
-        it.items = true;
-        function validateItems(valid, from) {
-          gen.forRange("i", from, len, (i) => {
-            cxt.subschema({ keyword: "unevaluatedItems", dataProp: i, dataPropType: util_1.Type.Num }, valid);
-            if (!it.allErrors)
-              gen.if((0, codegen_1.not)(valid), () => gen.break());
-          });
-        }
-      }
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/unevaluated/index.js
-var require_unevaluated = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/unevaluated/index.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var unevaluatedProperties_1 = require_unevaluatedProperties();
-    var unevaluatedItems_1 = require_unevaluatedItems();
-    var unevaluated = [unevaluatedProperties_1.default, unevaluatedItems_1.default];
-    exports.default = unevaluated;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/schema.json
-var require_schema = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/schema.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/schema",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/core": true,
-        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
-        "https://json-schema.org/draft/2019-09/vocab/validation": true,
-        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
-        "https://json-schema.org/draft/2019-09/vocab/format": false,
-        "https://json-schema.org/draft/2019-09/vocab/content": true
-      },
-      $recursiveAnchor: true,
-      title: "Core and Validation specifications meta-schema",
-      allOf: [
-        { $ref: "meta/core" },
-        { $ref: "meta/applicator" },
-        { $ref: "meta/validation" },
-        { $ref: "meta/meta-data" },
-        { $ref: "meta/format" },
-        { $ref: "meta/content" }
-      ],
-      type: ["object", "boolean"],
-      properties: {
-        definitions: {
-          $comment: "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
-          type: "object",
-          additionalProperties: { $recursiveRef: "#" },
-          default: {}
-        },
-        dependencies: {
-          $comment: '"dependencies" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to "dependentSchemas" and "dependentRequired"',
-          type: "object",
-          additionalProperties: {
-            anyOf: [{ $recursiveRef: "#" }, { $ref: "meta/validation#/$defs/stringArray" }]
-          }
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/applicator.json
-var require_applicator2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/applicator.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/meta/applicator",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/applicator": true
-      },
-      $recursiveAnchor: true,
-      title: "Applicator vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        additionalItems: { $recursiveRef: "#" },
-        unevaluatedItems: { $recursiveRef: "#" },
-        items: {
-          anyOf: [{ $recursiveRef: "#" }, { $ref: "#/$defs/schemaArray" }]
-        },
-        contains: { $recursiveRef: "#" },
-        additionalProperties: { $recursiveRef: "#" },
-        unevaluatedProperties: { $recursiveRef: "#" },
-        properties: {
-          type: "object",
-          additionalProperties: { $recursiveRef: "#" },
-          default: {}
-        },
-        patternProperties: {
-          type: "object",
-          additionalProperties: { $recursiveRef: "#" },
-          propertyNames: { format: "regex" },
-          default: {}
-        },
-        dependentSchemas: {
-          type: "object",
-          additionalProperties: {
-            $recursiveRef: "#"
-          }
-        },
-        propertyNames: { $recursiveRef: "#" },
-        if: { $recursiveRef: "#" },
-        then: { $recursiveRef: "#" },
-        else: { $recursiveRef: "#" },
-        allOf: { $ref: "#/$defs/schemaArray" },
-        anyOf: { $ref: "#/$defs/schemaArray" },
-        oneOf: { $ref: "#/$defs/schemaArray" },
-        not: { $recursiveRef: "#" }
-      },
-      $defs: {
-        schemaArray: {
-          type: "array",
-          minItems: 1,
-          items: { $recursiveRef: "#" }
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/content.json
-var require_content = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/content.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/meta/content",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/content": true
-      },
-      $recursiveAnchor: true,
-      title: "Content vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        contentMediaType: { type: "string" },
-        contentEncoding: { type: "string" },
-        contentSchema: { $recursiveRef: "#" }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/core.json
-var require_core3 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/core.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/meta/core",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/core": true
-      },
-      $recursiveAnchor: true,
-      title: "Core vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        $id: {
-          type: "string",
-          format: "uri-reference",
-          $comment: "Non-empty fragments not allowed.",
-          pattern: "^[^#]*#?$"
-        },
-        $schema: {
-          type: "string",
-          format: "uri"
-        },
-        $anchor: {
-          type: "string",
-          pattern: "^[A-Za-z][-A-Za-z0-9.:_]*$"
-        },
-        $ref: {
-          type: "string",
-          format: "uri-reference"
-        },
-        $recursiveRef: {
-          type: "string",
-          format: "uri-reference"
-        },
-        $recursiveAnchor: {
-          type: "boolean",
-          default: false
-        },
-        $vocabulary: {
-          type: "object",
-          propertyNames: {
-            type: "string",
-            format: "uri"
-          },
-          additionalProperties: {
-            type: "boolean"
-          }
-        },
-        $comment: {
-          type: "string"
-        },
-        $defs: {
-          type: "object",
-          additionalProperties: { $recursiveRef: "#" },
-          default: {}
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/format.json
-var require_format3 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/format.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/meta/format",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/format": true
-      },
-      $recursiveAnchor: true,
-      title: "Format vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        format: { type: "string" }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/meta-data.json
-var require_meta_data = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/meta-data.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/meta/meta-data",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/meta-data": true
-      },
-      $recursiveAnchor: true,
-      title: "Meta-data vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        title: {
-          type: "string"
-        },
-        description: {
-          type: "string"
-        },
-        default: true,
-        deprecated: {
-          type: "boolean",
-          default: false
-        },
-        readOnly: {
-          type: "boolean",
-          default: false
-        },
-        writeOnly: {
-          type: "boolean",
-          default: false
-        },
-        examples: {
-          type: "array",
-          items: true
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/validation.json
-var require_validation2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/meta/validation.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2019-09/schema",
-      $id: "https://json-schema.org/draft/2019-09/meta/validation",
-      $vocabulary: {
-        "https://json-schema.org/draft/2019-09/vocab/validation": true
-      },
-      $recursiveAnchor: true,
-      title: "Validation vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        multipleOf: {
-          type: "number",
-          exclusiveMinimum: 0
-        },
-        maximum: {
-          type: "number"
-        },
-        exclusiveMaximum: {
-          type: "number"
-        },
-        minimum: {
-          type: "number"
-        },
-        exclusiveMinimum: {
-          type: "number"
-        },
-        maxLength: { $ref: "#/$defs/nonNegativeInteger" },
-        minLength: { $ref: "#/$defs/nonNegativeIntegerDefault0" },
-        pattern: {
-          type: "string",
-          format: "regex"
-        },
-        maxItems: { $ref: "#/$defs/nonNegativeInteger" },
-        minItems: { $ref: "#/$defs/nonNegativeIntegerDefault0" },
-        uniqueItems: {
-          type: "boolean",
-          default: false
-        },
-        maxContains: { $ref: "#/$defs/nonNegativeInteger" },
-        minContains: {
-          $ref: "#/$defs/nonNegativeInteger",
-          default: 1
-        },
-        maxProperties: { $ref: "#/$defs/nonNegativeInteger" },
-        minProperties: { $ref: "#/$defs/nonNegativeIntegerDefault0" },
-        required: { $ref: "#/$defs/stringArray" },
-        dependentRequired: {
-          type: "object",
-          additionalProperties: {
-            $ref: "#/$defs/stringArray"
-          }
-        },
-        const: true,
-        enum: {
-          type: "array",
-          items: true
-        },
-        type: {
-          anyOf: [
-            { $ref: "#/$defs/simpleTypes" },
-            {
-              type: "array",
-              items: { $ref: "#/$defs/simpleTypes" },
-              minItems: 1,
-              uniqueItems: true
-            }
-          ]
-        }
-      },
-      $defs: {
-        nonNegativeInteger: {
-          type: "integer",
-          minimum: 0
-        },
-        nonNegativeIntegerDefault0: {
-          $ref: "#/$defs/nonNegativeInteger",
-          default: 0
-        },
-        simpleTypes: {
-          enum: ["array", "boolean", "integer", "null", "number", "object", "string"]
-        },
-        stringArray: {
-          type: "array",
-          items: { type: "string" },
-          uniqueItems: true,
-          default: []
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/index.js
-var require_json_schema_2019_09 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2019-09/index.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var metaSchema = require_schema();
-    var applicator = require_applicator2();
-    var content = require_content();
-    var core = require_core3();
-    var format5 = require_format3();
-    var metadata = require_meta_data();
-    var validation = require_validation2();
-    var META_SUPPORT_DATA = ["/properties"];
-    function addMetaSchema2019($data) {
-      ;
-      [
-        metaSchema,
-        applicator,
-        content,
-        core,
-        with$data(this, format5),
-        metadata,
-        with$data(this, validation)
-      ].forEach((sch) => this.addMetaSchema(sch, void 0, false));
-      return this;
-      function with$data(ajv2, sch) {
-        return $data ? ajv2.$dataMetaSchema(sch, META_SUPPORT_DATA) : sch;
-      }
-    }
-    exports.default = addMetaSchema2019;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/2019.js
-var require__ = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/2019.js"(exports, module) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv2019 = void 0;
-    var core_1 = require_core();
-    var draft7_1 = require_draft7();
-    var dynamic_1 = require_dynamic();
-    var next_1 = require_next();
-    var unevaluated_1 = require_unevaluated();
-    var discriminator_1 = require_discriminator();
-    var json_schema_2019_09_1 = require_json_schema_2019_09();
-    var META_SCHEMA_ID = "https://json-schema.org/draft/2019-09/schema";
-    var Ajv20192 = class extends core_1.default {
-      constructor(opts = {}) {
-        super({
-          ...opts,
-          dynamicRef: true,
-          next: true,
-          unevaluated: true
-        });
-      }
-      _addVocabularies() {
-        super._addVocabularies();
-        this.addVocabulary(dynamic_1.default);
-        draft7_1.default.forEach((v) => this.addVocabulary(v));
-        this.addVocabulary(next_1.default);
-        this.addVocabulary(unevaluated_1.default);
-        if (this.opts.discriminator)
-          this.addKeyword(discriminator_1.default);
-      }
-      _addDefaultMetaSchema() {
-        super._addDefaultMetaSchema();
-        const { $data, meta } = this.opts;
-        if (!meta)
-          return;
-        json_schema_2019_09_1.default.call(this, $data);
-        this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
-      }
-      defaultMeta() {
-        return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
-      }
-    };
-    exports.Ajv2019 = Ajv20192;
-    module.exports = exports = Ajv20192;
-    module.exports.Ajv2019 = Ajv20192;
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.default = Ajv20192;
-    var validate_1 = require_validate();
-    Object.defineProperty(exports, "KeywordCxt", { enumerable: true, get: function() {
-      return validate_1.KeywordCxt;
-    } });
-    var codegen_1 = require_codegen();
-    Object.defineProperty(exports, "_", { enumerable: true, get: function() {
-      return codegen_1._;
-    } });
-    Object.defineProperty(exports, "str", { enumerable: true, get: function() {
-      return codegen_1.str;
-    } });
-    Object.defineProperty(exports, "stringify", { enumerable: true, get: function() {
-      return codegen_1.stringify;
-    } });
-    Object.defineProperty(exports, "nil", { enumerable: true, get: function() {
-      return codegen_1.nil;
-    } });
-    Object.defineProperty(exports, "Name", { enumerable: true, get: function() {
-      return codegen_1.Name;
-    } });
-    Object.defineProperty(exports, "CodeGen", { enumerable: true, get: function() {
-      return codegen_1.CodeGen;
-    } });
-    var validation_error_1 = require_validation_error();
-    Object.defineProperty(exports, "ValidationError", { enumerable: true, get: function() {
-      return validation_error_1.default;
-    } });
-    var ref_error_1 = require_ref_error();
-    Object.defineProperty(exports, "MissingRefError", { enumerable: true, get: function() {
-      return ref_error_1.default;
-    } });
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/draft2020.js
-var require_draft2020 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/vocabularies/draft2020.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var core_1 = require_core2();
-    var validation_1 = require_validation();
-    var applicator_1 = require_applicator();
-    var dynamic_1 = require_dynamic();
-    var next_1 = require_next();
-    var unevaluated_1 = require_unevaluated();
-    var format_1 = require_format2();
-    var metadata_1 = require_metadata();
-    var draft2020Vocabularies = [
-      dynamic_1.default,
-      core_1.default,
-      validation_1.default,
-      (0, applicator_1.default)(true),
-      format_1.default,
-      metadata_1.metadataVocabulary,
-      metadata_1.contentVocabulary,
-      next_1.default,
-      unevaluated_1.default
-    ];
-    exports.default = draft2020Vocabularies;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/schema.json
-var require_schema2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/schema.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/schema",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/core": true,
-        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-        "https://json-schema.org/draft/2020-12/vocab/validation": true,
-        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-        "https://json-schema.org/draft/2020-12/vocab/content": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Core and Validation specifications meta-schema",
-      allOf: [
-        { $ref: "meta/core" },
-        { $ref: "meta/applicator" },
-        { $ref: "meta/unevaluated" },
-        { $ref: "meta/validation" },
-        { $ref: "meta/meta-data" },
-        { $ref: "meta/format-annotation" },
-        { $ref: "meta/content" }
-      ],
-      type: ["object", "boolean"],
-      $comment: "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
-      properties: {
-        definitions: {
-          $comment: '"definitions" has been replaced by "$defs".',
-          type: "object",
-          additionalProperties: { $dynamicRef: "#meta" },
-          deprecated: true,
-          default: {}
-        },
-        dependencies: {
-          $comment: '"dependencies" has been split and replaced by "dependentSchemas" and "dependentRequired" in order to serve their differing semantics.',
-          type: "object",
-          additionalProperties: {
-            anyOf: [{ $dynamicRef: "#meta" }, { $ref: "meta/validation#/$defs/stringArray" }]
-          },
-          deprecated: true,
-          default: {}
-        },
-        $recursiveAnchor: {
-          $comment: '"$recursiveAnchor" has been replaced by "$dynamicAnchor".',
-          $ref: "meta/core#/$defs/anchorString",
-          deprecated: true
-        },
-        $recursiveRef: {
-          $comment: '"$recursiveRef" has been replaced by "$dynamicRef".',
-          $ref: "meta/core#/$defs/uriReferenceString",
-          deprecated: true
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/applicator.json
-var require_applicator3 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/applicator.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/applicator",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/applicator": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Applicator vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        prefixItems: { $ref: "#/$defs/schemaArray" },
-        items: { $dynamicRef: "#meta" },
-        contains: { $dynamicRef: "#meta" },
-        additionalProperties: { $dynamicRef: "#meta" },
-        properties: {
-          type: "object",
-          additionalProperties: { $dynamicRef: "#meta" },
-          default: {}
-        },
-        patternProperties: {
-          type: "object",
-          additionalProperties: { $dynamicRef: "#meta" },
-          propertyNames: { format: "regex" },
-          default: {}
-        },
-        dependentSchemas: {
-          type: "object",
-          additionalProperties: { $dynamicRef: "#meta" },
-          default: {}
-        },
-        propertyNames: { $dynamicRef: "#meta" },
-        if: { $dynamicRef: "#meta" },
-        then: { $dynamicRef: "#meta" },
-        else: { $dynamicRef: "#meta" },
-        allOf: { $ref: "#/$defs/schemaArray" },
-        anyOf: { $ref: "#/$defs/schemaArray" },
-        oneOf: { $ref: "#/$defs/schemaArray" },
-        not: { $dynamicRef: "#meta" }
-      },
-      $defs: {
-        schemaArray: {
-          type: "array",
-          minItems: 1,
-          items: { $dynamicRef: "#meta" }
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/unevaluated.json
-var require_unevaluated2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/unevaluated.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/unevaluated",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Unevaluated applicator vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        unevaluatedItems: { $dynamicRef: "#meta" },
-        unevaluatedProperties: { $dynamicRef: "#meta" }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/content.json
-var require_content2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/content.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/content",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/content": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Content vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        contentEncoding: { type: "string" },
-        contentMediaType: { type: "string" },
-        contentSchema: { $dynamicRef: "#meta" }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/core.json
-var require_core4 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/core.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/core",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/core": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Core vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        $id: {
-          $ref: "#/$defs/uriReferenceString",
-          $comment: "Non-empty fragments not allowed.",
-          pattern: "^[^#]*#?$"
-        },
-        $schema: { $ref: "#/$defs/uriString" },
-        $ref: { $ref: "#/$defs/uriReferenceString" },
-        $anchor: { $ref: "#/$defs/anchorString" },
-        $dynamicRef: { $ref: "#/$defs/uriReferenceString" },
-        $dynamicAnchor: { $ref: "#/$defs/anchorString" },
-        $vocabulary: {
-          type: "object",
-          propertyNames: { $ref: "#/$defs/uriString" },
-          additionalProperties: {
-            type: "boolean"
-          }
-        },
-        $comment: {
-          type: "string"
-        },
-        $defs: {
-          type: "object",
-          additionalProperties: { $dynamicRef: "#meta" }
-        }
-      },
-      $defs: {
-        anchorString: {
-          type: "string",
-          pattern: "^[A-Za-z_][-A-Za-z0-9._]*$"
-        },
-        uriString: {
-          type: "string",
-          format: "uri"
-        },
-        uriReferenceString: {
-          type: "string",
-          format: "uri-reference"
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/format-annotation.json
-var require_format_annotation = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/format-annotation.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/format-annotation",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Format vocabulary meta-schema for annotation results",
-      type: ["object", "boolean"],
-      properties: {
-        format: { type: "string" }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/meta-data.json
-var require_meta_data2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/meta-data.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/meta-data",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/meta-data": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Meta-data vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        title: {
-          type: "string"
-        },
-        description: {
-          type: "string"
-        },
-        default: true,
-        deprecated: {
-          type: "boolean",
-          default: false
-        },
-        readOnly: {
-          type: "boolean",
-          default: false
-        },
-        writeOnly: {
-          type: "boolean",
-          default: false
-        },
-        examples: {
-          type: "array",
-          items: true
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/validation.json
-var require_validation3 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/meta/validation.json"(exports, module) {
-    module.exports = {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://json-schema.org/draft/2020-12/meta/validation",
-      $vocabulary: {
-        "https://json-schema.org/draft/2020-12/vocab/validation": true
-      },
-      $dynamicAnchor: "meta",
-      title: "Validation vocabulary meta-schema",
-      type: ["object", "boolean"],
-      properties: {
-        type: {
-          anyOf: [
-            { $ref: "#/$defs/simpleTypes" },
-            {
-              type: "array",
-              items: { $ref: "#/$defs/simpleTypes" },
-              minItems: 1,
-              uniqueItems: true
-            }
-          ]
-        },
-        const: true,
-        enum: {
-          type: "array",
-          items: true
-        },
-        multipleOf: {
-          type: "number",
-          exclusiveMinimum: 0
-        },
-        maximum: {
-          type: "number"
-        },
-        exclusiveMaximum: {
-          type: "number"
-        },
-        minimum: {
-          type: "number"
-        },
-        exclusiveMinimum: {
-          type: "number"
-        },
-        maxLength: { $ref: "#/$defs/nonNegativeInteger" },
-        minLength: { $ref: "#/$defs/nonNegativeIntegerDefault0" },
-        pattern: {
-          type: "string",
-          format: "regex"
-        },
-        maxItems: { $ref: "#/$defs/nonNegativeInteger" },
-        minItems: { $ref: "#/$defs/nonNegativeIntegerDefault0" },
-        uniqueItems: {
-          type: "boolean",
-          default: false
-        },
-        maxContains: { $ref: "#/$defs/nonNegativeInteger" },
-        minContains: {
-          $ref: "#/$defs/nonNegativeInteger",
-          default: 1
-        },
-        maxProperties: { $ref: "#/$defs/nonNegativeInteger" },
-        minProperties: { $ref: "#/$defs/nonNegativeIntegerDefault0" },
-        required: { $ref: "#/$defs/stringArray" },
-        dependentRequired: {
-          type: "object",
-          additionalProperties: {
-            $ref: "#/$defs/stringArray"
-          }
-        }
-      },
-      $defs: {
-        nonNegativeInteger: {
-          type: "integer",
-          minimum: 0
-        },
-        nonNegativeIntegerDefault0: {
-          $ref: "#/$defs/nonNegativeInteger",
-          default: 0
-        },
-        simpleTypes: {
-          enum: ["array", "boolean", "integer", "null", "number", "object", "string"]
-        },
-        stringArray: {
-          type: "array",
-          items: { type: "string" },
-          uniqueItems: true,
-          default: []
-        }
-      }
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/index.js
-var require_json_schema_2020_12 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/refs/json-schema-2020-12/index.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var metaSchema = require_schema2();
-    var applicator = require_applicator3();
-    var unevaluated = require_unevaluated2();
-    var content = require_content2();
-    var core = require_core4();
-    var format5 = require_format_annotation();
-    var metadata = require_meta_data2();
-    var validation = require_validation3();
-    var META_SUPPORT_DATA = ["/properties"];
-    function addMetaSchema2020($data) {
-      ;
-      [
-        metaSchema,
-        applicator,
-        unevaluated,
-        content,
-        core,
-        with$data(this, format5),
-        metadata,
-        with$data(this, validation)
-      ].forEach((sch) => this.addMetaSchema(sch, void 0, false));
-      return this;
-      function with$data(ajv2, sch) {
-        return $data ? ajv2.$dataMetaSchema(sch, META_SUPPORT_DATA) : sch;
-      }
-    }
-    exports.default = addMetaSchema2020;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv/dist/2020.js
-var require__2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv/dist/2020.js"(exports, module) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv2020 = void 0;
-    var core_1 = require_core();
-    var draft2020_1 = require_draft2020();
-    var discriminator_1 = require_discriminator();
-    var json_schema_2020_12_1 = require_json_schema_2020_12();
-    var META_SCHEMA_ID = "https://json-schema.org/draft/2020-12/schema";
-    var Ajv20202 = class extends core_1.default {
-      constructor(opts = {}) {
-        super({
-          ...opts,
-          dynamicRef: true,
-          next: true,
-          unevaluated: true
-        });
-      }
-      _addVocabularies() {
-        super._addVocabularies();
-        draft2020_1.default.forEach((v) => this.addVocabulary(v));
-        if (this.opts.discriminator)
-          this.addKeyword(discriminator_1.default);
-      }
-      _addDefaultMetaSchema() {
-        super._addDefaultMetaSchema();
-        const { $data, meta } = this.opts;
-        if (!meta)
-          return;
-        json_schema_2020_12_1.default.call(this, $data);
-        this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
-      }
-      defaultMeta() {
-        return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
-      }
-    };
-    exports.Ajv2020 = Ajv20202;
-    module.exports = exports = Ajv20202;
-    module.exports.Ajv2020 = Ajv20202;
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.default = Ajv20202;
-    var validate_1 = require_validate();
-    Object.defineProperty(exports, "KeywordCxt", { enumerable: true, get: function() {
-      return validate_1.KeywordCxt;
-    } });
-    var codegen_1 = require_codegen();
-    Object.defineProperty(exports, "_", { enumerable: true, get: function() {
-      return codegen_1._;
-    } });
-    Object.defineProperty(exports, "str", { enumerable: true, get: function() {
-      return codegen_1.str;
-    } });
-    Object.defineProperty(exports, "stringify", { enumerable: true, get: function() {
-      return codegen_1.stringify;
-    } });
-    Object.defineProperty(exports, "nil", { enumerable: true, get: function() {
-      return codegen_1.nil;
-    } });
-    Object.defineProperty(exports, "Name", { enumerable: true, get: function() {
-      return codegen_1.Name;
-    } });
-    Object.defineProperty(exports, "CodeGen", { enumerable: true, get: function() {
-      return codegen_1.CodeGen;
-    } });
-    var validation_error_1 = require_validation_error();
-    Object.defineProperty(exports, "ValidationError", { enumerable: true, get: function() {
-      return validation_error_1.default;
-    } });
-    var ref_error_1 = require_ref_error();
-    Object.defineProperty(exports, "MissingRefError", { enumerable: true, get: function() {
-      return ref_error_1.default;
-    } });
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/core.js
-var require_core5 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/core.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var ref_1 = require_ref();
-    var core = [
-      "$schema",
-      "id",
-      "$defs",
-      { keyword: "$comment" },
-      "definitions",
-      ref_1.default
-    ];
-    exports.default = core;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/validation/limitNumber.js
-var require_limitNumber2 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/validation/limitNumber.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var core_1 = require_core();
-    var codegen_1 = require_codegen();
-    var ops = codegen_1.operators;
-    var KWDs = {
-      maximum: {
-        exclusive: "exclusiveMaximum",
-        ops: [
-          { okStr: "<=", ok: ops.LTE, fail: ops.GT },
-          { okStr: "<", ok: ops.LT, fail: ops.GTE }
-        ]
-      },
-      minimum: {
-        exclusive: "exclusiveMinimum",
-        ops: [
-          { okStr: ">=", ok: ops.GTE, fail: ops.LT },
-          { okStr: ">", ok: ops.GT, fail: ops.LTE }
-        ]
-      }
-    };
-    var error = {
-      message: (cxt) => core_1.str`must be ${kwdOp(cxt).okStr} ${cxt.schemaCode}`,
-      params: (cxt) => core_1._`{comparison: ${kwdOp(cxt).okStr}, limit: ${cxt.schemaCode}}`
-    };
-    var def = {
-      keyword: Object.keys(KWDs),
-      type: "number",
-      schemaType: "number",
-      $data: true,
-      error,
-      code(cxt) {
-        const { data, schemaCode } = cxt;
-        cxt.fail$data(core_1._`${data} ${kwdOp(cxt).fail} ${schemaCode} || isNaN(${data})`);
-      }
-    };
-    function kwdOp(cxt) {
-      var _a;
-      const keyword = cxt.keyword;
-      const opsIdx = ((_a = cxt.parentSchema) === null || _a === void 0 ? void 0 : _a[KWDs[keyword].exclusive]) ? 1 : 0;
-      return KWDs[keyword].ops[opsIdx];
-    }
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/validation/limitNumberExclusive.js
-var require_limitNumberExclusive = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/validation/limitNumberExclusive.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var KWDs = {
-      exclusiveMaximum: "maximum",
-      exclusiveMinimum: "minimum"
-    };
-    var def = {
-      keyword: Object.keys(KWDs),
-      type: "number",
-      schemaType: "boolean",
-      code({ keyword, parentSchema }) {
-        const limitKwd = KWDs[keyword];
-        if (parentSchema[limitKwd] === void 0) {
-          throw new Error(`${keyword} can only be used with ${limitKwd}`);
-        }
-      }
-    };
-    exports.default = def;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/validation/index.js
-var require_validation4 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/validation/index.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var limitNumber_1 = require_limitNumber2();
-    var limitNumberExclusive_1 = require_limitNumberExclusive();
-    var multipleOf_1 = require_multipleOf();
-    var limitLength_1 = require_limitLength();
-    var pattern_1 = require_pattern();
-    var limitProperties_1 = require_limitProperties();
-    var required_1 = require_required();
-    var limitItems_1 = require_limitItems();
-    var uniqueItems_1 = require_uniqueItems();
-    var const_1 = require_const();
-    var enum_1 = require_enum();
-    var validation = [
-      // number
-      limitNumber_1.default,
-      limitNumberExclusive_1.default,
-      multipleOf_1.default,
-      // string
-      limitLength_1.default,
-      pattern_1.default,
-      // object
-      limitProperties_1.default,
-      required_1.default,
-      // array
-      limitItems_1.default,
-      uniqueItems_1.default,
-      // any
-      { keyword: "type", schemaType: ["string", "array"] },
-      { keyword: "nullable", schemaType: "boolean" },
-      const_1.default,
-      enum_1.default
-    ];
-    exports.default = validation;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/draft4.js
-var require_draft4 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/vocabulary/draft4.js"(exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var core_1 = require_core5();
-    var validation_1 = require_validation4();
-    var applicator_1 = require_applicator();
-    var format_1 = require_format2();
-    var metadataVocabulary = ["title", "description", "default"];
-    var draft4Vocabularies = [
-      core_1.default,
-      validation_1.default,
-      applicator_1.default(),
-      format_1.default,
-      metadataVocabulary
-    ];
-    exports.default = draft4Vocabularies;
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/refs/json-schema-draft-04.json
-var require_json_schema_draft_04 = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/refs/json-schema-draft-04.json"(exports, module) {
-    module.exports = {
-      id: "http://json-schema.org/draft-04/schema#",
-      $schema: "http://json-schema.org/draft-04/schema#",
-      description: "Core schema meta-schema",
-      definitions: {
-        schemaArray: {
-          type: "array",
-          minItems: 1,
-          items: { $ref: "#" }
-        },
-        positiveInteger: {
-          type: "integer",
-          minimum: 0
-        },
-        positiveIntegerDefault0: {
-          allOf: [{ $ref: "#/definitions/positiveInteger" }, { default: 0 }]
-        },
-        simpleTypes: {
-          enum: ["array", "boolean", "integer", "null", "number", "object", "string"]
-        },
-        stringArray: {
-          type: "array",
-          items: { type: "string" },
-          minItems: 1,
-          uniqueItems: true
-        }
-      },
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-          format: "uri"
-        },
-        $schema: {
-          type: "string",
-          format: "uri"
-        },
-        title: {
-          type: "string"
-        },
-        description: {
-          type: "string"
-        },
-        default: {},
-        multipleOf: {
-          type: "number",
-          minimum: 0,
-          exclusiveMinimum: true
-        },
-        maximum: {
-          type: "number"
-        },
-        exclusiveMaximum: {
-          type: "boolean",
-          default: false
-        },
-        minimum: {
-          type: "number"
-        },
-        exclusiveMinimum: {
-          type: "boolean",
-          default: false
-        },
-        maxLength: { $ref: "#/definitions/positiveInteger" },
-        minLength: { $ref: "#/definitions/positiveIntegerDefault0" },
-        pattern: {
-          type: "string",
-          format: "regex"
-        },
-        additionalItems: {
-          anyOf: [{ type: "boolean" }, { $ref: "#" }],
-          default: {}
-        },
-        items: {
-          anyOf: [{ $ref: "#" }, { $ref: "#/definitions/schemaArray" }],
-          default: {}
-        },
-        maxItems: { $ref: "#/definitions/positiveInteger" },
-        minItems: { $ref: "#/definitions/positiveIntegerDefault0" },
-        uniqueItems: {
-          type: "boolean",
-          default: false
-        },
-        maxProperties: { $ref: "#/definitions/positiveInteger" },
-        minProperties: { $ref: "#/definitions/positiveIntegerDefault0" },
-        required: { $ref: "#/definitions/stringArray" },
-        additionalProperties: {
-          anyOf: [{ type: "boolean" }, { $ref: "#" }],
-          default: {}
-        },
-        definitions: {
-          type: "object",
-          additionalProperties: { $ref: "#" },
-          default: {}
-        },
-        properties: {
-          type: "object",
-          additionalProperties: { $ref: "#" },
-          default: {}
-        },
-        patternProperties: {
-          type: "object",
-          additionalProperties: { $ref: "#" },
-          default: {}
-        },
-        dependencies: {
-          type: "object",
-          additionalProperties: {
-            anyOf: [{ $ref: "#" }, { $ref: "#/definitions/stringArray" }]
-          }
-        },
-        enum: {
-          type: "array",
-          minItems: 1,
-          uniqueItems: true
-        },
-        type: {
-          anyOf: [
-            { $ref: "#/definitions/simpleTypes" },
-            {
-              type: "array",
-              items: { $ref: "#/definitions/simpleTypes" },
-              minItems: 1,
-              uniqueItems: true
-            }
-          ]
-        },
-        allOf: { $ref: "#/definitions/schemaArray" },
-        anyOf: { $ref: "#/definitions/schemaArray" },
-        oneOf: { $ref: "#/definitions/schemaArray" },
-        not: { $ref: "#" }
-      },
-      dependencies: {
-        exclusiveMaximum: ["maximum"],
-        exclusiveMinimum: ["minimum"]
-      },
-      default: {}
-    };
-  }
-});
-
-// ../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/index.js
-var require_dist = __commonJS({
-  "../../node_modules/yaml-language-server/node_modules/ajv-draft-04/dist/index.js"(exports, module) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
-    var core_1 = require_core();
-    var draft4_1 = require_draft4();
-    var discriminator_1 = require_discriminator();
-    var draft4MetaSchema = require_json_schema_draft_04();
-    var META_SUPPORT_DATA = ["/properties"];
-    var META_SCHEMA_ID = "http://json-schema.org/draft-04/schema";
-    var Ajv2 = class extends core_1.default {
-      constructor(opts = {}) {
-        super({
-          ...opts,
-          schemaId: "id"
-        });
-      }
-      _addVocabularies() {
-        super._addVocabularies();
-        draft4_1.default.forEach((v) => this.addVocabulary(v));
-        if (this.opts.discriminator)
-          this.addKeyword(discriminator_1.default);
-      }
-      _addDefaultMetaSchema() {
-        super._addDefaultMetaSchema();
-        if (!this.opts.meta)
-          return;
-        const metaSchema = this.opts.$data ? this.$dataMetaSchema(draft4MetaSchema, META_SUPPORT_DATA) : draft4MetaSchema;
-        this.addMetaSchema(metaSchema, META_SCHEMA_ID, false);
-        this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
-      }
-      defaultMeta() {
-        return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
-      }
-    };
-    module.exports = exports = Ajv2;
-    Object.defineProperty(exports, "__esModule", { value: true });
-    exports.default = Ajv2;
-    var core_2 = require_core();
-    Object.defineProperty(exports, "KeywordCxt", { enumerable: true, get: function() {
-      return core_2.KeywordCxt;
-    } });
-    var core_3 = require_core();
-    Object.defineProperty(exports, "_", { enumerable: true, get: function() {
-      return core_3._;
-    } });
-    Object.defineProperty(exports, "str", { enumerable: true, get: function() {
-      return core_3.str;
-    } });
-    Object.defineProperty(exports, "stringify", { enumerable: true, get: function() {
-      return core_3.stringify;
-    } });
-    Object.defineProperty(exports, "nil", { enumerable: true, get: function() {
-      return core_3.nil;
-    } });
-    Object.defineProperty(exports, "Name", { enumerable: true, get: function() {
-      return core_3.Name;
-    } });
-    Object.defineProperty(exports, "CodeGen", { enumerable: true, get: function() {
-      return core_3.CodeGen;
-    } });
-  }
-});
-
 // ../../node_modules/prettier/standalone.js
 var require_standalone = __commonJS({
   "../../node_modules/prettier/standalone.js"(exports, module) {
@@ -12194,7 +10552,7 @@ in order for it to be formatted.`, cliCategory: "Other" }, tabWidth: { type: "in
         if (!o || i !== "auto")
           return;
         if (o.length > 2)
-          throw new Error("printer.embed has too many parameters. The API changed in Prettier v3. Please update your plugin. See https://prettier.io/docs/en/plugins.html#optional-embed");
+          throw new Error("printer.embed has too many parameters. The API changed in Prettier v3. Please update your plugin. See https://prettier.io/docs/plugins#optional-embed");
         let D = q((_a = o.getVisitorKeys) != null ? _a : a2), l = [];
         d();
         let p = e.stack;
@@ -12542,7 +10900,7 @@ in order for it to be formatted.`, cliCategory: "Other" }, tabWidth: { type: "in
       var Dr = {};
       vt(Dr, { builders: () => $i, printer: () => Mi, utils: () => Vi });
       var $i = { join: Se, line: Ze, softline: $r, hardline: K, literalline: Qe, group: kt, conditionalGroup: Ir, fill: Rr, lineSuffix: Te, lineSuffixBoundary: Hr, cursor: Z, breakParent: he, ifBreak: Yr, trim: Wr, indent: le, indentIfBreak: jr, align: De, addAlignmentToDoc: et, markAsRoot: Lr, dedentToRoot: kr, dedent: Pr, hardlineWithoutBreakParent: ke, literallineWithoutBreakParent: Lt, label: Mr, concat: (e) => e }, Mi = { printDocToString: Ce }, Vi = { willBreak: xr, traverseDoc: Fe, findInDoc: qe, mapDoc: Oe, removeLines: Nr, stripTrailingHardline: Xe, replaceEndOfLine: Or, canBreak: Sr };
-      var cu = "3.5.1";
+      var cu = "3.5.3";
       var cr = {};
       vt(cr, { addDanglingComment: () => re, addLeadingComment: () => ue, addTrailingComment: () => ie, getAlignmentSize: () => ge, getIndentSize: () => fu, getMaxContinuousCount: () => du, getNextNonSpaceNonCommentCharacter: () => pu, getNextNonSpaceNonCommentCharacterIndex: () => no, getPreferredQuote: () => mu, getStringWidth: () => Le, hasNewline: () => V, hasNewlineInRange: () => hu, hasSpaces: () => Eu, isNextLineEmpty: () => so, isNextLineEmptyAfterIndex: () => gt, isPreviousLineEmpty: () => io, makeString: () => Cu, skip: () => Ae, skipEverythingButNewLine: () => ut, skipInlineComment: () => Be, skipNewline: () => W, skipSpaces: () => S, skipToLineEnd: () => nt, skipTrailingComment: () => we, skipWhitespace: () => tn });
       function Ui(e, t) {
@@ -30354,64 +28712,64 @@ var ParseErrorCode;
 var LIB;
 (() => {
   "use strict";
-  var t = { 470: (t2) => {
+  var t = { 975: (t2) => {
     function e2(t3) {
       if ("string" != typeof t3)
         throw new TypeError("Path must be a string. Received " + JSON.stringify(t3));
     }
     function r2(t3, e3) {
-      for (var r3, n3 = "", i = 0, o = -1, s = 0, h = 0; h <= t3.length; ++h) {
-        if (h < t3.length)
-          r3 = t3.charCodeAt(h);
+      for (var r3, n3 = "", i2 = 0, o2 = -1, s2 = 0, h2 = 0; h2 <= t3.length; ++h2) {
+        if (h2 < t3.length)
+          r3 = t3.charCodeAt(h2);
         else {
           if (47 === r3)
             break;
           r3 = 47;
         }
         if (47 === r3) {
-          if (o === h - 1 || 1 === s)
+          if (o2 === h2 - 1 || 1 === s2)
             ;
-          else if (o !== h - 1 && 2 === s) {
-            if (n3.length < 2 || 2 !== i || 46 !== n3.charCodeAt(n3.length - 1) || 46 !== n3.charCodeAt(n3.length - 2)) {
+          else if (o2 !== h2 - 1 && 2 === s2) {
+            if (n3.length < 2 || 2 !== i2 || 46 !== n3.charCodeAt(n3.length - 1) || 46 !== n3.charCodeAt(n3.length - 2)) {
               if (n3.length > 2) {
-                var a2 = n3.lastIndexOf("/");
-                if (a2 !== n3.length - 1) {
-                  -1 === a2 ? (n3 = "", i = 0) : i = (n3 = n3.slice(0, a2)).length - 1 - n3.lastIndexOf("/"), o = h, s = 0;
+                var a3 = n3.lastIndexOf("/");
+                if (a3 !== n3.length - 1) {
+                  -1 === a3 ? (n3 = "", i2 = 0) : i2 = (n3 = n3.slice(0, a3)).length - 1 - n3.lastIndexOf("/"), o2 = h2, s2 = 0;
                   continue;
                 }
               } else if (2 === n3.length || 1 === n3.length) {
-                n3 = "", i = 0, o = h, s = 0;
+                n3 = "", i2 = 0, o2 = h2, s2 = 0;
                 continue;
               }
             }
-            e3 && (n3.length > 0 ? n3 += "/.." : n3 = "..", i = 2);
+            e3 && (n3.length > 0 ? n3 += "/.." : n3 = "..", i2 = 2);
           } else
-            n3.length > 0 ? n3 += "/" + t3.slice(o + 1, h) : n3 = t3.slice(o + 1, h), i = h - o - 1;
-          o = h, s = 0;
+            n3.length > 0 ? n3 += "/" + t3.slice(o2 + 1, h2) : n3 = t3.slice(o2 + 1, h2), i2 = h2 - o2 - 1;
+          o2 = h2, s2 = 0;
         } else
-          46 === r3 && -1 !== s ? ++s : s = -1;
+          46 === r3 && -1 !== s2 ? ++s2 : s2 = -1;
       }
       return n3;
     }
     var n2 = { resolve: function() {
-      for (var t3, n3 = "", i = false, o = arguments.length - 1; o >= -1 && !i; o--) {
-        var s;
-        o >= 0 ? s = arguments[o] : (void 0 === t3 && (t3 = process.cwd()), s = t3), e2(s), 0 !== s.length && (n3 = s + "/" + n3, i = 47 === s.charCodeAt(0));
+      for (var t3, n3 = "", i2 = false, o2 = arguments.length - 1; o2 >= -1 && !i2; o2--) {
+        var s2;
+        o2 >= 0 ? s2 = arguments[o2] : (void 0 === t3 && (t3 = process.cwd()), s2 = t3), e2(s2), 0 !== s2.length && (n3 = s2 + "/" + n3, i2 = 47 === s2.charCodeAt(0));
       }
-      return n3 = r2(n3, !i), i ? n3.length > 0 ? "/" + n3 : "/" : n3.length > 0 ? n3 : ".";
+      return n3 = r2(n3, !i2), i2 ? n3.length > 0 ? "/" + n3 : "/" : n3.length > 0 ? n3 : ".";
     }, normalize: function(t3) {
       if (e2(t3), 0 === t3.length)
         return ".";
-      var n3 = 47 === t3.charCodeAt(0), i = 47 === t3.charCodeAt(t3.length - 1);
-      return 0 !== (t3 = r2(t3, !n3)).length || n3 || (t3 = "."), t3.length > 0 && i && (t3 += "/"), n3 ? "/" + t3 : t3;
+      var n3 = 47 === t3.charCodeAt(0), i2 = 47 === t3.charCodeAt(t3.length - 1);
+      return 0 !== (t3 = r2(t3, !n3)).length || n3 || (t3 = "."), t3.length > 0 && i2 && (t3 += "/"), n3 ? "/" + t3 : t3;
     }, isAbsolute: function(t3) {
       return e2(t3), t3.length > 0 && 47 === t3.charCodeAt(0);
     }, join: function() {
       if (0 === arguments.length)
         return ".";
       for (var t3, r3 = 0; r3 < arguments.length; ++r3) {
-        var i = arguments[r3];
-        e2(i), i.length > 0 && (void 0 === t3 ? t3 = i : t3 += "/" + i);
+        var i2 = arguments[r3];
+        e2(i2), i2.length > 0 && (void 0 === t3 ? t3 = i2 : t3 += "/" + i2);
       }
       return void 0 === t3 ? "." : n2.normalize(t3);
     }, relative: function(t3, r3) {
@@ -30419,86 +28777,86 @@ var LIB;
         return "";
       if ((t3 = n2.resolve(t3)) === (r3 = n2.resolve(r3)))
         return "";
-      for (var i = 1; i < t3.length && 47 === t3.charCodeAt(i); ++i)
+      for (var i2 = 1; i2 < t3.length && 47 === t3.charCodeAt(i2); ++i2)
         ;
-      for (var o = t3.length, s = o - i, h = 1; h < r3.length && 47 === r3.charCodeAt(h); ++h)
+      for (var o2 = t3.length, s2 = o2 - i2, h2 = 1; h2 < r3.length && 47 === r3.charCodeAt(h2); ++h2)
         ;
-      for (var a2 = r3.length - h, c = s < a2 ? s : a2, f2 = -1, u = 0; u <= c; ++u) {
-        if (u === c) {
-          if (a2 > c) {
-            if (47 === r3.charCodeAt(h + u))
-              return r3.slice(h + u + 1);
-            if (0 === u)
-              return r3.slice(h + u);
+      for (var a3 = r3.length - h2, c2 = s2 < a3 ? s2 : a3, f3 = -1, u2 = 0; u2 <= c2; ++u2) {
+        if (u2 === c2) {
+          if (a3 > c2) {
+            if (47 === r3.charCodeAt(h2 + u2))
+              return r3.slice(h2 + u2 + 1);
+            if (0 === u2)
+              return r3.slice(h2 + u2);
           } else
-            s > c && (47 === t3.charCodeAt(i + u) ? f2 = u : 0 === u && (f2 = 0));
+            s2 > c2 && (47 === t3.charCodeAt(i2 + u2) ? f3 = u2 : 0 === u2 && (f3 = 0));
           break;
         }
-        var l = t3.charCodeAt(i + u);
-        if (l !== r3.charCodeAt(h + u))
+        var l2 = t3.charCodeAt(i2 + u2);
+        if (l2 !== r3.charCodeAt(h2 + u2))
           break;
-        47 === l && (f2 = u);
+        47 === l2 && (f3 = u2);
       }
-      var g = "";
-      for (u = i + f2 + 1; u <= o; ++u)
-        u !== o && 47 !== t3.charCodeAt(u) || (0 === g.length ? g += ".." : g += "/..");
-      return g.length > 0 ? g + r3.slice(h + f2) : (h += f2, 47 === r3.charCodeAt(h) && ++h, r3.slice(h));
+      var g2 = "";
+      for (u2 = i2 + f3 + 1; u2 <= o2; ++u2)
+        u2 !== o2 && 47 !== t3.charCodeAt(u2) || (0 === g2.length ? g2 += ".." : g2 += "/..");
+      return g2.length > 0 ? g2 + r3.slice(h2 + f3) : (h2 += f3, 47 === r3.charCodeAt(h2) && ++h2, r3.slice(h2));
     }, _makeLong: function(t3) {
       return t3;
     }, dirname: function(t3) {
       if (e2(t3), 0 === t3.length)
         return ".";
-      for (var r3 = t3.charCodeAt(0), n3 = 47 === r3, i = -1, o = true, s = t3.length - 1; s >= 1; --s)
-        if (47 === (r3 = t3.charCodeAt(s))) {
-          if (!o) {
-            i = s;
+      for (var r3 = t3.charCodeAt(0), n3 = 47 === r3, i2 = -1, o2 = true, s2 = t3.length - 1; s2 >= 1; --s2)
+        if (47 === (r3 = t3.charCodeAt(s2))) {
+          if (!o2) {
+            i2 = s2;
             break;
           }
         } else
-          o = false;
-      return -1 === i ? n3 ? "/" : "." : n3 && 1 === i ? "//" : t3.slice(0, i);
+          o2 = false;
+      return -1 === i2 ? n3 ? "/" : "." : n3 && 1 === i2 ? "//" : t3.slice(0, i2);
     }, basename: function(t3, r3) {
       if (void 0 !== r3 && "string" != typeof r3)
         throw new TypeError('"ext" argument must be a string');
       e2(t3);
-      var n3, i = 0, o = -1, s = true;
+      var n3, i2 = 0, o2 = -1, s2 = true;
       if (void 0 !== r3 && r3.length > 0 && r3.length <= t3.length) {
         if (r3.length === t3.length && r3 === t3)
           return "";
-        var h = r3.length - 1, a2 = -1;
+        var h2 = r3.length - 1, a3 = -1;
         for (n3 = t3.length - 1; n3 >= 0; --n3) {
-          var c = t3.charCodeAt(n3);
-          if (47 === c) {
-            if (!s) {
-              i = n3 + 1;
+          var c2 = t3.charCodeAt(n3);
+          if (47 === c2) {
+            if (!s2) {
+              i2 = n3 + 1;
               break;
             }
           } else
-            -1 === a2 && (s = false, a2 = n3 + 1), h >= 0 && (c === r3.charCodeAt(h) ? -1 == --h && (o = n3) : (h = -1, o = a2));
+            -1 === a3 && (s2 = false, a3 = n3 + 1), h2 >= 0 && (c2 === r3.charCodeAt(h2) ? -1 == --h2 && (o2 = n3) : (h2 = -1, o2 = a3));
         }
-        return i === o ? o = a2 : -1 === o && (o = t3.length), t3.slice(i, o);
+        return i2 === o2 ? o2 = a3 : -1 === o2 && (o2 = t3.length), t3.slice(i2, o2);
       }
       for (n3 = t3.length - 1; n3 >= 0; --n3)
         if (47 === t3.charCodeAt(n3)) {
-          if (!s) {
-            i = n3 + 1;
+          if (!s2) {
+            i2 = n3 + 1;
             break;
           }
         } else
-          -1 === o && (s = false, o = n3 + 1);
-      return -1 === o ? "" : t3.slice(i, o);
+          -1 === o2 && (s2 = false, o2 = n3 + 1);
+      return -1 === o2 ? "" : t3.slice(i2, o2);
     }, extname: function(t3) {
       e2(t3);
-      for (var r3 = -1, n3 = 0, i = -1, o = true, s = 0, h = t3.length - 1; h >= 0; --h) {
-        var a2 = t3.charCodeAt(h);
-        if (47 !== a2)
-          -1 === i && (o = false, i = h + 1), 46 === a2 ? -1 === r3 ? r3 = h : 1 !== s && (s = 1) : -1 !== r3 && (s = -1);
-        else if (!o) {
-          n3 = h + 1;
+      for (var r3 = -1, n3 = 0, i2 = -1, o2 = true, s2 = 0, h2 = t3.length - 1; h2 >= 0; --h2) {
+        var a3 = t3.charCodeAt(h2);
+        if (47 !== a3)
+          -1 === i2 && (o2 = false, i2 = h2 + 1), 46 === a3 ? -1 === r3 ? r3 = h2 : 1 !== s2 && (s2 = 1) : -1 !== r3 && (s2 = -1);
+        else if (!o2) {
+          n3 = h2 + 1;
           break;
         }
       }
-      return -1 === r3 || -1 === i || 0 === s || 1 === s && r3 === i - 1 && r3 === n3 + 1 ? "" : t3.slice(r3, i);
+      return -1 === r3 || -1 === i2 || 0 === s2 || 1 === s2 && r3 === i2 - 1 && r3 === n3 + 1 ? "" : t3.slice(r3, i2);
     }, format: function(t3) {
       if (null === t3 || "object" != typeof t3)
         throw new TypeError('The "pathObject" argument must be of type Object. Received type ' + typeof t3);
@@ -30511,25 +28869,25 @@ var LIB;
       var r3 = { root: "", dir: "", base: "", ext: "", name: "" };
       if (0 === t3.length)
         return r3;
-      var n3, i = t3.charCodeAt(0), o = 47 === i;
-      o ? (r3.root = "/", n3 = 1) : n3 = 0;
-      for (var s = -1, h = 0, a2 = -1, c = true, f2 = t3.length - 1, u = 0; f2 >= n3; --f2)
-        if (47 !== (i = t3.charCodeAt(f2)))
-          -1 === a2 && (c = false, a2 = f2 + 1), 46 === i ? -1 === s ? s = f2 : 1 !== u && (u = 1) : -1 !== s && (u = -1);
-        else if (!c) {
-          h = f2 + 1;
+      var n3, i2 = t3.charCodeAt(0), o2 = 47 === i2;
+      o2 ? (r3.root = "/", n3 = 1) : n3 = 0;
+      for (var s2 = -1, h2 = 0, a3 = -1, c2 = true, f3 = t3.length - 1, u2 = 0; f3 >= n3; --f3)
+        if (47 !== (i2 = t3.charCodeAt(f3)))
+          -1 === a3 && (c2 = false, a3 = f3 + 1), 46 === i2 ? -1 === s2 ? s2 = f3 : 1 !== u2 && (u2 = 1) : -1 !== s2 && (u2 = -1);
+        else if (!c2) {
+          h2 = f3 + 1;
           break;
         }
-      return -1 === s || -1 === a2 || 0 === u || 1 === u && s === a2 - 1 && s === h + 1 ? -1 !== a2 && (r3.base = r3.name = 0 === h && o ? t3.slice(1, a2) : t3.slice(h, a2)) : (0 === h && o ? (r3.name = t3.slice(1, s), r3.base = t3.slice(1, a2)) : (r3.name = t3.slice(h, s), r3.base = t3.slice(h, a2)), r3.ext = t3.slice(s, a2)), h > 0 ? r3.dir = t3.slice(0, h - 1) : o && (r3.dir = "/"), r3;
+      return -1 === s2 || -1 === a3 || 0 === u2 || 1 === u2 && s2 === a3 - 1 && s2 === h2 + 1 ? -1 !== a3 && (r3.base = r3.name = 0 === h2 && o2 ? t3.slice(1, a3) : t3.slice(h2, a3)) : (0 === h2 && o2 ? (r3.name = t3.slice(1, s2), r3.base = t3.slice(1, a3)) : (r3.name = t3.slice(h2, s2), r3.base = t3.slice(h2, a3)), r3.ext = t3.slice(s2, a3)), h2 > 0 ? r3.dir = t3.slice(0, h2 - 1) : o2 && (r3.dir = "/"), r3;
     }, sep: "/", delimiter: ":", win32: null, posix: null };
     n2.posix = n2, t2.exports = n2;
   } }, e = {};
   function r(n2) {
-    var i = e[n2];
-    if (void 0 !== i)
-      return i.exports;
-    var o = e[n2] = { exports: {} };
-    return t[n2](o, o.exports, r), o.exports;
+    var i2 = e[n2];
+    if (void 0 !== i2)
+      return i2.exports;
+    var o2 = e[n2] = { exports: {} };
+    return t[n2](o2, o2.exports, r), o2.exports;
   }
   r.d = (t2, e2) => {
     for (var n2 in e2)
@@ -30538,196 +28896,194 @@ var LIB;
     "undefined" != typeof Symbol && Symbol.toStringTag && Object.defineProperty(t2, Symbol.toStringTag, { value: "Module" }), Object.defineProperty(t2, "__esModule", { value: true });
   };
   var n = {};
-  (() => {
-    let t2;
-    if (r.r(n), r.d(n, { URI: () => f2, Utils: () => P }), "object" == typeof process)
-      t2 = "win32" === process.platform;
-    else if ("object" == typeof navigator) {
-      let e3 = navigator.userAgent;
-      t2 = e3.indexOf("Windows") >= 0;
+  let i;
+  if (r.r(n), r.d(n, { URI: () => l, Utils: () => I }), "object" == typeof process)
+    i = "win32" === process.platform;
+  else if ("object" == typeof navigator) {
+    let t2 = navigator.userAgent;
+    i = t2.indexOf("Windows") >= 0;
+  }
+  const o = /^\w[\w\d+.-]*$/, s = /^\//, h = /^\/\//;
+  function a2(t2, e2) {
+    if (!t2.scheme && e2)
+      throw new Error(`[UriError]: Scheme is missing: {scheme: "", authority: "${t2.authority}", path: "${t2.path}", query: "${t2.query}", fragment: "${t2.fragment}"}`);
+    if (t2.scheme && !o.test(t2.scheme))
+      throw new Error("[UriError]: Scheme contains illegal characters.");
+    if (t2.path) {
+      if (t2.authority) {
+        if (!s.test(t2.path))
+          throw new Error('[UriError]: If a URI contains an authority component, then the path component must either be empty or begin with a slash ("/") character');
+      } else if (h.test(t2.path))
+        throw new Error('[UriError]: If a URI does not contain an authority component, then the path cannot begin with two slash characters ("//")');
     }
-    const e2 = /^\w[\w\d+.-]*$/, i = /^\//, o = /^\/\//;
-    function s(t3, r2) {
-      if (!t3.scheme && r2)
-        throw new Error(`[UriError]: Scheme is missing: {scheme: "", authority: "${t3.authority}", path: "${t3.path}", query: "${t3.query}", fragment: "${t3.fragment}"}`);
-      if (t3.scheme && !e2.test(t3.scheme))
-        throw new Error("[UriError]: Scheme contains illegal characters.");
-      if (t3.path) {
-        if (t3.authority) {
-          if (!i.test(t3.path))
-            throw new Error('[UriError]: If a URI contains an authority component, then the path component must either be empty or begin with a slash ("/") character');
-        } else if (o.test(t3.path))
-          throw new Error('[UriError]: If a URI does not contain an authority component, then the path cannot begin with two slash characters ("//")');
-      }
-    }
-    const h = "", a2 = "/", c = /^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
-    class f2 {
-      constructor(t3, e3, r2, n2, i2, o2 = false) {
-        __publicField(this, "scheme");
-        __publicField(this, "authority");
-        __publicField(this, "path");
-        __publicField(this, "query");
-        __publicField(this, "fragment");
-        "object" == typeof t3 ? (this.scheme = t3.scheme || h, this.authority = t3.authority || h, this.path = t3.path || h, this.query = t3.query || h, this.fragment = t3.fragment || h) : (this.scheme = /* @__PURE__ */ function(t4, e4) {
-          return t4 || e4 ? t4 : "file";
-        }(t3, o2), this.authority = e3 || h, this.path = function(t4, e4) {
-          switch (t4) {
-            case "https":
-            case "http":
-            case "file":
-              e4 ? e4[0] !== a2 && (e4 = a2 + e4) : e4 = a2;
-          }
-          return e4;
-        }(this.scheme, r2 || h), this.query = n2 || h, this.fragment = i2 || h, s(this, o2));
-      }
-      static isUri(t3) {
-        return t3 instanceof f2 || !!t3 && "string" == typeof t3.authority && "string" == typeof t3.fragment && "string" == typeof t3.path && "string" == typeof t3.query && "string" == typeof t3.scheme && "string" == typeof t3.fsPath && "function" == typeof t3.with && "function" == typeof t3.toString;
-      }
-      get fsPath() {
-        return m(this, false);
-      }
-      with(t3) {
-        if (!t3)
-          return this;
-        let { scheme: e3, authority: r2, path: n2, query: i2, fragment: o2 } = t3;
-        return void 0 === e3 ? e3 = this.scheme : null === e3 && (e3 = h), void 0 === r2 ? r2 = this.authority : null === r2 && (r2 = h), void 0 === n2 ? n2 = this.path : null === n2 && (n2 = h), void 0 === i2 ? i2 = this.query : null === i2 && (i2 = h), void 0 === o2 ? o2 = this.fragment : null === o2 && (o2 = h), e3 === this.scheme && r2 === this.authority && n2 === this.path && i2 === this.query && o2 === this.fragment ? this : new l(e3, r2, n2, i2, o2);
-      }
-      static parse(t3, e3 = false) {
-        const r2 = c.exec(t3);
-        return r2 ? new l(r2[2] || h, C(r2[4] || h), C(r2[5] || h), C(r2[7] || h), C(r2[9] || h), e3) : new l(h, h, h, h, h);
-      }
-      static file(e3) {
-        let r2 = h;
-        if (t2 && (e3 = e3.replace(/\\/g, a2)), e3[0] === a2 && e3[1] === a2) {
-          const t3 = e3.indexOf(a2, 2);
-          -1 === t3 ? (r2 = e3.substring(2), e3 = a2) : (r2 = e3.substring(2, t3), e3 = e3.substring(t3) || a2);
+  }
+  const c = "", f2 = "/", u = /^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
+  class l {
+    constructor(t2, e2, r2, n2, i2, o2 = false) {
+      __publicField(this, "scheme");
+      __publicField(this, "authority");
+      __publicField(this, "path");
+      __publicField(this, "query");
+      __publicField(this, "fragment");
+      "object" == typeof t2 ? (this.scheme = t2.scheme || c, this.authority = t2.authority || c, this.path = t2.path || c, this.query = t2.query || c, this.fragment = t2.fragment || c) : (this.scheme = /* @__PURE__ */ function(t3, e3) {
+        return t3 || e3 ? t3 : "file";
+      }(t2, o2), this.authority = e2 || c, this.path = function(t3, e3) {
+        switch (t3) {
+          case "https":
+          case "http":
+          case "file":
+            e3 ? e3[0] !== f2 && (e3 = f2 + e3) : e3 = f2;
         }
-        return new l("file", r2, e3, h, h);
-      }
-      static from(t3) {
-        const e3 = new l(t3.scheme, t3.authority, t3.path, t3.query, t3.fragment);
-        return s(e3, true), e3;
-      }
-      toString(t3 = false) {
-        return y(this, t3);
-      }
-      toJSON() {
+        return e3;
+      }(this.scheme, r2 || c), this.query = n2 || c, this.fragment = i2 || c, a2(this, o2));
+    }
+    static isUri(t2) {
+      return t2 instanceof l || !!t2 && "string" == typeof t2.authority && "string" == typeof t2.fragment && "string" == typeof t2.path && "string" == typeof t2.query && "string" == typeof t2.scheme && "string" == typeof t2.fsPath && "function" == typeof t2.with && "function" == typeof t2.toString;
+    }
+    get fsPath() {
+      return v(this, false);
+    }
+    with(t2) {
+      if (!t2)
         return this;
+      let { scheme: e2, authority: r2, path: n2, query: i2, fragment: o2 } = t2;
+      return void 0 === e2 ? e2 = this.scheme : null === e2 && (e2 = c), void 0 === r2 ? r2 = this.authority : null === r2 && (r2 = c), void 0 === n2 ? n2 = this.path : null === n2 && (n2 = c), void 0 === i2 ? i2 = this.query : null === i2 && (i2 = c), void 0 === o2 ? o2 = this.fragment : null === o2 && (o2 = c), e2 === this.scheme && r2 === this.authority && n2 === this.path && i2 === this.query && o2 === this.fragment ? this : new d(e2, r2, n2, i2, o2);
+    }
+    static parse(t2, e2 = false) {
+      const r2 = u.exec(t2);
+      return r2 ? new d(r2[2] || c, w(r2[4] || c), w(r2[5] || c), w(r2[7] || c), w(r2[9] || c), e2) : new d(c, c, c, c, c);
+    }
+    static file(t2) {
+      let e2 = c;
+      if (i && (t2 = t2.replace(/\\/g, f2)), t2[0] === f2 && t2[1] === f2) {
+        const r2 = t2.indexOf(f2, 2);
+        -1 === r2 ? (e2 = t2.substring(2), t2 = f2) : (e2 = t2.substring(2, r2), t2 = t2.substring(r2) || f2);
       }
-      static revive(t3) {
-        if (t3) {
-          if (t3 instanceof f2)
-            return t3;
-          {
-            const e3 = new l(t3);
-            return e3._formatted = t3.external, e3._fsPath = t3._sep === u ? t3.fsPath : null, e3;
-          }
+      return new d("file", e2, t2, c, c);
+    }
+    static from(t2) {
+      const e2 = new d(t2.scheme, t2.authority, t2.path, t2.query, t2.fragment);
+      return a2(e2, true), e2;
+    }
+    toString(t2 = false) {
+      return b(this, t2);
+    }
+    toJSON() {
+      return this;
+    }
+    static revive(t2) {
+      if (t2) {
+        if (t2 instanceof l)
+          return t2;
+        {
+          const e2 = new d(t2);
+          return e2._formatted = t2.external, e2._fsPath = t2._sep === g ? t2.fsPath : null, e2;
         }
+      }
+      return t2;
+    }
+  }
+  const g = i ? 1 : void 0;
+  class d extends l {
+    constructor() {
+      super(...arguments);
+      __publicField(this, "_formatted", null);
+      __publicField(this, "_fsPath", null);
+    }
+    get fsPath() {
+      return this._fsPath || (this._fsPath = v(this, false)), this._fsPath;
+    }
+    toString(t2 = false) {
+      return t2 ? b(this, true) : (this._formatted || (this._formatted = b(this, false)), this._formatted);
+    }
+    toJSON() {
+      const t2 = { $mid: 1 };
+      return this._fsPath && (t2.fsPath = this._fsPath, t2._sep = g), this._formatted && (t2.external = this._formatted), this.path && (t2.path = this.path), this.scheme && (t2.scheme = this.scheme), this.authority && (t2.authority = this.authority), this.query && (t2.query = this.query), this.fragment && (t2.fragment = this.fragment), t2;
+    }
+  }
+  const p = { 58: "%3A", 47: "%2F", 63: "%3F", 35: "%23", 91: "%5B", 93: "%5D", 64: "%40", 33: "%21", 36: "%24", 38: "%26", 39: "%27", 40: "%28", 41: "%29", 42: "%2A", 43: "%2B", 44: "%2C", 59: "%3B", 61: "%3D", 32: "%20" };
+  function m(t2, e2, r2) {
+    let n2, i2 = -1;
+    for (let o2 = 0; o2 < t2.length; o2++) {
+      const s2 = t2.charCodeAt(o2);
+      if (s2 >= 97 && s2 <= 122 || s2 >= 65 && s2 <= 90 || s2 >= 48 && s2 <= 57 || 45 === s2 || 46 === s2 || 95 === s2 || 126 === s2 || e2 && 47 === s2 || r2 && 91 === s2 || r2 && 93 === s2 || r2 && 58 === s2)
+        -1 !== i2 && (n2 += encodeURIComponent(t2.substring(i2, o2)), i2 = -1), void 0 !== n2 && (n2 += t2.charAt(o2));
+      else {
+        void 0 === n2 && (n2 = t2.substr(0, o2));
+        const e3 = p[s2];
+        void 0 !== e3 ? (-1 !== i2 && (n2 += encodeURIComponent(t2.substring(i2, o2)), i2 = -1), n2 += e3) : -1 === i2 && (i2 = o2);
+      }
+    }
+    return -1 !== i2 && (n2 += encodeURIComponent(t2.substring(i2))), void 0 !== n2 ? n2 : t2;
+  }
+  function y(t2) {
+    let e2;
+    for (let r2 = 0; r2 < t2.length; r2++) {
+      const n2 = t2.charCodeAt(r2);
+      35 === n2 || 63 === n2 ? (void 0 === e2 && (e2 = t2.substr(0, r2)), e2 += p[n2]) : void 0 !== e2 && (e2 += t2[r2]);
+    }
+    return void 0 !== e2 ? e2 : t2;
+  }
+  function v(t2, e2) {
+    let r2;
+    return r2 = t2.authority && t2.path.length > 1 && "file" === t2.scheme ? `//${t2.authority}${t2.path}` : 47 === t2.path.charCodeAt(0) && (t2.path.charCodeAt(1) >= 65 && t2.path.charCodeAt(1) <= 90 || t2.path.charCodeAt(1) >= 97 && t2.path.charCodeAt(1) <= 122) && 58 === t2.path.charCodeAt(2) ? e2 ? t2.path.substr(1) : t2.path[1].toLowerCase() + t2.path.substr(2) : t2.path, i && (r2 = r2.replace(/\//g, "\\")), r2;
+  }
+  function b(t2, e2) {
+    const r2 = e2 ? y : m;
+    let n2 = "", { scheme: i2, authority: o2, path: s2, query: h2, fragment: a3 } = t2;
+    if (i2 && (n2 += i2, n2 += ":"), (o2 || "file" === i2) && (n2 += f2, n2 += f2), o2) {
+      let t3 = o2.indexOf("@");
+      if (-1 !== t3) {
+        const e3 = o2.substr(0, t3);
+        o2 = o2.substr(t3 + 1), t3 = e3.lastIndexOf(":"), -1 === t3 ? n2 += r2(e3, false, false) : (n2 += r2(e3.substr(0, t3), false, false), n2 += ":", n2 += r2(e3.substr(t3 + 1), false, true)), n2 += "@";
+      }
+      o2 = o2.toLowerCase(), t3 = o2.lastIndexOf(":"), -1 === t3 ? n2 += r2(o2, false, true) : (n2 += r2(o2.substr(0, t3), false, true), n2 += o2.substr(t3));
+    }
+    if (s2) {
+      if (s2.length >= 3 && 47 === s2.charCodeAt(0) && 58 === s2.charCodeAt(2)) {
+        const t3 = s2.charCodeAt(1);
+        t3 >= 65 && t3 <= 90 && (s2 = `/${String.fromCharCode(t3 + 32)}:${s2.substr(3)}`);
+      } else if (s2.length >= 2 && 58 === s2.charCodeAt(1)) {
+        const t3 = s2.charCodeAt(0);
+        t3 >= 65 && t3 <= 90 && (s2 = `${String.fromCharCode(t3 + 32)}:${s2.substr(2)}`);
+      }
+      n2 += r2(s2, true, false);
+    }
+    return h2 && (n2 += "?", n2 += r2(h2, false, false)), a3 && (n2 += "#", n2 += e2 ? a3 : m(a3, false, false)), n2;
+  }
+  function C(t2) {
+    try {
+      return decodeURIComponent(t2);
+    } catch {
+      return t2.length > 3 ? t2.substr(0, 3) + C(t2.substr(3)) : t2;
+    }
+  }
+  const A2 = /(%[0-9A-Za-z][0-9A-Za-z])+/g;
+  function w(t2) {
+    return t2.match(A2) ? t2.replace(A2, (t3) => C(t3)) : t2;
+  }
+  var x = r(975);
+  const P = x.posix || x, _2 = "/";
+  var I;
+  !function(t2) {
+    t2.joinPath = function(t3, ...e2) {
+      return t3.with({ path: P.join(t3.path, ...e2) });
+    }, t2.resolvePath = function(t3, ...e2) {
+      let r2 = t3.path, n2 = false;
+      r2[0] !== _2 && (r2 = _2 + r2, n2 = true);
+      let i2 = P.resolve(r2, ...e2);
+      return n2 && i2[0] === _2 && !t3.authority && (i2 = i2.substring(1)), t3.with({ path: i2 });
+    }, t2.dirname = function(t3) {
+      if (0 === t3.path.length || t3.path === _2)
         return t3;
-      }
-    }
-    const u = t2 ? 1 : void 0;
-    class l extends f2 {
-      constructor() {
-        super(...arguments);
-        __publicField(this, "_formatted", null);
-        __publicField(this, "_fsPath", null);
-      }
-      get fsPath() {
-        return this._fsPath || (this._fsPath = m(this, false)), this._fsPath;
-      }
-      toString(t3 = false) {
-        return t3 ? y(this, true) : (this._formatted || (this._formatted = y(this, false)), this._formatted);
-      }
-      toJSON() {
-        const t3 = { $mid: 1 };
-        return this._fsPath && (t3.fsPath = this._fsPath, t3._sep = u), this._formatted && (t3.external = this._formatted), this.path && (t3.path = this.path), this.scheme && (t3.scheme = this.scheme), this.authority && (t3.authority = this.authority), this.query && (t3.query = this.query), this.fragment && (t3.fragment = this.fragment), t3;
-      }
-    }
-    const g = { 58: "%3A", 47: "%2F", 63: "%3F", 35: "%23", 91: "%5B", 93: "%5D", 64: "%40", 33: "%21", 36: "%24", 38: "%26", 39: "%27", 40: "%28", 41: "%29", 42: "%2A", 43: "%2B", 44: "%2C", 59: "%3B", 61: "%3D", 32: "%20" };
-    function d(t3, e3, r2) {
-      let n2, i2 = -1;
-      for (let o2 = 0; o2 < t3.length; o2++) {
-        const s2 = t3.charCodeAt(o2);
-        if (s2 >= 97 && s2 <= 122 || s2 >= 65 && s2 <= 90 || s2 >= 48 && s2 <= 57 || 45 === s2 || 46 === s2 || 95 === s2 || 126 === s2 || e3 && 47 === s2 || r2 && 91 === s2 || r2 && 93 === s2 || r2 && 58 === s2)
-          -1 !== i2 && (n2 += encodeURIComponent(t3.substring(i2, o2)), i2 = -1), void 0 !== n2 && (n2 += t3.charAt(o2));
-        else {
-          void 0 === n2 && (n2 = t3.substr(0, o2));
-          const e4 = g[s2];
-          void 0 !== e4 ? (-1 !== i2 && (n2 += encodeURIComponent(t3.substring(i2, o2)), i2 = -1), n2 += e4) : -1 === i2 && (i2 = o2);
-        }
-      }
-      return -1 !== i2 && (n2 += encodeURIComponent(t3.substring(i2))), void 0 !== n2 ? n2 : t3;
-    }
-    function p(t3) {
-      let e3;
-      for (let r2 = 0; r2 < t3.length; r2++) {
-        const n2 = t3.charCodeAt(r2);
-        35 === n2 || 63 === n2 ? (void 0 === e3 && (e3 = t3.substr(0, r2)), e3 += g[n2]) : void 0 !== e3 && (e3 += t3[r2]);
-      }
-      return void 0 !== e3 ? e3 : t3;
-    }
-    function m(e3, r2) {
-      let n2;
-      return n2 = e3.authority && e3.path.length > 1 && "file" === e3.scheme ? `//${e3.authority}${e3.path}` : 47 === e3.path.charCodeAt(0) && (e3.path.charCodeAt(1) >= 65 && e3.path.charCodeAt(1) <= 90 || e3.path.charCodeAt(1) >= 97 && e3.path.charCodeAt(1) <= 122) && 58 === e3.path.charCodeAt(2) ? r2 ? e3.path.substr(1) : e3.path[1].toLowerCase() + e3.path.substr(2) : e3.path, t2 && (n2 = n2.replace(/\//g, "\\")), n2;
-    }
-    function y(t3, e3) {
-      const r2 = e3 ? p : d;
-      let n2 = "", { scheme: i2, authority: o2, path: s2, query: h2, fragment: c2 } = t3;
-      if (i2 && (n2 += i2, n2 += ":"), (o2 || "file" === i2) && (n2 += a2, n2 += a2), o2) {
-        let t4 = o2.indexOf("@");
-        if (-1 !== t4) {
-          const e4 = o2.substr(0, t4);
-          o2 = o2.substr(t4 + 1), t4 = e4.lastIndexOf(":"), -1 === t4 ? n2 += r2(e4, false, false) : (n2 += r2(e4.substr(0, t4), false, false), n2 += ":", n2 += r2(e4.substr(t4 + 1), false, true)), n2 += "@";
-        }
-        o2 = o2.toLowerCase(), t4 = o2.lastIndexOf(":"), -1 === t4 ? n2 += r2(o2, false, true) : (n2 += r2(o2.substr(0, t4), false, true), n2 += o2.substr(t4));
-      }
-      if (s2) {
-        if (s2.length >= 3 && 47 === s2.charCodeAt(0) && 58 === s2.charCodeAt(2)) {
-          const t4 = s2.charCodeAt(1);
-          t4 >= 65 && t4 <= 90 && (s2 = `/${String.fromCharCode(t4 + 32)}:${s2.substr(3)}`);
-        } else if (s2.length >= 2 && 58 === s2.charCodeAt(1)) {
-          const t4 = s2.charCodeAt(0);
-          t4 >= 65 && t4 <= 90 && (s2 = `${String.fromCharCode(t4 + 32)}:${s2.substr(2)}`);
-        }
-        n2 += r2(s2, true, false);
-      }
-      return h2 && (n2 += "?", n2 += r2(h2, false, false)), c2 && (n2 += "#", n2 += e3 ? c2 : d(c2, false, false)), n2;
-    }
-    function v(t3) {
-      try {
-        return decodeURIComponent(t3);
-      } catch {
-        return t3.length > 3 ? t3.substr(0, 3) + v(t3.substr(3)) : t3;
-      }
-    }
-    const b = /(%[0-9A-Za-z][0-9A-Za-z])+/g;
-    function C(t3) {
-      return t3.match(b) ? t3.replace(b, (t4) => v(t4)) : t3;
-    }
-    var A2 = r(470);
-    const w = A2.posix || A2, x = "/";
-    var P;
-    !function(t3) {
-      t3.joinPath = function(t4, ...e3) {
-        return t4.with({ path: w.join(t4.path, ...e3) });
-      }, t3.resolvePath = function(t4, ...e3) {
-        let r2 = t4.path, n2 = false;
-        r2[0] !== x && (r2 = x + r2, n2 = true);
-        let i2 = w.resolve(r2, ...e3);
-        return n2 && i2[0] === x && !t4.authority && (i2 = i2.substring(1)), t4.with({ path: i2 });
-      }, t3.dirname = function(t4) {
-        if (0 === t4.path.length || t4.path === x)
-          return t4;
-        let e3 = w.dirname(t4.path);
-        return 1 === e3.length && 46 === e3.charCodeAt(0) && (e3 = ""), t4.with({ path: e3 });
-      }, t3.basename = function(t4) {
-        return w.basename(t4.path);
-      }, t3.extname = function(t4) {
-        return w.extname(t4.path);
-      };
-    }(P || (P = {}));
-  })(), LIB = n;
+      let e2 = P.dirname(t3.path);
+      return 1 === e2.length && 46 === e2.charCodeAt(0) && (e2 = ""), t3.with({ path: e2 });
+    }, t2.basename = function(t3) {
+      return P.basename(t3.path);
+    }, t2.extname = function(t3) {
+      return P.extname(t3.path);
+    };
+  }(I || (I = {})), LIB = n;
 })();
 var { URI, Utils } = LIB;
 
@@ -43251,14 +41607,10 @@ function isModeline(lineText) {
 
 // ../../node_modules/yaml-language-server/lib/esm/languageservice/services/yamlSchemaService.js
 var import_ajv = __toESM(require_ajv());
-var import__ = __toESM(require__());
-var import__2 = __toESM(require__2());
-var import_ajv_draft_04 = __toESM(require_dist());
 var ajv = new import_ajv.default();
-var ajv04 = new import_ajv_draft_04.default();
-var ajv2019 = new import__.default();
-var ajv2020 = new import__2.default();
 var localize8 = loadMessageBundle();
+var jsonSchema07 = require_json_schema_draft_07();
+var schema07Validator = ajv.compile(jsonSchema07);
 var MODIFICATION_ACTIONS;
 (function(MODIFICATION_ACTIONS2) {
   MODIFICATION_ACTIONS2[MODIFICATION_ACTIONS2["delete"] = 0] = "delete";
@@ -43324,35 +41676,9 @@ var YAMLSchemaService = class extends JSONSchemaService {
     const resolveErrors = schemaToResolve.errors.slice(0);
     let schema4 = schemaToResolve.schema;
     const contextService = this.contextService;
-    let validationErrors = [];
-    switch (this.normalizeId(schema4.$schema)) {
-      case ajv04.defaultMeta(): {
-        if (!ajv04.validateSchema(schema4)) {
-          validationErrors = validationErrors.concat(ajv04.errors);
-        }
-        break;
-      }
-      case ajv2019.defaultMeta(): {
-        if (!ajv2019.validateSchema(schema4)) {
-          validationErrors = validationErrors.concat(ajv2019.errors);
-        }
-        break;
-      }
-      case ajv2020.defaultMeta(): {
-        if (!ajv2020.validateSchema(schema4)) {
-          validationErrors = validationErrors.concat(ajv2020.errors);
-        }
-        break;
-      }
-      default:
-        if (!ajv.validateSchema(schema4)) {
-          validationErrors = validationErrors.concat(ajv.errors);
-        }
-        break;
-    }
-    if (validationErrors.length > 0) {
+    if (!schema07Validator(schema4)) {
       const errs = [];
-      for (const err of validationErrors) {
+      for (const err of schema07Validator.errors) {
         errs.push(`${err.instancePath} : ${err.message}`);
       }
       resolveErrors.push(`Schema '${getSchemaTitle(schemaToResolve.schema, schemaURL)}' is not valid:

--- a/packages/ace-linters/types/html-service.d.ts
+++ b/packages/ace-linters/types/html-service.d.ts
@@ -111,7 +111,7 @@ export interface HTMLFormatConfiguration {
 	endWithNewline?: boolean;
 	extraLiners?: string;
 	indentScripts?: "keep" | "separate" | "normal";
-	templating?: boolean;
+	templating?: ("auto" | "none" | "angular" | "django" | "erb" | "handlebars" | "php" | "smarty")[] | boolean;
 	unformattedContentDelimiter?: string;
 }
 declare abstract class BaseService<OptionsType extends ServiceOptions = ServiceOptions> implements LanguageService {

--- a/packages/ace-linters/types/json-service.d.ts
+++ b/packages/ace-linters/types/json-service.d.ts
@@ -225,6 +225,7 @@ export interface JSONSchema {
 	suggestSortText?: string;
 	allowComments?: boolean;
 	allowTrailingCommas?: boolean;
+	completionDetail?: string;
 }
 export interface JSONSchemaMap {
 	[name: string]: JSONSchemaRef;


### PR DESCRIPTION
Hi,

I was having a look into the "Content-Modified" error, that I got, when doing the other pull request (https://github.com/mkslanc/ace-linters/pull/161). The error also appeared when not using those code changes.
The LSP-Spec says, that the Content-Modified-Error appears, when the server is executing a request and the editor state changes, which in my understanding happens, when typing quite fast and the server is not keeping pace with the request executions (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#implementationConsiderations):

> if a server detects an internal state change (for example, a project context changed) that invalidates the result of a request in execution the server can error these requests with ContentModified. If clients receive a ContentModified error, it generally should not show it in the UI for the end-user.

So I tracked down the position where the error is thrown, which is inside the service-manager, which is awaiting the Promise that is returned by the service-feature (in that case the language-client). That promise is rejected in case of the Content-Modified-Error, so the 'await' expression is throwing the error.
For every message-type, that is awaiting a promise I simply put a try-catch around the code, that is catching the error, which is ignored, if it is the "Content-Modified" error.