### PR TITLE
fix: trim mode names when splitting service modes by pipe

### DIFF
--- a/packages/ace-linters/src/services/service-manager.ts
+++ b/packages/ace-linters/src/services/service-manager.ts
@@ -412,7 +412,7 @@ export class ServiceManager {
     findServicesByMode(mode: string): { [serviceName: string]: (ServiceConfig | LanguageClientConfig) } {
         let servicesWithName = {};
         Object.entries(this.$services).forEach(([key, value]) => {
-                let extensions = value.modes.split('|');
+                let extensions = value.modes.split('|').map(m => m.trim());
                 if (extensions.includes(mode))
                     servicesWithName[key] = this.$services[key];
             }


### PR DESCRIPTION
Ensure that service modes are trimmed of whitespace before matching.