### PR TITLE
Add support for edit text autocompletion

### DIFF
--- a/packages/ace-linters/package.json
+++ b/packages/ace-linters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ace-linters",
   "author": "Azat Alimov <mkslanc@gmail.com>",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "scripts": {
     "clean": "rimraf build",
     "prebuild": "node prebuild.js",

--- a/packages/ace-linters/src/services/typescript/typescript-converters.ts
+++ b/packages/ace-linters/src/services/typescript/typescript-converters.ts
@@ -149,29 +149,16 @@ export function toCompletions(completionInfo: CompletionInfo, doc: TextDocument,
             entry: entry.name
         }
 
-        /**
-         * The `insertText` is subject to interpretation by the client side.
-         * Some tools might not take the string literally. For example
-         * VS Code when code complete is requested in this example
-         * `con<cursor position>` and a completion item with an `insertText` of
-         * `console` is provided it will only insert `sole`. Therefore it is
-         * recommended to use `textEdit` instead since it avoids additional client
-         * side interpretation.
-         *
-         * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem
-         */
         let completionText = entry.insertText ?? entry.name;
-        let rangeStart = toPosition(position, doc);
-        let rangeEnd = toPosition(position, doc);
-
         if (entry.replacementSpan) {
-            rangeStart = toPosition(entry.replacementSpan.start, doc);
-            rangeEnd = toPosition(entry.replacementSpan.start + entry.replacementSpan.length, doc);
-        }
-
-        completion["textEdit"] = {
-            range: createRangeFromPoints(rangeStart, rangeEnd),
-            newText: completionText
+            const rangeStart = toPosition(entry.replacementSpan.start, doc);
+            const rangeEnd = toPosition(entry.replacementSpan.start + entry.replacementSpan.length, doc);
+            completion["textEdit"] = {
+                range: createRangeFromPoints(rangeStart, rangeEnd),
+                newText: completionText
+            }
+        } else {
+            completion["insertText"] = completionText;
         }
 
         return completion;

--- a/packages/ace-linters/src/services/typescript/typescript-service.ts
+++ b/packages/ace-linters/src/services/typescript/typescript-service.ts
@@ -267,7 +267,7 @@ export class TypescriptService extends BaseService<TsServiceOptions> implements 
         if (!fullDocument)
             return null;
         let offset = fullDocument.offsetAt(position);
-        let completions = this.$service.getCompletionsAtPosition(document.uri, offset, undefined);
+        let completions = this.$service.getCompletionsAtPosition(document.uri, offset, {"includeCompletionsWithInsertText": true});
         if (!completions)
             return null;
 

--- a/packages/ace-linters/tests/ui/dist/test.html
+++ b/packages/ace-linters/tests/ui/dist/test.html
@@ -6,7 +6,8 @@
 </head>
 <body>
 <div id="editor" style="height: 300px;"></div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.16.0/ace.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.41.0/ace.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.41.0/ext-language_tools.min.js" integrity="sha512-L+lSo49H8Yv9b6EdszH1LdR7xM+hVSP1klSeAKnjAw8izjfpkoVBlFNOQGm34u1gWIS3uwTzIZ9APNv0Bx7Otw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="http://127.0.0.1:8080/build/ace-linters.js"></script>
 <script>
     const editor = window.editor = ace.edit("editor", {


### PR DESCRIPTION
The current implementation of typescript autocompletion doesn't work when a property name has dashes in it. 

For example:
```javascript
class A {
    "undashed" = 1;
    "with-dashes" = 2;
};

let a = new A();
```

If I type `a.` I only get `undashed` as an autocomplete option. Since the linter doesn't pass the flag (and handle the response) for suggestions that require the code to be updated, instead of just inserting, meaning:

For `undashed` case:
`a.` -> Insert `undashed`. Result: `a.undashed`

For `with-dashes` case:
`a.` -> Remove the `.` -> Insert `["with-dashes"]`. Result: `a["with-dashes"]`

As mentioned in the comment added to the code, the LSP specification recommends using `textEdit` instead of `insertText` to handle both cases.

### Before:
#### With `.`
<img width="598" alt="Screenshot 2025-05-05 at 12 23 16 PM" src="https://github.com/user-attachments/assets/813cc481-af39-4225-b61c-32e00cf2ff66" />

#### With `["`
<img width="564" alt="Screenshot 2025-05-05 at 12 23 44 PM" src="https://github.com/user-attachments/assets/7416eb54-127f-4083-a474-b50fb2032c4f" />


### After:
#### With `.`
<img width="588" alt="Screenshot 2025-05-05 at 12 22 22 PM" src="https://github.com/user-attachments/assets/6afdda72-bf78-4f71-b9d0-318a7c5ccc4a" />
<img width="595" alt="Screenshot 2025-05-05 at 12 22 31 PM" src="https://github.com/user-attachments/assets/fa7e5e41-7104-4c2b-95e7-f8da42c5f30e" />

#### With `["`
<img width="577" alt="Screenshot 2025-05-05 at 12 24 42 PM" src="https://github.com/user-attachments/assets/0b775ddc-a33a-4704-a696-d13a7b26c000" />



