### PR TITLE
Manual session control

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,35 @@ languageProvider.registerEditor(editor);
 
 [Example webworker.js with all services](https://github.com/mkslanc/ace-linters/blob/main/packages/demo/webworker-lsp/webworker.ts)
 
+
+## New features in 1.8.1
+- add `manualSessionControl` provider option to disable automatic session registration. When enabled, you must manually handle session changes:
+```javascript
+// Create provider with manual session control
+let languageProvider = LanguageProvider.create(worker, {
+    manualSessionControl: true
+});
+
+// Register sessions manually
+languageProvider.registerSession(editor.session, editor, {
+    filePath: 'path/to/file.ts',
+    joinWorkspaceURI: true
+});
+
+// Handle session changes manually
+editor.on("changeSession", ({session}) => {
+    languageProvider.registerSession(session, editor, session.lspConfig);
+});
+```
+- add `lspConfig` property to Ace sessions for storing LSP configuration:
+```javascript
+// Set LSP configuration on session
+editor.session.lspConfig = {
+    filePath: 'src/components/MyComponent.tsx',
+    joinWorkspaceURI: true
+};
+```
+
 ## New Features in 1.2.0
 - add `setProviderOptions` method to `LanguageProvider` to set options for client.
 - add experimental semantic tokens support (turned off by default). To turn on semantic tokens, set `semanticTokens` to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ace-linters-root",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "scripts": {
     "build:parts": "npm run build -ws",
     "build": "npm run build:parts && webpack",

--- a/packages/ace-linters/README.md
+++ b/packages/ace-linters/README.md
@@ -28,6 +28,34 @@ languageProvider.registerEditor(editor);
 
 [Example webworker.js with all services](https://github.com/mkslanc/ace-linters/blob/main/packages/demo/webworker-lsp/webworker.ts)
 
+## New features in 1.8.1
+- add `manualSessionControl` provider option to disable automatic session registration. When enabled, you must manually handle session changes:
+```javascript
+// Create provider with manual session control
+let languageProvider = LanguageProvider.create(worker, {
+    manualSessionControl: true
+});
+
+// Register sessions manually
+languageProvider.registerSession(editor.session, editor, {
+    filePath: 'path/to/file.ts',
+    joinWorkspaceURI: true
+});
+
+// Handle session changes manually
+editor.on("changeSession", ({session}) => {
+    languageProvider.registerSession(session, editor, session.lspConfig);
+});
+```
+- add `lspConfig` property to Ace sessions for storing LSP configuration:
+```javascript
+// Set LSP configuration on session
+editor.session.lspConfig = {
+    filePath: 'src/components/MyComponent.tsx',
+    joinWorkspaceURI: true
+};
+```
+
 ## New Features in 1.2.0
 - add `setProviderOptions` method to `LanguageProvider` to set options for client.
 - add experimental semantic tokens support (turned off by default). To turn on semantic tokens, set `semanticTokens` to

--- a/packages/ace-linters/src/services/language-client.ts
+++ b/packages/ace-linters/src/services/language-client.ts
@@ -205,6 +205,10 @@ export class LanguageClient extends BaseService implements LanguageService {
     }
 
     addDocument(document: lsp.TextDocumentItem) {//TODO: this need to be async to avoid race condition
+        if (this.getDocument(document.uri)) {
+            console.warn(document.uri + ' already exists');
+            return;
+        }
         super.addDocument(document);
         const textDocumentMessage: lsp.DidOpenTextDocumentParams = {
             textDocument: document

--- a/packages/ace-linters/src/types/ace-extension.ts
+++ b/packages/ace-linters/src/types/ace-extension.ts
@@ -1,16 +1,20 @@
-import { DecodedSemanticTokens } from "../type-converters/lsp/semantic-tokens";
+import {DecodedSemanticTokens} from "../type-converters/lsp/semantic-tokens";
+import {SessionLspConfig} from "./language-service";
 
 declare module "ace-code/src/edit_session" {
 
     interface EditSession {
         setSemanticTokens: (tokens: DecodedSemanticTokens | undefined) => void;
+        lspConfig?: SessionLspConfig
     }
 }
 
 declare module "ace-code/src/background_tokenizer" {
     interface BackgroundTokenizer {
         semanticTokens: DecodedSemanticTokens | undefined;
+
         $tokenizeRow(row: number): import("ace-code").Ace.Token[];
+
         $worker: () => void;
         $updateOnChange: () => void;
     }

--- a/packages/ace-linters/src/types/language-service.ts
+++ b/packages/ace-linters/src/types/language-service.ts
@@ -260,16 +260,24 @@ export interface ProviderOptions {
         "InlineAutocomplete"?: typeof InlineAutocomplete,
         "CommandBarTooltip"?: typeof CommandBarTooltip,
         "CompletionProvider"?: typeof CompletionProvider,
-    }
+    },
+    /**
+     * When true, disables automatic session registration on editor session changes.
+     * Users must manually call registerSession() and handle session change events themselves.
+     * @default false
+     */
+    manualSessionControl?: boolean;
 }
 
-export interface SessionInitialConfig {
+export interface SessionLspConfig {
     /**
-     * The associated file path for the session
+     * Absolute or relative path of the file for the session
      */
     filePath: string,
     /**
-     * Determines if the editor should join the workspace URI
+     * When `true` the given path is treated as relative and will be joined with
+     * the workspace’s root URI to form the final canonical URI. When false (or omitted) filePath is just transformed to
+     * URI.
      * @default `false`
      */
     joinWorkspaceURI?: boolean


### PR DESCRIPTION
- add `manualSessionControl` provider option to disable automatic session registration. When enabled, you must manually handle session changes:
```javascript
// Create provider with manual session control
let languageProvider = LanguageProvider.create(worker, {
    manualSessionControl: true
});

// Register sessions manually
languageProvider.registerSession(editor.session, editor, {
    filePath: 'path/to/file.ts',
    joinWorkspaceURI: true
});

// Handle session changes manually
editor.on("changeSession", ({session}) => {
    languageProvider.registerSession(session, editor, session.lspConfig);
});
```
- add `lspConfig` property to Ace sessions for storing LSP configuration:
```javascript
// Set LSP configuration on session
editor.session.lspConfig = {
    filePath: 'src/components/MyComponent.tsx',
    joinWorkspaceURI: true
};
```
- prevent duplicate document addition