### PR TITLE
Enable completionProvider.resolveProvider capability for the JsonService

### DIFF
--- a/packages/ace-linters/src/services/json/json-service.ts
+++ b/packages/ace-linters/src/services/json/json-service.ts
@@ -17,7 +17,8 @@ export class JsonService extends BaseService<JsonServiceOptions> implements Lang
 
     serviceCapabilities = {
         completionProvider: {
-            triggerCharacters: ['"', ':']
+            triggerCharacters: ['"', ':'],
+            resolveProvider: true
         },
         diagnosticProvider: {
             interFileDependencies: true,


### PR DESCRIPTION
I noticed that Ace Editor doesn't show documentation from `description` field in JSON schema in suggestion list. So I did a little reverse engineering and found that everything that needs to be done is to enable `completionProvider.resolveProvider` for the JSON service.

I think it was disabled by mistake, because the JSON service implements `doResolve` method. It just seems like it was never called because of the disabled `resolveProvider`.

<img width="601" height="116" alt="image" src="https://github.com/user-attachments/assets/0cce5c44-c218-4f18-b7fc-5e58d9b8a73a" />
