### PR TITLE
 fix: abort callbacks after `LanguageProvider.closeDocument` called 

### DIFF
--- a/packages/ace-linters/src/language-provider.ts
+++ b/packages/ace-linters/src/language-provider.ts
@@ -322,9 +322,13 @@ export class LanguageProvider {
                 if (!$timer)
                     $timer =
                         setTimeout(() => {
-                            let cursor = editor.getCursorPosition();
                             let sessionLanguageProvider = this.$getSessionLanguageProvider(editor.session);
+                            if (!sessionLanguageProvider) {
+                                $timer = undefined;
+                                return;
+                            }
 
+                            let cursor = editor.getCursorPosition();
                             this.$messageController.findDocumentHighlights(this.$getFileName(editor.session), fromPoint(cursor), sessionLanguageProvider.$applyDocumentHighlight);
                             $timer = undefined;
                         }, 50);
@@ -372,6 +376,11 @@ export class LanguageProvider {
             if (!actionTimer)
                 actionTimer =
                     setTimeout(() => {
+                        if (!this.$getSessionLanguageProvider(editor.session)) {
+                            actionTimer = undefined;
+                            return;
+                        }
+
                         //TODO: no need to send request on empty
                         let selection = editor.getSelection().getRange();
                         let cursor = editor.getCursorPosition();
@@ -508,6 +517,8 @@ export class LanguageProvider {
     }
 
     provideSignatureHelp(session: Ace.EditSession, position: Ace.Point, callback?: (signatureHelp: Tooltip | undefined) => void) {
+        if (!this.$getSessionLanguageProvider(session))
+            return;
         this.$messageController.provideSignatureHelp(this.$getFileName(session), fromPoint(position), (signatureHelp) => callback && callback(fromSignatureHelp(signatureHelp)));
     }
 

--- a/packages/ace-linters/tests/unit/language-provider.tests.ts
+++ b/packages/ace-linters/tests/unit/language-provider.tests.ts
@@ -80,9 +80,9 @@ describe('LanguageProvider tests', () => {
                 },
                 completionResolve: true,
                 format: true,
-                documentHighlights: false,
+                documentHighlights: true,
                 signatureHelp: false,
-                codeActions: false
+                codeActions: true
             }
         });
         languageProvider.registerEditor(editor);
@@ -458,6 +458,15 @@ describe('LanguageProvider tests', () => {
             done()
         });
 
+    })
+
+    it('should not error from callbacks after closeDocument', (done) => {
+        languageProvider.closeDocument(editor.session);
+        expect(() => languageProvider.provideSignatureHelp(editor.session, null, null)).not.to.throw();
+
+        // Check for exceptions from changeSelection from documentHighlights and $provideCodeActions
+        editor.session.setValue("example");
+        setTimeout(done, 600);
     })
 
     after(() => {


### PR DESCRIPTION
Fixes #203 by aborting the relevant callbacks that may occur after `LanguageProvider.closeDocument` has been called during the middle of provider callbacks and auto-completion. These changes look up `this.$getSessionLanguageProvider(session)` and return immediately when this isn't found.

Thanks for making this project open source and for your consideration. Please let me know if anything needs adjusting in this PR, such as a better way to assert on the `setTimeout` callbacks (I couldn't see the ability to mock timers in this project at present).